### PR TITLE
DAO-824 Added voting power received

### DIFF
--- a/src/app/user/Delegation/DelegationSection.tsx
+++ b/src/app/user/Delegation/DelegationSection.tsx
@@ -15,16 +15,12 @@ import { BalancesProvider } from '../Balances/context/BalancesContext'
 import { useGetDelegates } from './hooks/useGetDelegates'
 import { ReclaimCell } from './ReclaimCell'
 import { DelegationAction } from './type'
-import { useGetAddressBalances } from '../Balances/hooks/useGetAddressBalances'
 import { useGetExternalDelegatedAmount } from '@/shared/hooks/useGetExternalDelegatedAmount'
 import { TokenValue } from '@/app/user/Delegation/TokenValue'
 
 export const DelegationSection = () => {
   const { address } = useAccount()
   const { delegateeAddress } = useGetDelegates(address)
-  const {
-    stRIF: { balance: stRIFBalance },
-  } = useGetAddressBalances()
 
   const [isDelegateModalOpened, setIsDelegateModalOpened] = useState(false)
   const [hash, setHash] = useState<Hash | undefined>(undefined)
@@ -48,7 +44,7 @@ export const DelegationSection = () => {
     }
   }, [action, isError, isSuccess, setGlobalMessage])
 
-  const isValidDelegatee = delegateeAddress !== address && Number(stRIFBalance) > 0
+  const isValidDelegatee = delegateeAddress !== address
   const delegatee = {
     'Voting Power Delegated': isValidDelegatee ? <HolderColumn address={delegateeAddress || ''} /> : '-',
     Amount: isValidDelegatee ? <RenderTotalBalance symbol="stRIF" /> : '-',

--- a/src/app/user/Delegation/DelegationSection.tsx
+++ b/src/app/user/Delegation/DelegationSection.tsx
@@ -16,6 +16,8 @@ import { useGetDelegates } from './hooks/useGetDelegates'
 import { ReclaimCell } from './ReclaimCell'
 import { DelegationAction } from './type'
 import { useGetAddressBalances } from '../Balances/hooks/useGetAddressBalances'
+import { useGetExternalDelegatedAmount } from '@/shared/hooks/useGetExternalDelegatedAmount'
+import { TokenValue } from '@/app/user/Delegation/TokenValue'
 
 export const DelegationSection = () => {
   const { address } = useAccount()
@@ -53,6 +55,13 @@ export const DelegationSection = () => {
     Actions: isValidDelegatee ? <ReclaimCell onDelegateTxStarted={onDelegateTxStarted} /> : '-',
   }
 
+  const { amount: amountDelegatedToMe, isLoading: isExternalDelegatedAmountLoading } =
+    useGetExternalDelegatedAmount(address)
+
+  const delegatedToMe = {
+    'Voting Power Received': <TokenValue symbol="stRIF" amount={amountDelegatedToMe} shouldFormatBalance />,
+  }
+
   return (
     <div className="mb-6">
       {/* Header Components*/}
@@ -63,6 +72,7 @@ export const DelegationSection = () => {
         </Button>
       </div>
       <BalancesProvider>
+        {!isExternalDelegatedAmountLoading && <Table data={[delegatedToMe]} />}
         <Table data={[delegatee]} />
       </BalancesProvider>
       {isDelegateModalOpened && (

--- a/src/app/user/Delegation/TokenValue.tsx
+++ b/src/app/user/Delegation/TokenValue.tsx
@@ -1,0 +1,31 @@
+import { useBalancesContext } from '@/app/user/Balances/context/BalancesContext'
+import { SupportedTokens } from '@/lib/contracts'
+import { Paragraph } from '@/components/Typography'
+import { formatCurrency, toFixed } from '@/lib/utils'
+import { formatBalanceToHuman } from '@/app/user/Balances/balanceUtils'
+
+interface TokenValueProps {
+  symbol: SupportedTokens
+  amount: bigint | number
+  shouldFormatBalance?: boolean
+}
+
+export const TokenValue = ({ symbol, amount, shouldFormatBalance = false }: TokenValueProps) => {
+  const { prices } = useBalancesContext()
+  const amountFormatted = shouldFormatBalance ? formatBalanceToHuman(amount) : amount
+  const price = prices[symbol]?.price || 0
+  const value = price * Number(amountFormatted)
+
+  return (
+    <>
+      <Paragraph size="small">
+        {toFixed(amountFormatted.toString())} {symbol}
+      </Paragraph>
+      {prices[symbol] && (
+        <Paragraph size="small" className="text-zinc-500">
+          = USD {formatCurrency(value) ?? 0}
+        </Paragraph>
+      )}
+    </>
+  )
+}

--- a/src/app/user/Delegation/hooks/useGetDelegates.tsx
+++ b/src/app/user/Delegation/hooks/useGetDelegates.tsx
@@ -9,7 +9,7 @@ const stRifContract = {
 }
 
 export const useGetDelegates = (address: Address | undefined) => {
-  const { data: delegateeAddress } = useReadContract(
+  const { data: delegateeAddress, isLoading } = useReadContract(
     address && {
       ...stRifContract,
       functionName: 'delegates',
@@ -20,5 +20,5 @@ export const useGetDelegates = (address: Address | undefined) => {
     },
   )
 
-  return { delegateeAddress }
+  return { delegateeAddress, isLoading }
 }

--- a/src/shared/hooks/useGetExternalDelegatedAmount.tsx
+++ b/src/shared/hooks/useGetExternalDelegatedAmount.tsx
@@ -1,0 +1,73 @@
+import { Address } from 'viem'
+import { useGetDelegates } from '@/app/user/Delegation/hooks/useGetDelegates'
+import { useAccount, useReadContract } from 'wagmi'
+import { StRIFTokenAbi } from '@/lib/abis/StRIFTokenAbi'
+import { STRIF_ADDRESS } from '@/lib/constants'
+
+/**
+ * Custom hook to calculate the amount of voting power delegated to an address by other users.
+ * Excludes self-delegated voting power from the calculation.
+ *
+ * @param {Address|undefined} address - The address to check delegations for
+ * @returns {Object} Object containing the external delegated amount and loading state
+ * @property {bigint} amount - The amount of voting power delegated by other users
+ * @property {boolean} isLoading - True if any dependent data is still loading
+ *
+ * @example
+ * ```tsx
+ * const externalDelegations = useGetExternalDelegatedAmount(userAddress)
+ * ```
+ *
+ * @remarks
+ * Returns:
+ * - All voting power if user hasn't self-delegated but has voting power (full external delegation)
+ * - Difference between voting power and balance if self-delegated (partial external delegation)
+ * - 0n if no external delegations exist
+ */
+export const useGetExternalDelegatedAmount = (address: Address | undefined) => {
+  const { address: ownAddress } = useAccount()
+  const { delegateeAddress, isLoading: isDelegateLoading } = useGetDelegates(address)
+
+  const { data: votingPower, isLoading: isVotingPowerLoading } = useReadContract(
+    ownAddress && {
+      abi: StRIFTokenAbi,
+      address: STRIF_ADDRESS,
+      functionName: 'getVotes',
+      args: [ownAddress],
+      query: {
+        refetchInterval: 10000,
+      },
+    },
+  )
+
+  const { data: balance, isLoading: isBalanceLoading } = useReadContract(
+    ownAddress && {
+      abi: StRIFTokenAbi,
+      address: STRIF_ADDRESS,
+      functionName: 'balanceOf',
+      args: [ownAddress],
+      query: {
+        refetchInterval: 10000,
+      },
+    },
+  )
+
+  const isLoading = isDelegateLoading || isVotingPowerLoading || isBalanceLoading
+
+  const didIDelegateToMyself = ownAddress === delegateeAddress
+  const doIHaveVotingPower = (votingPower || 0n) > 0n
+
+  let amount = 0n
+
+  if (!didIDelegateToMyself && doIHaveVotingPower) {
+    amount = votingPower || 0n
+  }
+
+  if (didIDelegateToMyself && votingPower && balance) {
+    if (votingPower > balance) {
+      amount = votingPower - balance
+    }
+  }
+
+  return { amount, isLoading }
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2fbbae2b-2640-4887-9767-1420fcdfab30)

When no power has been received
![image](https://github.com/user-attachments/assets/71af7e7d-4e11-4d4a-9737-747f82837a09)

EDIT: I've added a commit to include a patch after the daily of 11/15/2024 - the voting power delegated table should always show - no matter if there is balance or not. Because else, the user will never be able to reclaim.