### PR TITLE
fix: implement fix for edge case where balance in rbtc is less that 1e-7

### DIFF
--- a/src/app/treasury/TreasurySection.tsx
+++ b/src/app/treasury/TreasurySection.tsx
@@ -27,7 +27,12 @@ export const TreasurySection = () => {
           <MetricsCard
             key={`${contract.name}-RBTC`}
             title={`${contract.name} RBTC`}
-            amount={`${buckets[index]?.RBTC?.amount ? toFixed(buckets[index].RBTC.amount) : 0}`}
+            // If the amount is less than 1e-7, show 0, this is because,
+            // toFixed may not be correctly formatting it to a clean
+            // output due to limitations in JavaScript's handling of floating-point numbers
+            amount={`${
+              Number(buckets[index]?.RBTC?.amount) < 1e-7 ? 0 : toFixed(Number(buckets[index]?.RBTC?.amount))
+            }`}
             fiatAmount={`= USD ${buckets[index]?.RBTC?.fiatAmount ? buckets[index].RBTC.fiatAmount : 0}`}
             data-testid={`${contract.name}-RBTC`}
             borderless


### PR DESCRIPTION
This PR addresses this jira [ticket](https://rsklabs.atlassian.net/browse/DAO-737) 

Previous Render
<img width="1202" alt="Screenshot 2024-10-29 at 2 55 54 PM" src="https://github.com/user-attachments/assets/8ed0c5ac-5384-4cdb-891a-3932a411ec11">

Current Render
<img width="1202" alt="Screenshot 2024-10-29 at 3 11 36 PM" src="https://github.com/user-attachments/assets/624ea8f7-ab16-4b48-a373-6d9139b3ecd1">
