### PR TITLE
fix: filter out builders without allocations or rewards

### DIFF
--- a/src/app/collective-rewards/rewards/backers/BackerRewardsTable.tsx
+++ b/src/app/collective-rewards/rewards/backers/BackerRewardsTable.tsx
@@ -19,6 +19,7 @@ import { useHandleErrors } from '@/app/collective-rewards/utils'
 import { LoadingSpinner } from '@/components/LoadingSpinner'
 import { useBasicPaginationUi } from '@/shared/hooks/usePaginationUi'
 import { CycleContextProvider } from '@/app/collective-rewards/metrics'
+import Link from 'next/link'
 
 enum RewardsColumnKeyEnum {
   builder = 'builder',
@@ -110,58 +111,73 @@ const RewardsTable: FC<BackerRewardsTable> = ({ builder, gauges, tokens }) => {
 
   return (
     <div className="flex flex-col gap-5 w-full">
-      <TableCore className="table-fixed">
-        <TableHead>
-          <TableRow className="min-h-0 normal-case">
-            {tableHeaders.map(header => (
-              <TableHeaderCell
-                key={header.label}
-                tableHeader={header}
-                onSort={() => handleSort(header.sortKey)}
-                sortConfig={sortConfig}
-              />
-            ))}
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {Object.values(paginatedRewardsData).map(
-            ({
-              address,
-              builderName,
-              stateFlags,
-              rewardPercentage,
-              estimatedRewards,
-              totalAllocationPercentage,
-              claimableRewards,
-              allTimeRewards,
-            }) => (
-              <TableRow key={address} className="text-[14px] border-hidden">
-                <BuilderNameCell
-                  tableHeader={tableHeaders[0]}
-                  builderName={builderName}
-                  address={address}
-                  stateFlags={stateFlags}
-                />
-                <BackerRewardsPercentage tableHeader={tableHeaders[1]} percentage={rewardPercentage} />
-                <LazyRewardCell
-                  tableHeader={tableHeaders[2]}
-                  rewards={[estimatedRewards.rbtc, estimatedRewards.rif]}
-                />
-                <TotalAllocationCell tableHeader={tableHeaders[3]} percentage={totalAllocationPercentage} />
-                <LazyRewardCell
-                  tableHeader={tableHeaders[4]}
-                  rewards={[claimableRewards.rbtc, claimableRewards.rif]}
-                />
-                <LazyRewardCell
-                  tableHeader={tableHeaders[5]}
-                  rewards={[allTimeRewards.rbtc, allTimeRewards.rif]}
-                />
+      {Object.values(paginatedRewardsData).length === 0 ? (
+        <div className="text-center font-kk-topo">
+          Have your say! Start voting now to shape the RootstockCollective community. Click{' '}
+          <Link href={'/collective-rewards'} className="text-[#E56B1A]">
+            here
+          </Link>{' '}
+          to begin!
+        </div>
+      ) : (
+        <>
+          <TableCore className="table-fixed">
+            <TableHead>
+              <TableRow className="min-h-0 normal-case">
+                {tableHeaders.map(header => (
+                  <TableHeaderCell
+                    key={header.label}
+                    tableHeader={header}
+                    onSort={() => handleSort(header.sortKey)}
+                    sortConfig={sortConfig}
+                  />
+                ))}
               </TableRow>
-            ),
-          )}
-        </TableBody>
-      </TableCore>
-      <div className="flex justify-center">{paginationUi}</div>
+            </TableHead>
+            <TableBody>
+              {Object.values(paginatedRewardsData).map(
+                ({
+                  address,
+                  builderName,
+                  stateFlags,
+                  rewardPercentage,
+                  estimatedRewards,
+                  totalAllocationPercentage,
+                  claimableRewards,
+                  allTimeRewards,
+                }) => (
+                  <TableRow key={address} className="text-[14px] border-hidden">
+                    <BuilderNameCell
+                      tableHeader={tableHeaders[0]}
+                      builderName={builderName}
+                      address={address}
+                      stateFlags={stateFlags}
+                    />
+                    <BackerRewardsPercentage tableHeader={tableHeaders[1]} percentage={rewardPercentage} />
+                    <LazyRewardCell
+                      tableHeader={tableHeaders[2]}
+                      rewards={[estimatedRewards.rbtc, estimatedRewards.rif]}
+                    />
+                    <TotalAllocationCell
+                      tableHeader={tableHeaders[3]}
+                      percentage={totalAllocationPercentage}
+                    />
+                    <LazyRewardCell
+                      tableHeader={tableHeaders[4]}
+                      rewards={[claimableRewards.rbtc, claimableRewards.rif]}
+                    />
+                    <LazyRewardCell
+                      tableHeader={tableHeaders[5]}
+                      rewards={[allTimeRewards.rbtc, allTimeRewards.rif]}
+                    />
+                  </TableRow>
+                ),
+              )}
+            </TableBody>
+          </TableCore>
+          <div className="flex justify-center">{paginationUi}</div>
+        </>
+      )}
     </div>
   )
 }

--- a/src/app/collective-rewards/rewards/backers/hooks/useGetBackerRewards.ts
+++ b/src/app/collective-rewards/rewards/backers/hooks/useGetBackerRewards.ts
@@ -14,6 +14,7 @@ import { usePricesContext } from '@/shared/context/PricesContext'
 import { formatBalanceToHuman } from '@/app/user/Balances/balanceUtils'
 import { useGetBuildersByState } from '@/app/collective-rewards//user'
 import { Builder, BuilderStateFlags } from '@/app/collective-rewards/types'
+import { useMemo } from 'react'
 
 export type BackerRewards = {
   address: Address
@@ -55,9 +56,9 @@ export const useGetBackerRewards = (
   } = useGetBuildersByState<Required<Builder>>()
   const buildersAddress = builders.map(({ address }) => address)
   const {
-    data: buildersRewardsPct,
-    isLoading: buildersRewardsPctLoading,
-    error: buildersRewardsPctError,
+    data: backersRewardsPct,
+    isLoading: backersRewardsPctLoading,
+    error: backersRewardsPctError,
   } = useGetBackersRewardPercentage(buildersAddress)
   const {
     data: totalAllocation,
@@ -71,110 +72,142 @@ export const useGetBackerRewards = (
   } = useGaugesGetFunction(gauges, 'allocationOf', [builder])
   const { data: tokenRewards, isLoading: rewardsLoading, error: rewardsError } = useBackerRewardsContext()
 
-  const isLoading =
-    buildersLoading ||
-    buildersRewardsPctLoading ||
-    totalAllocationLoading ||
-    allocationOfLoading ||
-    rewardsLoading
-  const error =
-    buildersError ?? buildersRewardsPctError ?? totalAllocationError ?? allocationOfError ?? rewardsError
+  const isLoading = useMemo(
+    () =>
+      buildersLoading ||
+      backersRewardsPctLoading ||
+      totalAllocationLoading ||
+      allocationOfLoading ||
+      rewardsLoading,
+    [buildersLoading, backersRewardsPctLoading, totalAllocationLoading, allocationOfLoading, rewardsLoading],
+  )
+  const error = useMemo(
+    () =>
+      buildersError ?? backersRewardsPctError ?? totalAllocationError ?? allocationOfError ?? rewardsError,
+    [buildersError, backersRewardsPctError, totalAllocationError, allocationOfError, rewardsError],
+  )
 
   const { prices } = usePricesContext()
   const rifPrice = prices[rif.symbol]?.price ?? 0
   const rbtcPrice = prices[rbtc.symbol]?.price ?? 0
 
-  const data: BackerRewards[] = builders.map(({ address, builderName, gauge, stateFlags }) => {
-    const builderTotalAllocation = totalAllocation[gauge] ?? 0n
-    const backerAllocationOf = allocationOf[gauge] ?? 0n
-    const totalAllocationPercentage = builderTotalAllocation
-      ? (backerAllocationOf * 100n) / builderTotalAllocation
-      : 0n
-    const rewardPercentage = buildersRewardsPct[address] ?? null
+  const data = useMemo(() => {
+    return builders.reduce((acc, { address, builderName, gauge, stateFlags }) => {
+      const builderTotalAllocation = totalAllocation[gauge] ?? 0n
+      const backerAllocationOf = allocationOf[gauge] ?? 0n
+      const totalAllocationPercentage = builderTotalAllocation
+        ? (backerAllocationOf * 100n) / builderTotalAllocation
+        : 0n
+      const rewardPercentage = backersRewardsPct[address] ?? null
 
-    const rifRewards = tokenRewardsMetrics(tokenRewards[rif.address], gauge)
-    const rbtcRewards = tokenRewardsMetrics(tokenRewards[rbtc.address], gauge)
+      const rifRewards = tokenRewardsMetrics(tokenRewards[rif.address], gauge)
+      const rbtcRewards = tokenRewardsMetrics(tokenRewards[rbtc.address], gauge)
 
-    return {
-      address,
-      builderName,
-      stateFlags,
-      totalAllocationPercentage,
-      rewardPercentage,
-      estimatedRewards: {
-        rif: {
-          crypto: {
-            value: rifRewards.estimatedRewards,
-            symbol: rif.symbol,
-          },
-          fiat: {
-            value: rifPrice * rifRewards.estimatedRewards,
-            symbol: currency,
-          },
-          logo: RifSvg(),
-        },
-        rbtc: {
-          crypto: {
-            value: rbtcRewards.estimatedRewards,
-            symbol: rbtc.symbol,
-          },
-          fiat: {
-            value: rbtcPrice * rbtcRewards.estimatedRewards,
-            symbol: currency,
-          },
-          logo: RbtcSvg(),
-        },
-      },
-      claimableRewards: {
-        rif: {
-          crypto: {
-            value: rifRewards.claimableRewards,
-            symbol: rif.symbol,
-          },
-          fiat: {
-            value: rifPrice * rifRewards.claimableRewards,
-            symbol: currency,
-          },
-          logo: RifSvg(),
-        },
-        rbtc: {
-          crypto: {
-            value: rbtcRewards.claimableRewards,
-            symbol: rbtc.symbol,
-          },
-          fiat: {
-            value: rbtcPrice * rbtcRewards.claimableRewards,
-            symbol: currency,
-          },
-          logo: RbtcSvg(),
-        },
-      },
-      allTimeRewards: {
-        rif: {
-          crypto: {
-            value: rifRewards.allTimeRewards,
-            symbol: rif.symbol,
-          },
-          fiat: {
-            value: rifPrice * rifRewards.allTimeRewards,
-            symbol: currency,
-          },
-          logo: RifSvg(),
-        },
-        rbtc: {
-          crypto: {
-            value: rbtcRewards.allTimeRewards,
-            symbol: rbtc.symbol,
-          },
-          fiat: {
-            value: rbtcPrice * rbtcRewards.allTimeRewards,
-            symbol: currency,
-          },
-          logo: RbtcSvg(),
-        },
-      },
-    }
-  })
+      // If backer allocated for the builder or if they have rewards (estimated or claimable)
+      if (
+        backerAllocationOf > 0n ||
+        rifRewards.estimatedRewards > 0 ||
+        rbtcRewards.estimatedRewards > 0 ||
+        rifRewards.claimableRewards > 0 ||
+        rbtcRewards.claimableRewards > 0
+      ) {
+        return [
+          ...acc,
+          {
+            address,
+            builderName,
+            stateFlags,
+            totalAllocationPercentage,
+            rewardPercentage,
+            estimatedRewards: {
+              rif: {
+                crypto: {
+                  value: rifRewards.estimatedRewards,
+                  symbol: rif.symbol,
+                },
+                fiat: {
+                  value: rifPrice * rifRewards.estimatedRewards,
+                  symbol: currency,
+                },
+                logo: RifSvg(),
+              },
+              rbtc: {
+                crypto: {
+                  value: rbtcRewards.estimatedRewards,
+                  symbol: rbtc.symbol,
+                },
+                fiat: {
+                  value: rbtcPrice * rbtcRewards.estimatedRewards,
+                  symbol: currency,
+                },
+                logo: RbtcSvg(),
+              },
+            },
+            claimableRewards: {
+              rif: {
+                crypto: {
+                  value: rifRewards.claimableRewards,
+                  symbol: rif.symbol,
+                },
+                fiat: {
+                  value: rifPrice * rifRewards.claimableRewards,
+                  symbol: currency,
+                },
+                logo: RifSvg(),
+              },
+              rbtc: {
+                crypto: {
+                  value: rbtcRewards.claimableRewards,
+                  symbol: rbtc.symbol,
+                },
+                fiat: {
+                  value: rbtcPrice * rbtcRewards.claimableRewards,
+                  symbol: currency,
+                },
+                logo: RbtcSvg(),
+              },
+            },
+            allTimeRewards: {
+              rif: {
+                crypto: {
+                  value: rifRewards.allTimeRewards,
+                  symbol: rif.symbol,
+                },
+                fiat: {
+                  value: rifPrice * rifRewards.allTimeRewards,
+                  symbol: currency,
+                },
+                logo: RifSvg(),
+              },
+              rbtc: {
+                crypto: {
+                  value: rbtcRewards.allTimeRewards,
+                  symbol: rbtc.symbol,
+                },
+                fiat: {
+                  value: rbtcPrice * rbtcRewards.allTimeRewards,
+                  symbol: currency,
+                },
+                logo: RbtcSvg(),
+              },
+            },
+          } as BackerRewards,
+        ]
+      }
+      return acc
+    }, [] as BackerRewards[])
+  }, [
+    builders,
+    totalAllocation,
+    allocationOf,
+    backersRewardsPct,
+    tokenRewards,
+    rif,
+    rbtc,
+    rifPrice,
+    rbtcPrice,
+    currency,
+  ])
 
   return {
     data,

--- a/src/app/collective-rewards/rewards/utils/getPercentageData.ts
+++ b/src/app/collective-rewards/rewards/utils/getPercentageData.ts
@@ -1,5 +1,6 @@
 import { toPercentage } from '@/app/collective-rewards/rewards'
 
+// TODO: this is a duplicate of BackerRewardPercentage
 export type BuilderRewardPercentage = {
   current: number
   next: number


### PR DESCRIPTION
## What

- filter out builders without allocations or available rewards for the backer

