### PR TITLE
Fix proposals cache

### DIFF
--- a/src/app/proposals/api/route.ts
+++ b/src/app/proposals/api/route.ts
@@ -1,46 +1,40 @@
 import { fetchProposalCreated } from '@/app/user/Balances/actions'
 
-let cachedProposals = {
+const cachedProposals = {
   lastUpdated: Date.now(),
   data: [],
-  isFetching: false,
   error: '',
 }
 
-function fetchProposals() {
-  cachedProposals.isFetching = true
+const fetchProposals = async () => {
   console.log(11, 'Fetching proposals...')
-  fetchProposalCreated()
-    .then(({ data }) => {
-      console.log(14, 'Finished fetching proposals...')
-      if (Array.isArray(data) && data.length > 0) {
-        cachedProposals.data = data as []
-        cachedProposals.error = ''
-      } else {
-        cachedProposals.error = JSON.stringify(data)
-      }
-      cachedProposals.lastUpdated = Date.now()
-    })
-    .catch(err => {
-      cachedProposals.error = err.toString()
-    })
-    .finally(() => (cachedProposals.isFetching = false))
+  try {
+    const { data } = await fetchProposalCreated()
+    console.log(14, 'Finished fetching proposals...')
+    if (Array.isArray(data) && data.length > 0) {
+      cachedProposals.data = data as []
+      cachedProposals.error = ''
+    } else {
+      cachedProposals.error = JSON.stringify(data)
+    }
+    cachedProposals.lastUpdated = Date.now()
+  } catch (err: any) {
+    cachedProposals.error = err.toString()
+  }
 }
 
 const SECONDS_INTERVAL = 10
 
-export async function GET(request: Request) {
-  const disableCache = request.url
+export async function GET() {
   const currentTime = Date.now()
   const timeElapsed = (currentTime - cachedProposals.lastUpdated) / 1000 // Time elapsed in seconds
 
-  if ((cachedProposals.data.length === 0 || timeElapsed > SECONDS_INTERVAL) && !cachedProposals.isFetching) {
-    fetchProposals()
+  if (cachedProposals.data.length === 0 || timeElapsed > SECONDS_INTERVAL) {
+    await fetchProposals()
   }
   return Response.json(cachedProposals.data, {
     headers: {
       'X-Error': cachedProposals.error,
-      'X-Fetching': cachedProposals.isFetching ? 'true' : 'false',
       'X-LastUpdated': cachedProposals.lastUpdated.toString(),
       'X-TimeElapsed': timeElapsed.toString(),
     },

--- a/src/app/proposals/hooks/useFetchLatestProposals.ts
+++ b/src/app/proposals/hooks/useFetchLatestProposals.ts
@@ -5,7 +5,7 @@ import { GovernorAbi } from '@/lib/abis/Governor'
 import { fetchProposalsCreatedCached } from '@/app/user/Balances/actions'
 
 export const useFetchLatestProposals = () => {
-  const { data } = useQuery({
+  const { data, isLoading } = useQuery({
     queryFn: fetchProposalsCreatedCached,
     queryKey: ['proposalsCreated'],
     refetchInterval: 2000,
@@ -33,5 +33,5 @@ export const useFetchLatestProposals = () => {
     return []
   }, [data])
 
-  return { latestProposals }
+  return { latestProposals, isLoading }
 }

--- a/src/app/proposals/page.tsx
+++ b/src/app/proposals/page.tsx
@@ -9,11 +9,11 @@ import { toFixed } from '@/lib/utils'
 import { FaRegQuestionCircle } from 'react-icons/fa'
 import { useVotingPower } from './hooks/useVotingPower'
 import { TxStatusMessage } from '@/components/TxStatusMessage/TxStatusMessage'
+import { LoadingSpinner } from '@/components/LoadingSpinner'
 
 export default function Proposals() {
   const { votingPower, canCreateProposal, threshold } = useVotingPower()
-
-  const { latestProposals } = useFetchLatestProposals()
+  const { latestProposals, isLoading: isLoadingProposals } = useFetchLatestProposals()
 
   return (
     <MainContainer>
@@ -31,7 +31,7 @@ export default function Proposals() {
           <DelegatedTable />
           <ReceivedDelegationTable />
         </div> */}
-        <LatestProposalsTable latestProposals={latestProposals} />
+        {isLoadingProposals ? <LoadingSpinner /> : <LatestProposalsTable latestProposals={latestProposals} />}
       </div>
     </MainContainer>
   )


### PR DESCRIPTION
- Make fetching for latest proposals await for response and show a loading spinner meanwhile.
- This avoids to return empty array right away.
- Cache capabilities still remains there.