### PR TITLE
chore(cr_cd): add build cd check

### DIFF
--- a/.github/workflows/cr.build.yaml
+++ b/.github/workflows/cr.build.yaml
@@ -1,0 +1,16 @@
+name: Build dApp
+
+on: pull_request
+
+jobs:
+  build_test:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build
+        run: |
+          npm run build


### PR DESCRIPTION
adds build cd check to avoid later surprises and the necessity to run it locally, as that messes with .next 