### PR TITLE
chore: move reward distributed endpoint in a single place

### DIFF
--- a/src/app/collective-rewards/actions.ts
+++ b/src/app/collective-rewards/actions.ts
@@ -1,15 +1,8 @@
-import { encodeEventTopics } from 'viem'
-import { SimplifiedRewardDistributorAbi } from '@/lib/abis/SimplifiedRewardDistributorAbi'
 import { SimplifiedRewardDistributorAddress } from '@/lib/contracts'
 import { axiosInstance } from '@/lib/utils'
 import { fetchRewardDistributedLogsByAddress } from '@/lib/endpoints'
 
 export const fetchRewardDistributedLogs = (fromBlock = 0) => {
-  const topic = encodeEventTopics({
-    abi: SimplifiedRewardDistributorAbi,
-    eventName: 'RewardDistributed',
-  })[0]
-
   return axiosInstance.get(
     fetchRewardDistributedLogsByAddress
       .replace('{{address}}', SimplifiedRewardDistributorAddress)

--- a/src/app/collective-rewards/actions.ts
+++ b/src/app/collective-rewards/actions.ts
@@ -2,6 +2,7 @@ import { encodeEventTopics } from 'viem'
 import { SimplifiedRewardDistributorAbi } from '@/lib/abis/SimplifiedRewardDistributorAbi'
 import { SimplifiedRewardDistributorAddress } from '@/lib/contracts'
 import { axiosInstance } from '@/lib/utils'
+import { fetchRewardDistributedLogsByAddress } from '@/lib/endpoints'
 
 export const fetchRewardDistributedLogs = (fromBlock = 0) => {
   const topic = encodeEventTopics({
@@ -10,7 +11,9 @@ export const fetchRewardDistributedLogs = (fromBlock = 0) => {
   })[0]
 
   return axiosInstance.get(
-    `address/${SimplifiedRewardDistributorAddress}/eventsByTopic0?topic0=${topic}&fromBlock=${fromBlock}`,
+    fetchRewardDistributedLogsByAddress
+      .replace('{{address}}', SimplifiedRewardDistributorAddress)
+      .replace('{{fromBlock}}', fromBlock.toString()),
   )
 }
 

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -24,4 +24,4 @@ export const getTokenHoldersOfAddress = `/address/{{address}}/holders?chainId=${
 export const getNftHolders = `/nfts/{{address}}/holders?chainId=${CHAIN_ID}`
 
 const REWARD_DISTRIBUTED_EVENT = '0x57ea5c7c295b52ef3b06c69661d59c8a6d9c602ac5355cfe5e54e303c139f270'
-export const fetchRewardDistributedLogsByAddress = `address/{{address}}/eventsByTopic0?topic0=${REWARD_DISTRIBUTED_EVENT}&chainId=${CHAIN_ID}&fromBlock={{fromBlock}}`
+export const fetchRewardDistributedLogsByAddress = `/address/{{address}}/eventsByTopic0?topic0=${REWARD_DISTRIBUTED_EVENT}&chainId=${CHAIN_ID}&fromBlock={{fromBlock}}`

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -22,3 +22,6 @@ export const getNftInfo =
 export const getTokenHoldersOfAddress = `/address/{{address}}/holders?chainId=${CHAIN_ID}`
 
 export const getNftHolders = `/nfts/{{address}}/holders?chainId=${CHAIN_ID}`
+
+const REWARD_DISTRIBUTED_EVENT = '0x57ea5c7c295b52ef3b06c69661d59c8a6d9c602ac5355cfe5e54e303c139f270'
+export const fetchRewardDistributedLogsByAddress = `address/{{address}}/eventsByTopic0?topic0=${REWARD_DISTRIBUTED_EVENT}&chainId=${CHAIN_ID}&fromBlock={{fromBlock}}`


### PR DESCRIPTION
## What

- Move the fetch reward distributed endpoint where are the other endpoints
- include the `chainId` parameter

## Why

- the `chainId` is required, otherwise 31 will be used by default