### PR TITLE
fix: DAO-791 remove unnecessary decimals on the treasury page

### DIFF
--- a/src/app/treasury/TokenHoldings.tsx
+++ b/src/app/treasury/TokenHoldings.tsx
@@ -14,7 +14,7 @@ export const TokenHoldings = ({ symbol }: TokenHoldingsProps) => {
   return (
     <>
       <Paragraph size="small">
-        {toFixed(bucketsTotal[symbol])} {symbol}
+        {Math.ceil(Number(bucketsTotal[symbol]))} {symbol}
       </Paragraph>
       {prices[symbol] && (
         <Paragraph size="small" className="text-zinc-500">

--- a/src/app/treasury/TokenHoldingsStRIF.tsx
+++ b/src/app/treasury/TokenHoldingsStRIF.tsx
@@ -19,7 +19,7 @@ export const TokenHoldingsStRIF = () => {
   const symbol = 'stRIF'
   return (
     <>
-      <Paragraph size="small">{toFixed(balance)} stRIF</Paragraph>
+      <Paragraph size="small">{Math.ceil(Number(balance))} stRIF</Paragraph>
       {prices[symbol] && (
         <Paragraph size="small" className="text-zinc-500">
           = USD {formatCurrency(prices[symbol].price * Number(balance)) ?? 0}

--- a/src/app/treasury/TreasurySection.tsx
+++ b/src/app/treasury/TreasurySection.tsx
@@ -15,7 +15,7 @@ export const TreasurySection = () => {
           <MetricsCard
             key={`${contract.name}-RIF`}
             title={`${contract.name} RIF`}
-            amount={`${buckets[index]?.RIF?.amount ? toFixed(buckets[index].RIF.amount) : 0} RIF`}
+            amount={`${buckets[index]?.RIF?.amount ? Math.ceil(Number(buckets[index].RIF.amount)) : 0} RIF`}
             fiatAmount={`= USD ${buckets[index]?.RIF?.fiatAmount ? buckets[index].RIF.fiatAmount : 0}`}
             contractAddress={contract.address}
             data-testid={`${contract.name}-RIF`}


### PR DESCRIPTION
This PR addresses this jira [ticket](https://rsklabs.atlassian.net/browse/DAO-791)

Previous Renders
<img width="277" alt="Screenshot 2024-10-29 at 8 47 12 AM" src="https://github.com/user-attachments/assets/552b1ef6-cc6b-4ee2-9de1-a9280e40637b">
<img width="1511" alt="Screenshot 2024-10-27 at 10 04 35 PM" src="https://github.com/user-attachments/assets/8acb2c7a-564d-4b05-a9e4-544552e83eeb">

Current Renders
<img width="277" alt="Screenshot 2024-10-29 at 8 48 14 AM" src="https://github.com/user-attachments/assets/8d1aa9d9-62f6-453a-960f-27c6031e4d75">
<img width="1190" alt="Screenshot 2024-10-29 at 8 50 38 AM" src="https://github.com/user-attachments/assets/24edb78d-7bdb-4d5c-af9f-bce0059bb8c9">

