### PR TITLE
DAO-799 show error of Unsupported Network

### DIFF
--- a/src/components/MainContainer/MainContainer.tsx
+++ b/src/components/MainContainer/MainContainer.tsx
@@ -35,9 +35,11 @@ export const MainContainer: FC<Props> = ({ children, notProtected = false }) => 
   }
 
   useEffect(() => {
-    // Clear message on route change
-    setMessage(null)
-  }, [pathname, setMessage])
+    // Clear message on route change unless it is Unsupported network
+    if (message && message.title !== 'Unsupported network') {
+      setMessage(null)
+    }
+  }, [pathname, message, setMessage])
 
   useEffect(() => {
     // This is to prevent Hydration error on client side


### PR DESCRIPTION
The errors are removed when you navigate from one page to another causing a blank screen if the user is connected to the wrong network. This PR fixes this by checking the network title first. 

I don't particularly like this approach but I don't have the full context of the codebase on why errors are being erased on page change so I didn't want to remove the block. This should be a good alternate.

