### PR TITLE
TOK-540: update gh checkout action

### DIFF
--- a/.github/workflows/cr.qa.deploy.yaml
+++ b/.github/workflows/cr.qa.deploy.yaml
@@ -32,8 +32,11 @@ jobs:
       contents: read
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - name: Checkout with Node.js 18.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## What

- update Github checkout action to v4

## Why

- v2 is outdated