### PR TITLE
fix: tweak css of communities page to closely align with UI design

### DIFF
--- a/src/app/communities/CommunityItem.tsx
+++ b/src/app/communities/CommunityItem.tsx
@@ -20,7 +20,7 @@ export const CommunityItem = ({
   description,
   numberOfMembers,
 }: CommunityItemProps) => (
-  <div className="rounded-[8px] bg-input-bg p-[16px] w-[330px] h-[201px]">
+  <div className="rounded-[8px] bg-input-bg p-[16px] w-[358px] h-[201px]">
     <Link
       href={nftAddress ? `/communities/nft/${nftAddress}` : '/communities'}
       className="flex flex-col h-full"
@@ -30,7 +30,7 @@ export const CommunityItem = ({
           <Image src={leftImageSrc} alt={title} width={50} height={50} />
         </div>
         <div className="flex-1 flex flex-col ml-[12px]">
-          <Span>{title}</Span>
+          <Span className="text-[15px] font-bold">{title}</Span>
           <Span size="small" variant="light">
             {subtitle}
           </Span>


### PR DESCRIPTION
Previous Render
<img width="1060" alt="previous" src="https://github.com/user-attachments/assets/4b19664b-0fc4-4b0e-9ba0-6754a5694576">

Current Render After Change
<img width="1144" alt="Screenshot 2024-10-22 at 4 58 43 PM" src="https://github.com/user-attachments/assets/2ffb5045-51b6-499e-8a20-a3779c14a29a">
