### PR TITLE
chore: implement allow account to create proposal once totalVotingPower is sufficient

### DIFF
--- a/src/app/proposals/hooks/useVotingPower.ts
+++ b/src/app/proposals/hooks/useVotingPower.ts
@@ -44,7 +44,7 @@ export const useVotingPower = () => {
   return {
     isLoading: false,
     votingPower: formatUnits(balance, decimals),
-    canCreateProposal: balance >= threshold,
+    canCreateProposal: totalVotingPower >= threshold,
     threshold: formatUnits(threshold, decimals),
     totalVotingPower: formatUnits(totalVotingPower, decimals),
   }


### PR DESCRIPTION
This PR fixes a bug that incorrectly uses an account's voting balance instead of total voting power (balance + delegated) to check if a proposal can be created