### PR TITLE
Change trigger release

### DIFF
--- a/.github/workflows/dev.deploy.yaml
+++ b/.github/workflows/dev.deploy.yaml
@@ -19,9 +19,9 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    # NOTYET we need a non-free plan
-    #environment:
-    #  name: dev
+    environment:
+      name: dev
+
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/mainnet.deploy.yaml
+++ b/.github/workflows/mainnet.deploy.yaml
@@ -18,9 +18,10 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    # NOTYET we need a non-free plan
-    #environment:
-    #  name: mainnet
+    environment:
+      name: mainnet
+      url: https://app.rootstockcollective.xyz
+
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/testnet.deploy.yaml
+++ b/.github/workflows/testnet.deploy.yaml
@@ -18,9 +18,10 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    # NOTYET we need a non-free plan
-    #environment:
-    #  name: testnet
+    environment:
+      name: testnet
+      url: https://testnet.app.rootstockcollective.xyz
+
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
This repo has three deployments that are associated with it. This PR aims to change two of them to only happen on release. 

This repo also adds in the `environment` variable used by Github actions as well as the URLs that are associated with the stable versions. This will be used to populate the Github repo's home screen with links to the deployments. There was a comment regarding the free version, but I am using this feature on a private repo with a free plan without issue.

### Workflows triggers changed:

- File `mainnet.deployment.yml` - is the official mainnet version that lives at https://app.rootstockcollective.xyz
- File `testneet.deployment.yml` - is the official testnet version that lives at https://testnet.app.rootstockcollective.xyz

### Workflows triggers unchanged:
- File `dev.deploy.yml` - is the development testing area that is located at https://dev.app.rootstockcollective.xyz/ . This ones trigger is to deploy when merging into the `develop` branch and is unchanged. This url should be considered unstable and untested for (all) developers to use for the development lifecycle. 