### PR TITLE
DAO-679 Fixed proposal confirmation message UI

### DIFF
--- a/src/pages/proposals/[id].tsx
+++ b/src/pages/proposals/[id].tsx
@@ -281,6 +281,7 @@ const PageWithProposal = (proposal: ParsedProposal) => {
             <Popover
               size="small"
               trigger="hover"
+              disabled={isExecuting}
               content={
                 !canProposalBeExecuted ? (
                   <p className="text-[12px] font-bold mb-1">
@@ -290,13 +291,15 @@ const PageWithProposal = (proposal: ParsedProposal) => {
                 ) : isExecuting ? (
                   <p className="text-[12px] font-bold mb-1">The proposal is being executed.</p>
                 ) : (
-                  <p className="text-[12px] font-bold mb-1">The proposal can be executed.</p>
+                  <p className="text-[12px] font-bold mb-1">
+                    The proposal <br /> can be executed.
+                  </p>
                 )
               }
             >
               <Button
                 onClick={handleVotingExecution}
-                className="mt-2"
+                className="mt-2 ml-auto"
                 disabled={!canProposalBeExecuted || isExecuting}
                 data-testid="Execute"
               >
@@ -304,7 +307,12 @@ const PageWithProposal = (proposal: ParsedProposal) => {
               </Button>
             </Popover>
           )}
-          {isExecuting && <p>Pending transaction confirmation to complete execution.</p>}
+          {isExecuting && (
+            <Span variant="light" className="inline-block mt-2">
+              Pending transaction confirmation <br />
+              to complete execution.
+            </Span>
+          )}
           {votingModal.isModalOpened && address && (
             <VoteProposalModal
               onSubmit={handleVoting}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/07e1222f-e0f0-47f3-ac29-8c26af60c126)

Note: the image is reflecting the message. When there is a proposal being executed, it'll not show the popup and will always show the button at the right.