### PR TITLE
DAO-413 fix: wrap link component with a next.js router link

### DIFF
--- a/src/components/Link/ExternalLink.tsx
+++ b/src/components/Link/ExternalLink.tsx
@@ -1,0 +1,37 @@
+import { FC } from 'react'
+import classnames from 'classnames'
+import { PiArrowUpRightLight } from 'react-icons/pi'
+import { ExternalLinkProps } from './types'
+
+/**
+ * Styled anchor tag. The wrapped 'a' tag can be replaced by a custom
+ * component by providing a `component` prop
+ */
+export const ExternalLink: FC<ExternalLinkProps> = ({
+  children,
+  variant = 'default',
+  component: Component = 'a',
+  // can be customized by providing additional classnames
+  className,
+  ...props
+}) => {
+  return (
+    <Component
+      {...props}
+      className={classnames(
+        'inline-flex items-center gap-1.5 font-sora underline underline-offset-2 underline-thick hover:cursor-pointer w-fit',
+        {
+          'tracking-tight leading-tight text-base': variant === 'menu',
+        },
+        {
+          'leading-normal text-sm': variant === 'default',
+        },
+        // combines hardcoded styles with classes coming from props
+        className,
+      )}
+    >
+      {children}
+      {variant === 'menu' && <PiArrowUpRightLight />}
+    </Component>
+  )
+}

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Link } from './Link'
+import { Typography } from '../Typography'
 
 const meta = {
   title: 'Components/Link',
@@ -13,31 +14,51 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   args: {
     variant: 'default',
+    href: '/bonus',
+    target: '_blank',
     children: <p>Grant Bonus wave 6</p>,
   },
 }
 export const Menu: Story = {
   args: {
     variant: 'menu',
+    href: 'http://rootstock.io',
+    target: '_blank',
     children: <p>Register RNS Domain</p>,
   },
 }
+
 export const DefaultInText: Story = {
+  args: {
+    href: '/home',
+  },
   render: () => (
-    <p>
-      This is a <Link>default Link</Link> inside a paragraph of text.
-    </p>
+    <Typography tagVariant="p">
+      This is a{' '}
+      <Link className="text-[1rem]" href="/home">
+        Link with modified font size
+      </Link>{' '}
+      inside a paragraph of Typography text.
+    </Typography>
   ),
 }
 export const MenuInList: Story = {
+  args: {
+    href: '/home',
+  },
   render: () => (
     <ul>
       <li>
-        <Link variant="menu">Register RNS Domain</Link>
+        <Link variant="menu" href="/home">
+          <Typography tagVariant="p">Register RNS Domain</Typography>
+        </Link>
       </li>
       <li>
-        <Link variant="menu">Token Bridge Dapp</Link>
+        <Link variant="menu" href="/home">
+          <Typography tagVariant="p">Token Bridge Dapp</Typography>
+        </Link>
       </li>
     </ul>
   ),
 }
+

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,27 +1,11 @@
-import { FC, AnchorHTMLAttributes } from 'react'
-import classnames from 'classnames'
-import { PiArrowUpRightLight } from 'react-icons/pi'
+import { FC } from 'react'
+import NextLink from 'next/link'
+import { ExternalLink } from './ExternalLink'
+import { LinkProps } from './types'
 
-interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  variant?: 'default' | 'menu'
-}
-
-export const Link: FC<LinkProps> = ({ children, variant = 'default', ...props }) => {
-  return (
-    <a
-      {...props}
-      className={classnames(
-        'inline-flex items-center gap-1.5 font-sora underline underline-offset-2 underline-thick hover:cursor-pointer w-fit',
-        {
-          'tracking-tight leading-tight text-base': variant === 'menu',
-        },
-        {
-          'leading-normal text-sm': variant === 'default',
-        },
-      )}
-    >
-      <div>{children}</div>
-      {variant === 'menu' && <PiArrowUpRightLight />}
-    </a>
-  )
+/**
+ * Base link component uses Next.js router link
+ */
+export const Link: FC<LinkProps> = props => {
+  return <ExternalLink {...props} component={NextLink} />
 }

--- a/src/components/Link/index.ts
+++ b/src/components/Link/index.ts
@@ -1,0 +1,2 @@
+export { Link } from './Link'
+export type { LinkProps } from './types'

--- a/src/components/Link/types.ts
+++ b/src/components/Link/types.ts
@@ -1,0 +1,9 @@
+import type { AnchorHTMLAttributes, ElementType } from 'react'
+import { LinkProps as NextLinkProps } from 'next/link'
+
+export interface ExternalLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  variant?: 'default' | 'menu'
+  component?: ElementType
+}
+
+export type LinkProps = ExternalLinkProps & NextLinkProps


### PR DESCRIPTION
# What

- rename customised Link component to ExternalLink which means that it isn't using the internal next.js router
- create a new base Link component by wrapping ExternalLink with Next.js router
- provide StoryBook demo of Typography / Link combination

# Ref

DAO-413