### PR TITLE
fix: disable save allocs and other goodness

### DIFF
--- a/src/app/collective-rewards/allocations/components/AllocationAmount.tsx
+++ b/src/app/collective-rewards/allocations/components/AllocationAmount.tsx
@@ -23,20 +23,19 @@ const ALLOCATION_EXCEED_AMOUNT_ERROR = 'Builder allocations exceeds amount to al
 export const AllocationAmount = () => {
   const {
     state: {
-      backer: { balance, totalAllocation, cumulativeAllocation, allocationCount },
+      backer: { balance, amountToAllocate, cumulativeAllocation, allocationsCount },
     },
-    actions: { updateAllocations, updateTotalAllocation },
+    actions: { updateAllocations, updateAmountToAllocate: updateTotalAllocation },
   } = useContext(AllocationsContext)
 
   const [activeButtonIndex, setActiveButtonIndex] = useState<number | null>(null)
   const onPercentageButtonClicked = (percentage: number, index: number) => {
-    const newTotalAllocation = (BigInt(balance ?? 0n) * BigInt(percentage)) / BigInt(100)
-    updateTotalAllocation(newTotalAllocation)
+    const newAmountToAllocate = (BigInt(balance ?? 0n) * BigInt(percentage)) / BigInt(100)
+    updateTotalAllocation(newAmountToAllocate)
     setActiveButtonIndex(index)
-    if (allocationCount === 0) return
-    const allocationValue = allocationCount > 0 ? newTotalAllocation / BigInt(allocationCount) : 0n
+    if (allocationsCount === 0) return
 
-    updateAllocations(Array(allocationCount).fill(allocationValue))
+    updateAllocations(Array(allocationsCount).fill(BigInt(allocationsCount)))
   }
 
   const handleOnChange = (value: string) => {
@@ -54,14 +53,14 @@ export const AllocationAmount = () => {
           name="allocated-amount"
           fullWidth
           onChange={handleOnChange}
-          value={formatEther(totalAllocation)}
+          value={formatEther(amountToAllocate)}
           errorMessage={
-            cumulativeAllocation > totalAllocation && cumulativeAllocation < balance
+            cumulativeAllocation > amountToAllocate && cumulativeAllocation < balance
               ? ALLOCATION_EXCEED_AMOUNT_ERROR
               : ''
           }
           hint={
-            Number(totalAllocation - cumulativeAllocation) < 0 || totalAllocation > balance ? (
+            Number(amountToAllocate - cumulativeAllocation) < 0 || amountToAllocate > balance ? (
               <StakeHint />
             ) : undefined
           }

--- a/src/app/collective-rewards/allocations/components/AllocationMetrics.tsx
+++ b/src/app/collective-rewards/allocations/components/AllocationMetrics.tsx
@@ -41,15 +41,15 @@ const UnallocatedAmount = ({ value }: ValueProps) => {
 export const AllocationMetrics = () => {
   const {
     initialState: {
-      backer: { totalAllocation, balance },
+      backer: { amountToAllocate, balance },
     },
   } = useContext(AllocationsContext)
 
   const balanceValue = `${formatEther(balance)} stRIF`
 
-  const allocatedAmountValue = `${formatEther(totalAllocation)} stRIF`
+  const allocatedAmountValue = `${formatEther(amountToAllocate)} stRIF`
 
-  const unallocatedAmount = formatEther(balance - totalAllocation)
+  const unallocatedAmount = formatEther(balance - amountToAllocate)
 
   const unallocatedAmountValue = `${unallocatedAmount} stRIF`
   return (

--- a/src/app/collective-rewards/allocations/components/BuilderAllocation.tsx
+++ b/src/app/collective-rewards/allocations/components/BuilderAllocation.tsx
@@ -18,11 +18,11 @@ export type BuilderAllocationProps = BuilderAllocationHeaderProps &
 export const BuilderAllocation = (builder: BuilderAllocationProps) => {
   const {
     state: {
-      backer: { totalAllocation, cumulativeAllocation },
+      backer: { amountToAllocate, cumulativeAllocation },
     },
     actions: { updateAllocation },
   } = useContext(AllocationsContext)
-  const allocationLeft = totalAllocation - cumulativeAllocation
+  const allocationLeft = amountToAllocate - cumulativeAllocation
   const { currentAllocation, backerRewardPercentage, address } = builder
   const onInputChange = (value: string) => {
     updateAllocation(builder.index, parseEther(value))
@@ -47,7 +47,7 @@ export const BuilderAllocation = (builder: BuilderAllocationProps) => {
       />
       <Slider
         value={[Number(currentAllocation)]}
-        max={Number(totalAllocation)}
+        max={Number(amountToAllocate)}
         onValueChange={onSliderValueChange}
       />
     </div>

--- a/src/app/collective-rewards/allocations/context/allocationsActions.tsx
+++ b/src/app/collective-rewards/allocations/context/allocationsActions.tsx
@@ -39,10 +39,10 @@ export const createActions = (
       cumulativeAllocation: newCumulativeAllocation,
     }))
   },
-  updateTotalAllocation: (value: bigint) => {
+  updateAmountToAllocate: (value: bigint) => {
     setBacker(prevBacker => ({
       ...prevBacker,
-      totalAllocation: value,
+      amountToAllocate: value,
     }))
   },
   resetAllocations: () => {

--- a/src/app/collective-rewards/allocations/page.tsx
+++ b/src/app/collective-rewards/allocations/page.tsx
@@ -40,7 +40,7 @@ export default function Allocations() {
 
   const router = useRouter()
   const {
-    state: { allocations, getBuilder },
+    state: { allocations, getBuilder, isValidState },
     actions: { resetAllocations },
   } = useContext(AllocationsContext)
 
@@ -105,7 +105,7 @@ export default function Allocations() {
           <div className="flex items-center self-stretch justify-between gap-4">
             <div className="flex gap-4">
               {/* TODO: review disabled statuses */}
-              <Button variant="primary" onClick={() => saveAllocations()}>
+              <Button disabled={!isValidState()} variant="primary" onClick={() => saveAllocations()}>
                 {' '}
                 Save allocations
               </Button>


### PR DESCRIPTION
# What

- disables save allocs when:
  - the amount to allocate is bigger than balance
  - the cumulative amount is bigger than balance
  - allocation didn't change
- fixes the allocationsCount value
- renames totalAllocations to amountToAllocate as it was confusing
