### PR TITLE
Alternative IPFS gateways

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,1 +1,2 @@
 export * from './config'
+export { ipfsGateways } from './ipfsGateways'

--- a/src/config/ipfsGateways.ts
+++ b/src/config/ipfsGateways.ts
@@ -1,0 +1,5 @@
+export const ipfsGateways = [
+  'https://ipfs.io/ipfs/',
+  'https://gateway.pinata.cloud/ipfs/',
+  'https://dweb.link/ipfs/',
+]


### PR DESCRIPTION
# What

Add 3 alternative IPFS gateways for fetching NFT meta instead of one

# Why

A single `https://ipfs.io/ipfs/` gateway sometimes didn't manage to return image/metadata because of CORS restrictions and threw errors