### PR TITLE
fix: error message on proposal creation not properly displayed

### DIFF
--- a/src/components/MainContainer/MainContainer.tsx
+++ b/src/components/MainContainer/MainContainer.tsx
@@ -35,13 +35,6 @@ export const MainContainer: FC<Props> = ({ children, notProtected = false }) => 
   }
 
   useEffect(() => {
-    // Clear message on route change unless it is Unsupported network
-    if (message && message.title !== 'Unsupported network') {
-      setMessage(null)
-    }
-  }, [pathname, message, setMessage])
-
-  useEffect(() => {
     // This is to prevent Hydration error on client side
     // because useAccount hook is not available on server side
     setHasMounted(true)

--- a/src/components/MainContainer/MainContainer.tsx
+++ b/src/components/MainContainer/MainContainer.tsx
@@ -5,7 +5,7 @@ import { Footer } from '@/components/Footer'
 import { ConnectButton, Header } from '@/components/Header'
 import { StatefulSidebar } from '@/components/MainContainer/StatefulSidebar'
 import { shortAddress } from '@/lib/utils'
-import { usePathname, useRouter } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 import { FC, ReactNode, useEffect, useState } from 'react'
 import { useAccount, useDisconnect } from 'wagmi'
 import { Alert } from '../Alert'
@@ -25,7 +25,6 @@ export const MainContainer: FC<Props> = ({ children, notProtected = false }) => 
   const { message, setMessage } = useAlertContext()
   const router = useRouter()
   const modal = useModal()
-  const pathname = usePathname()
 
   const [hasMounted, setHasMounted] = useState(false)
 


### PR DESCRIPTION
## What

- Remove the `useEffect` to clear the message on route change
- We did some testing to check if the message was clear on route change and it worked


## Why

- In this [PR](https://github.com/RootstockCollective/dao-frontend/pull/116) we introduced a `useEffect` to clear message on route change that we updated on this [PR](https://github.com/RootstockCollective/dao-frontend/pull/299/files) which clears the messages if it was not the 'Unsupported network'

# Link

- [DAO-805](https://rsklabs.atlassian.net/browse/DAO-805)
