### PR TITLE
fix(dao): removes hydration error for Logo

### DIFF
--- a/src/components/Header/Logo.tsx
+++ b/src/components/Header/Logo.tsx
@@ -1,3 +1,4 @@
+'use client'
 import Image from 'next/image'
 
 export const Logo = ({ className = '' }) => {

--- a/src/lib/contracts.ts
+++ b/src/lib/contracts.ts
@@ -46,7 +46,7 @@ const treasuryContracts = [
   { name: 'Grants', address: GRANTS_BUCKET_ADDRESS },
   { name: 'Grants - Active', address: GRANTS_ACTIVE_BUCKET_ADDRESS },
   { name: 'Growth', address: GROWTH_BUCKET_ADDRESS },
-  { name: 'Growth - Rewards', address: REWARD_DISTRIBUTOR_ADDRESS },
+  { name: 'Growth - Rewards', address: SIMPLIFIED_REWARD_DISTRIBUTOR_ADDRESS },
   { name: 'General', address: GENERAL_BUCKET_ADDRESS },
 ]
 


### PR DESCRIPTION
# What

makes the Logo component client side only
changes growth bucket back to v1 distributor

# Why

This is to prevent
![Screenshot 2024-11-08 at 08 22 24](https://github.com/user-attachments/assets/9e553166-5d93-49cc-899b-d056c2633e18)

and
![Screenshot 2024-11-08 at 12 27 34 PM](https://github.com/user-attachments/assets/a977e1d2-70b6-4958-ab31-532da8e32b86)


