### PR TITLE
TOK-502: use active backer rewards percentage

### DIFF
--- a/src/app/collective-rewards/allocations/components/BuilderAllocation.tsx
+++ b/src/app/collective-rewards/allocations/components/BuilderAllocation.tsx
@@ -36,7 +36,7 @@ export const BuilderAllocation = (builder: BuilderAllocationProps) => {
     <div className="flex flex-col py-4 px-2 gap-6 shrink-0 bg-foreground rounded-[8px] min-w-[calc(25%-2rem)] max-w-[25%-1rem]">
       <BuilderAllocationHeader {...builder} />
       <Label className="font-bold">
-        Backer rewards {weiToPercentage(backerRewardPercentage?.previous ?? 0n, 0)}%{' '}
+        Backer rewards {weiToPercentage(backerRewardPercentage?.active ?? 0n, 0)}%{' '}
       </Label>
       <Input
         type="number"

--- a/src/app/collective-rewards/allocations/context/AllocationsContext.tsx
+++ b/src/app/collective-rewards/allocations/context/AllocationsContext.tsx
@@ -135,7 +135,12 @@ export const AllocationsContextProvider: FC<{ children: ReactNode }> = ({ childr
     return rawBuilders.reduce((acc, builder, index) => {
       acc[builder.address] = {
         ...builder,
-        ...backerRewards[index],
+        backerRewardPercentage: {
+          active: backerRewards[index]?.active ?? BigInt(0),
+          previous: backerRewards[index]?.previous ?? BigInt(0),
+          next: backerRewards[index]?.next ?? BigInt(0),
+          cooldown: backerRewards[index]?.cooldown ?? BigInt(0),
+        },
       }
       return acc
     }, {} as Builders)

--- a/src/app/collective-rewards/allocations/hooks/useBackerTotalAllocation.ts
+++ b/src/app/collective-rewards/allocations/hooks/useBackerTotalAllocation.ts
@@ -3,18 +3,20 @@ import { GaugeAbi } from '@/lib/abis/v2/GaugeAbi'
 import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BackersManagerAddress } from '@/lib/contracts'
 import { useMemo } from 'react'
-import { Address } from 'viem'
+import { Address, zeroAddress } from 'viem'
 import { useReadContract, useReadContracts } from 'wagmi'
+import { Builder } from '../../types'
 
-export const useBackerTotalAllocation = (backer: Address) => {
+export const useBackerTotalAllocation = (backer?: Address) => {
   const { data, isLoading, error } = useReadContract({
     abi: BackersManagerAbi,
     address: BackersManagerAddress,
     functionName: 'backerTotalAllocation',
-    args: [backer],
+    args: [backer ?? zeroAddress],
     query: {
       refetchInterval: AVERAGE_BLOCKTIME,
       initialData: 0n,
+      enabled: !!backer,
     },
   })
 
@@ -25,20 +27,21 @@ export const useBackerTotalAllocation = (backer: Address) => {
   }
 }
 
-export const useGetAllAllocationOf = (backer: Address, gaugeAddresses: Address[]) => {
+export const useGetAllAllocationOf = (builder: Builder[], backer?: Address) => {
   const {
     data: gauges,
     isLoading,
     error,
   } = useReadContracts({
-    contracts: gaugeAddresses.map(gaugeAddress => ({
+    contracts: builder.map(({ gauge }) => ({
       abi: GaugeAbi,
-      address: gaugeAddress,
+      address: gauge,
       functionName: 'allocationOf',
       args: [backer],
     })),
     query: {
       refetchInterval: AVERAGE_BLOCKTIME,
+      enabled: !!backer,
     },
   })
 

--- a/src/app/collective-rewards/rewards/builders/hooks/useGetBuildersRewards.ts
+++ b/src/app/collective-rewards/rewards/builders/hooks/useGetBuildersRewards.ts
@@ -32,6 +32,7 @@ const isBuilderShown = (
   return (kycApproved && !revoked) || (allocation && allocation > 0n)
 }
 
+// FIXME: remove and use Builder and/or combination of existing types
 export type BuildersRewards = {
   address: Address
   builderName: string

--- a/src/app/collective-rewards/types.ts
+++ b/src/app/collective-rewards/types.ts
@@ -9,7 +9,7 @@ export type Builder = {
   address: Address
   builderName: string
   // TODO: do we want to keep it here?
-  backerRewardPercentage?: BackerRewardPercentage
+  backerRewardPercentage?: BackerRewardsConfig
 }
 
 type BuilderFunctionOutputs = Extract<
@@ -30,10 +30,11 @@ export type BuilderProposal = {
   date: string
 }
 
-export type BackerRewardPercentage = {
+export type BackerRewardsConfig = {
   previous: bigint
   next: bigint
   cooldown: bigint
+  active: bigint
 }
 
 export type ProposalByBuilder = Record<Address, BuilderProposal>


### PR DESCRIPTION
Resolves https://rsklabs.atlassian.net/browse/TOK-502?focusedCommentId=86848
by fetching both backer rewards and the currently active rewards percentage
it also simplifies the context and its hook dependencies by not combining everything with builders