### PR TITLE
feat: proposal ID copy button

### DIFF
--- a/src/app/proposals/LatestProposalsTable.tsx
+++ b/src/app/proposals/LatestProposalsTable.tsx
@@ -103,7 +103,7 @@ const latestProposalsTransformer = (proposals: ReturnType<typeof getEventArgumen
   proposals.map((proposal, i) => ({
     'Proposal Name': <ProposalNameColumn {...proposal} />,
     'Current Votes': <VotesColumn {...proposal} />,
-    Starts: proposal.Starts,
+    Starts: proposal.Starts.format('YYYY-MM-DD'),
     Sentiment: <SentimentColumn {...proposal} index={i} />,
     Status: <StatusColumn {...proposal} />,
   }))

--- a/src/app/proposals/shared/utils.ts
+++ b/src/app/proposals/shared/utils.ts
@@ -4,6 +4,7 @@ import { DAOTreasuryAbi } from '@/lib/abis/DAOTreasuryAbi'
 import { ZeroAddress } from 'ethers'
 import { RIF_ADDRESS } from '@/lib/constants'
 import { formatBalanceToHuman } from '@/app/user/Balances/balanceUtils'
+import moment from 'moment'
 
 export interface EventArgumentsParameter {
   args: {
@@ -48,7 +49,7 @@ export const getEventArguments = ({
     proposer,
     description: description.split(';')[1],
     proposalId: proposalId.toString(),
-    Starts: new Date(parseInt(timeStamp, 16) * 1000).toISOString().split('T')[0],
+    Starts: moment(parseInt(timeStamp, 16) * 1000),
     calldatasParsed,
   }
 }

--- a/src/components/CopyButton/CopyButton.tsx
+++ b/src/components/CopyButton/CopyButton.tsx
@@ -90,7 +90,7 @@ export const CopyButton: FC<CopyButtonProps> = ({
     <div
       {...props}
       ref={ref}
-      className={cn(className, 'flex gap-2 items-center justify-end font-normal', statusClasses)}
+      className={cn('flex gap-2 items-center justify-end font-normal', className, statusClasses)}
       style={{ minWidth }}
       onClick={copyToClipboard}
     >

--- a/src/pages/proposals/[id].tsx
+++ b/src/pages/proposals/[id].tsx
@@ -19,7 +19,7 @@ import { MetricsCard } from '@/components/MetricsCard'
 import { Popover } from '@/components/Popover'
 import { Header, Paragraph, Span } from '@/components/Typography'
 import { useVoteOnProposal } from '@/shared/hooks/useVoteOnProposal'
-import { shortAddress } from '@/lib/utils'
+import { truncateMiddle } from '@/lib/utils'
 import { useRouter } from 'next/router'
 import { FC, useMemo, useState } from 'react'
 import { useAccount } from 'wagmi'
@@ -33,6 +33,7 @@ import { waitForTransactionReceipt } from '@wagmi/core'
 import { config } from '@/config'
 import { useAlertContext } from '@/app/providers'
 import { TX_MESSAGES } from '@/shared/txMessages'
+import { CopyButton } from '@/components/CopyButton'
 
 export default function ProposalView() {
   const {
@@ -166,15 +167,20 @@ const PageWithProposal = (proposal: PageWithProposal) => {
     <div className="pl-4 grid grid-rows-1 gap-[32px] mb-[100px]">
       <BreadcrumbSection title={name} />
       <Header className="text-2xl">{name}</Header>
-      <div className="flex flex-row">
-        <Paragraph className="text-sm text-gray-500">
-          Proposed by: <span className="text-primary">{shortAddress(proposer, 10)}</span>
-        </Paragraph>
-        <Paragraph className="text-sm text-gray-500 ml-4">
-          Created at: <span className="text-primary">{Starts}</span>
-        </Paragraph>
+
+      <div className="flex flex-row gap-4 items-baseline">
+        <div className="flex flex-row items-baseline gap-1">
+          <Paragraph className="text-sm text-gray-500">Proposed by: </Paragraph>
+          <CopyButton icon={null} copyText={proposer} className="text-primary font-semibold">
+            {truncateMiddle(proposer, 3, 3)}
+          </CopyButton>
+        </div>
+        <Paragraph className="text-sm text-gray-500">Created {Starts.fromNow()}</Paragraph>
+        <CopyButton icon={null} copyText={proposalId} className="font-semibold text-primary">
+          ID {truncateMiddle(proposalId, 3, 3)}
+        </CopyButton>
         {blocksUntilClosure !== null && proposalStateHuman === 'Active' && (
-          <Paragraph className="text-sm text-gray-500 ml-4">
+          <Paragraph className="text-sm text-gray-500">
             Blocks until closure: <span className="text-primary">{blocksUntilClosure.toString()}</span>
           </Paragraph>
         )}


### PR DESCRIPTION
# What

UI changes on the Proposal details page:

- display proposal ID
- change proposal time rendering from the format "YYYY-MM-DD" to "created X time-units ago"
- add copy buttons to proposal creator address and to the proposal ID

# Why

It existed on the Figma sketch but not in the app

<img width="571" alt="Screenshot 2024-09-09 at 23 07 02" src="https://github.com/user-attachments/assets/d751567b-eaf1-4343-8e32-f5ea506fa52d">

