### PR TITLE
fix: make title text on communities card in my collective page render appropriately

### DIFF
--- a/src/app/user/Communities/CommunityCard.tsx
+++ b/src/app/user/Communities/CommunityCard.tsx
@@ -16,7 +16,7 @@ export const CommunityCard: FC<CommunityCardProps> = ({ img, title, description,
         height={300}
       />
       {/* community title */}
-      <Paragraph className="text-[18px] mb-[5px] px-[14px] uppercase" fontFamily="kk-topo">
+      <Paragraph className="text-[18px] mb-[5px] px-[14px] uppercase break-words" fontFamily="kk-topo">
         {title}
       </Paragraph>
       {/* description */}


### PR DESCRIPTION
Previous Render
![image (1)](https://github.com/user-attachments/assets/8cc895f6-fc33-46c0-9deb-cdbe6f429d77)


Current Render After Fix
<img width="554" alt="Screenshot 2024-10-23 at 6 30 40 PM" src="https://github.com/user-attachments/assets/7baa718b-d900-4b03-b9e5-145f2f51e241">
