### PR TITLE
TOK-536: update text and tooltips

### DIFF
--- a/src/app/collective-rewards/allocations/components/Header.tsx
+++ b/src/app/collective-rewards/allocations/components/Header.tsx
@@ -1,5 +1,5 @@
 import { HeaderTitle, Paragraph } from '@/components/Typography'
-import { CRWhitepaperLink } from '../../shared'
+import { CRWhitepaperLink } from '@/app/collective-rewards/shared'
 
 export const Header = () => {
   return (

--- a/src/app/collective-rewards/allocations/components/Header.tsx
+++ b/src/app/collective-rewards/allocations/components/Header.tsx
@@ -1,12 +1,14 @@
 import { HeaderTitle, Paragraph } from '@/components/Typography'
+import { CRWhitepaperLink } from '../../shared'
 
 export const Header = () => {
   return (
     <>
       <HeaderTitle>Confirm strif allocation for the selected builders</HeaderTitle>
       <Paragraph className="font-normal leading-6 text-[rgba(255,255,255,0.6)]">
-        Back builders who drive innovations. Review the selection and support the Builders you align with.
-        Your allocations influence the rewards the Builders will receive.
+        Support innovative Builders by allocating your stRIF to those you align with. Your allocations shape
+        their rewards, and you retain full ownership and access to your stRIF while earning a portion of their
+        rewards. For more information check the <CRWhitepaperLink />.
       </Paragraph>
     </>
   )

--- a/src/app/collective-rewards/leaderboard/BuilderLeaderBoard.tsx
+++ b/src/app/collective-rewards/leaderboard/BuilderLeaderBoard.tsx
@@ -1,10 +1,11 @@
 import { CycleContextProvider } from '@/app/collective-rewards/metrics'
 import { Button } from '@/components/Button'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/Collapsible'
-import { HeaderTitle } from '@/components/Typography'
+import { HeaderTitle, Paragraph } from '@/components/Typography'
 import { BuildersLeaderBoardContent } from '@/app/collective-rewards/leaderboard'
 import { useRouter } from 'next/navigation'
 import { useCanManageAllocations } from '@/app/collective-rewards/allocations/hooks'
+import { CRWhitepaperLink } from '../shared'
 
 export const BuildersLeaderBoard = () => {
   const router = useRouter()
@@ -17,9 +18,16 @@ export const BuildersLeaderBoard = () => {
   return (
     <>
       <Collapsible defaultOpen>
-        <CollapsibleTrigger>
+        <CollapsibleTrigger className="self-start pt-1">
           <div className="flex items-center justify-between w-full">
-            <HeaderTitle className="">Rewards leaderboard</HeaderTitle>
+            <div className="flex flex-col justify-center items-start gap-2 flex-1">
+              <HeaderTitle className="">Rewards leaderboard</HeaderTitle>
+              <Paragraph className="text-[14px] text-white font-rootstock-sans">
+                Select one or more Builders you want to back. You retain full ownership and access to your
+                stRIF while earning a portion of their rewards. For more information check the{' '}
+                <CRWhitepaperLink />.
+              </Paragraph>
+            </div>
             <Button variant="primary" onClick={onManageAllocations} disabled={!canManageAllocations}>
               Manage Allocations
             </Button>

--- a/src/app/collective-rewards/leaderboard/BuildersLeaderBoardTable.tsx
+++ b/src/app/collective-rewards/leaderboard/BuildersLeaderBoardTable.tsx
@@ -37,7 +37,15 @@ const tableHeaders: TableHeader[] = [
     className: 'w-[22%]',
     sortKey: RewardsColumnKeyEnum.estimatedRewards,
     tooltip: {
-      text: 'The estimated Backers’ share of the Builder’s rewards which will become claimable in the next Cycle. The displayed information is dynamic and may vary based on total rewards and user activity. This data is for informational purposes only.',
+      text: (
+        <p>
+          The estimated Backers’ share of the Builder’s rewards which will become claimable in the next Cycle.
+          <br />
+          <br />
+          The displayed information is dynamic and may vary based on total rewards and user activity. This
+          data is for informational purposes only.
+        </p>
+      ),
       popoverProps: { size: 'medium' },
     },
   },

--- a/src/app/collective-rewards/leaderboard/BuildersLeaderBoardTable.tsx
+++ b/src/app/collective-rewards/leaderboard/BuildersLeaderBoardTable.tsx
@@ -38,13 +38,13 @@ const tableHeaders: TableHeader[] = [
     sortKey: RewardsColumnKeyEnum.estimatedRewards,
     tooltip: {
       text: (
-        <p>
+        <>
           The estimated Backers’ share of the Builder’s rewards which will become claimable in the next Cycle.
           <br />
           <br />
           The displayed information is dynamic and may vary based on total rewards and user activity. This
           data is for informational purposes only.
-        </p>
+        </>
       ),
       popoverProps: { size: 'medium' },
     },

--- a/src/app/collective-rewards/leaderboard/BuildersLeaderBoardTable.tsx
+++ b/src/app/collective-rewards/leaderboard/BuildersLeaderBoardTable.tsx
@@ -26,12 +26,25 @@ enum RewardsColumnKeyEnum {
 const tableHeaders: TableHeader[] = [
   { label: 'Builder', className: 'w-[14%]', sortKey: RewardsColumnKeyEnum.builder },
   { label: 'Backer Rewards %', className: 'w-[10%]', sortKey: RewardsColumnKeyEnum.rewardPercentage },
-  { label: 'Last Cycle Rewards', className: 'w-[22%]', sortKey: RewardsColumnKeyEnum.lastCycleRewards },
-  { label: 'Est. Backers Rewards', className: 'w-[22%]', sortKey: RewardsColumnKeyEnum.estimatedRewards },
+  {
+    label: 'Last Cycle Rewards',
+    className: 'w-[22%]',
+    sortKey: RewardsColumnKeyEnum.lastCycleRewards,
+    tooltip: { text: 'The Backers’ share of the Builder’s rewards in the previous Cycle' },
+  },
+  {
+    label: 'Est. Backers Rewards',
+    className: 'w-[22%]',
+    sortKey: RewardsColumnKeyEnum.estimatedRewards,
+    tooltip: {
+      text: 'The estimated Backers’ share of the Builder’s rewards which will become claimable in the next Cycle. The displayed information is dynamic and may vary based on total rewards and user activity. This data is for informational purposes only.',
+      popoverProps: { size: 'medium' },
+    },
+  },
   {
     label: 'Total Allocations',
     className: 'w-[16%]',
-    tooltip: 'The Builder’s share of the total stRIF allocations',
+    tooltip: { text: 'The Builder’s share of the total stRIF allocations' },
     sortKey: RewardsColumnKeyEnum.totalAllocationPercentage,
   },
   // TODO: text-center isn't applied

--- a/src/app/collective-rewards/metrics/TotalAllocationsMetrics.tsx
+++ b/src/app/collective-rewards/metrics/TotalAllocationsMetrics.tsx
@@ -40,7 +40,7 @@ export const TotalAllocationsMetrics: FC<TotalAllocationsProps> = ({
         title="Total allocations"
         data-testid="TotalAllocations"
         tooltip={{
-          text: 'Total stRIF allocation from Backers to Builders',
+          text: 'Total stRIF allocation from Backers to Builders. Backers retain full ownership and access to their stRIF.',
         }}
       />
       {withSpinner(

--- a/src/app/collective-rewards/metrics/TotalAllocationsMetrics.tsx
+++ b/src/app/collective-rewards/metrics/TotalAllocationsMetrics.tsx
@@ -41,6 +41,7 @@ export const TotalAllocationsMetrics: FC<TotalAllocationsProps> = ({
         data-testid="TotalAllocations"
         tooltip={{
           text: 'Total stRIF allocation from Backers to Builders. Backers retain full ownership and access to their stRIF.',
+          popoverProps: { size: 'medium' },
         }}
       />
       {withSpinner(

--- a/src/app/collective-rewards/rewards/MyRewards.tsx
+++ b/src/app/collective-rewards/rewards/MyRewards.tsx
@@ -12,10 +12,9 @@ import { tokenContracts } from '@/lib/contracts'
 import { FC } from 'react'
 import { Address, getAddress, zeroAddress } from 'viem'
 import { useRouter } from 'next/navigation'
-import { Link } from '@/components/Link'
 import { Builder } from '../types'
 import { useCanManageAllocations } from '@/app/collective-rewards/allocations/hooks'
-import { CRWhitepaperLink } from '../shared'
+import { CRWhitepaperLink } from '@/app/collective-rewards/shared'
 
 const SubText = () => {
   return (

--- a/src/app/collective-rewards/rewards/MyRewards.tsx
+++ b/src/app/collective-rewards/rewards/MyRewards.tsx
@@ -15,22 +15,13 @@ import { useRouter } from 'next/navigation'
 import { Link } from '@/components/Link'
 import { Builder } from '../types'
 import { useCanManageAllocations } from '@/app/collective-rewards/allocations/hooks'
+import { CRWhitepaperLink } from '../shared'
 
 const SubText = () => {
   return (
     <>
       Track and claim the rewards you earn from Collective Rewards. For more information check the{' '}
-      <Link
-        className="text-[#E56B1A]"
-        href={
-          'https://file.notion.so/f/f/5c274ed5-ccaa-43f3-9086-7ff7fed02299/2d5ab5ff-a08b-428f-b8ef-1fb642dcaf42/20241128_RootstockCollective_Rewards_Whitepaper_V1_0.pdf?table=block&id=14c1ca6b-0b02-8093-beba-c642396e4e09&spaceId=5c274ed5-ccaa-43f3-9086-7ff7fed02299&expirationTimestamp=1733918400000&signature=0fXpO_3zOse-KRipYdYjHuOFRMqBcbKy5gHR2T5yyZQ&downloadName=20241128_RootstockCollective_Rewards_Whitepaper_V1_0.pdf'
-        }
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Whitepaper
-      </Link>{' '}
-      .
+      <CRWhitepaperLink />.
     </>
   )
 }

--- a/src/app/collective-rewards/rewards/backers/BackerRewardsTable.tsx
+++ b/src/app/collective-rewards/rewards/backers/BackerRewardsTable.tsx
@@ -33,14 +33,29 @@ enum RewardsColumnKeyEnum {
 const tableHeaders: TableHeader[] = [
   { label: 'Builder', className: 'w-[11%]', sortKey: RewardsColumnKeyEnum.builder },
   { label: 'Backer Rewards %', className: 'w-[11%]', sortKey: RewardsColumnKeyEnum.rewardPercentage },
-  { label: 'Estimated Rewards', className: 'w-[20%]', sortKey: RewardsColumnKeyEnum.estimatedRewards },
+  {
+    label: 'Estimated Rewards',
+    className: 'w-[20%]',
+    sortKey: RewardsColumnKeyEnum.estimatedRewards,
+    tooltip: {
+      text: `An estimate of this Cycle’s rewards from each Builder that will become fully claimable by the end of the current Cycle. These rewards gradually become claimable and are added to your ‘Claimable Rewards’ as the cycle progresses. To check the cycle completion, go to Collective Rewards → Current Cycle. 
+
+        The displayed information is dynamic and may vary based on total rewards and user activity. This data is for informational purposes only.`,
+      popoverProps: { size: 'medium' },
+    },
+  },
   {
     label: 'Total Allocations',
     className: 'w-[18%]',
     sortKey: RewardsColumnKeyEnum.totalAllocationPercentage,
     tooltip: { text: 'Your share of the total allocations for each Builder' },
   },
-  { label: 'Claimable Rewards', className: 'w-[20%]', sortKey: RewardsColumnKeyEnum.claimableRewards },
+  {
+    label: 'Claimable Rewards',
+    className: 'w-[20%]',
+    sortKey: RewardsColumnKeyEnum.claimableRewards,
+    tooltip: { text: 'Your rewards from each Builder available to claim' },
+  },
   { label: 'All Time Rewards', className: 'w-[20%]', sortKey: RewardsColumnKeyEnum.allTimeRewards },
 ]
 

--- a/src/app/collective-rewards/rewards/backers/BackerRewardsTable.tsx
+++ b/src/app/collective-rewards/rewards/backers/BackerRewardsTable.tsx
@@ -39,7 +39,7 @@ const tableHeaders: TableHeader[] = [
     sortKey: RewardsColumnKeyEnum.estimatedRewards,
     tooltip: {
       text: (
-        <p>
+        <>
           An estimate of this Cycle’s rewards from each Builder that will become fully claimable by the end of
           the current Cycle. These rewards gradually become claimable and are added to your ‘Claimable
           Rewards’ as the cycle progresses. To check the cycle completion, go to Collective Rewards → Current
@@ -48,7 +48,7 @@ const tableHeaders: TableHeader[] = [
           <br />
           The displayed information is dynamic and may vary based on total rewards and user activity. This
           data is for informational purposes only.
-        </p>
+        </>
       ),
       popoverProps: { size: 'medium' },
     },

--- a/src/app/collective-rewards/rewards/backers/BackerRewardsTable.tsx
+++ b/src/app/collective-rewards/rewards/backers/BackerRewardsTable.tsx
@@ -38,7 +38,7 @@ const tableHeaders: TableHeader[] = [
     label: 'Total Allocations',
     className: 'w-[18%]',
     sortKey: RewardsColumnKeyEnum.totalAllocationPercentage,
-    tooltip: 'Your share of the total allocations for each Builder',
+    tooltip: { text: 'Your share of the total allocations for each Builder' },
   },
   { label: 'Claimable Rewards', className: 'w-[20%]', sortKey: RewardsColumnKeyEnum.claimableRewards },
   { label: 'All Time Rewards', className: 'w-[20%]', sortKey: RewardsColumnKeyEnum.allTimeRewards },

--- a/src/app/collective-rewards/rewards/backers/BackerRewardsTable.tsx
+++ b/src/app/collective-rewards/rewards/backers/BackerRewardsTable.tsx
@@ -38,9 +38,18 @@ const tableHeaders: TableHeader[] = [
     className: 'w-[20%]',
     sortKey: RewardsColumnKeyEnum.estimatedRewards,
     tooltip: {
-      text: `An estimate of this Cycle’s rewards from each Builder that will become fully claimable by the end of the current Cycle. These rewards gradually become claimable and are added to your ‘Claimable Rewards’ as the cycle progresses. To check the cycle completion, go to Collective Rewards → Current Cycle. 
-
-        The displayed information is dynamic and may vary based on total rewards and user activity. This data is for informational purposes only.`,
+      text: (
+        <p>
+          An estimate of this Cycle’s rewards from each Builder that will become fully claimable by the end of
+          the current Cycle. These rewards gradually become claimable and are added to your ‘Claimable
+          Rewards’ as the cycle progresses. To check the cycle completion, go to Collective Rewards → Current
+          Cycle.
+          <br />
+          <br />
+          The displayed information is dynamic and may vary based on total rewards and user activity. This
+          data is for informational purposes only.
+        </p>
+      ),
       popoverProps: { size: 'medium' },
     },
   },

--- a/src/app/collective-rewards/rewards/backers/ClaimableRewards.tsx
+++ b/src/app/collective-rewards/rewards/backers/ClaimableRewards.tsx
@@ -57,7 +57,11 @@ type ClaimableRewardsProps = Omit<RewardDetails, 'gauge'>
 export const ClaimableRewards: FC<ClaimableRewardsProps> = ({ tokens: { rif, rbtc }, ...rest }) => {
   return (
     <MetricsCard borderless>
-      <MetricsCardTitle title="Claimable rewards" data-testid="ClaimableRewards" />
+      <MetricsCardTitle
+        title="Claimable rewards"
+        data-testid="ClaimableRewards"
+        tooltip={{ text: 'Your rewards available to claim' }}
+      />
       <TokenRewardsMetrics {...rest} token={rif} />
       <TokenRewardsMetrics {...rest} token={rbtc} />
     </MetricsCard>

--- a/src/app/collective-rewards/rewards/backers/Rewards.tsx
+++ b/src/app/collective-rewards/rewards/backers/Rewards.tsx
@@ -39,7 +39,7 @@ const RewardsContent: FC<RewardsProps> = ({ builder, gauges, tokens }) => {
           rewards={['estimated']}
           tooltip={{
             text: (
-              <p>
+              <>
                 An estimate of this Cycle’s rewards that will become fully claimable by the end of the current
                 Cycle. These rewards gradually become claimable and are added to your ‘Claimable Rewards’ as
                 the cycle progresses. To check the cycle completion, go to Collective Rewards → Current Cycle.
@@ -47,7 +47,7 @@ const RewardsContent: FC<RewardsProps> = ({ builder, gauges, tokens }) => {
                 <br />
                 The displayed information is dynamic and may vary based on total rewards and user activity.
                 This data is for informational purposes only.
-              </p>
+              </>
             ),
             popoverProps: { size: 'medium' },
           }}

--- a/src/app/collective-rewards/rewards/backers/Rewards.tsx
+++ b/src/app/collective-rewards/rewards/backers/Rewards.tsx
@@ -38,8 +38,17 @@ const RewardsContent: FC<RewardsProps> = ({ builder, gauges, tokens }) => {
           tokens={tokens}
           rewards={['estimated']}
           tooltip={{
-            text: `An estimate of this Cycle’s rewards that will become fully claimable by the end of the current Cycle. These rewards gradually become claimable and are added to your ‘Claimable Rewards’ as the cycle progresses. To check the cycle completion, go to Collective Rewards → Current Cycle.
-                  The displayed information is dynamic and may vary based on total rewards and user activity. This data is for informational purposes only.`,
+            text: (
+              <p>
+                An estimate of this Cycle’s rewards that will become fully claimable by the end of the current
+                Cycle. These rewards gradually become claimable and are added to your ‘Claimable Rewards’ as
+                the cycle progresses. To check the cycle completion, go to Collective Rewards → Current Cycle.
+                <br />
+                <br />
+                The displayed information is dynamic and may vary based on total rewards and user activity.
+                This data is for informational purposes only.
+              </p>
+            ),
             popoverProps: { size: 'medium' },
           }}
         />

--- a/src/app/collective-rewards/rewards/backers/Rewards.tsx
+++ b/src/app/collective-rewards/rewards/backers/Rewards.tsx
@@ -38,7 +38,8 @@ const RewardsContent: FC<RewardsProps> = ({ builder, gauges, tokens }) => {
           tokens={tokens}
           rewards={['estimated']}
           tooltip={{
-            text: 'The information displayed is dynamic and may vary based on total rewards available and user activity. This data is provided for informational purposes only. Please note that the final reward amount will be determined at the end of the cycle.',
+            text: `An estimate of this Cycle’s rewards that will become fully claimable by the end of the current Cycle. These rewards gradually become claimable and are added to your ‘Claimable Rewards’ as the cycle progresses. To check the cycle completion, go to Collective Rewards → Current Cycle.
+                  The displayed information is dynamic and may vary based on total rewards and user activity. This data is for informational purposes only.`,
             popoverProps: { size: 'medium' },
           }}
         />

--- a/src/app/collective-rewards/rewards/builders/ClaimableRewards.tsx
+++ b/src/app/collective-rewards/rewards/builders/ClaimableRewards.tsx
@@ -72,7 +72,11 @@ type ClaimableRewardsProps = BuilderRewardDetails
 export const ClaimableRewards: FC<ClaimableRewardsProps> = ({ tokens: { rif, rbtc }, ...rest }) => {
   return (
     <MetricsCard borderless>
-      <MetricsCardTitle title="Claimable rewards" data-testid="ClaimableRewards" />
+      <MetricsCardTitle
+        title="Claimable rewards"
+        data-testid="ClaimableRewards"
+        tooltip={{ text: 'Your rewards available to claim' }}
+      />
       <TokenRewardsMetrics {...rest} token={rif} />
       <TokenRewardsMetrics {...rest} token={rbtc} />
     </MetricsCard>

--- a/src/app/collective-rewards/rewards/builders/EstimatedRewards.tsx
+++ b/src/app/collective-rewards/rewards/builders/EstimatedRewards.tsx
@@ -104,8 +104,15 @@ export const EstimatedRewards: FC<EstimatedRewardsProps> = ({ tokens: { rif, rbt
         title="Estimated rewards"
         data-testid="EstimatedRewards"
         tooltip={{
-          text: `Your estimated rewards which will become claimable at the start of the next Cycle. 
-          The displayed information is dynamic and may vary based on total rewards and user activity. This data is for informational purposes only.`,
+          text: (
+            <p>
+              Your estimated rewards which will become claimable at the start of the next Cycle.
+              <br />
+              <br />
+              The displayed information is dynamic and may vary based on total rewards and user activity. This
+              data is for informational purposes only.
+            </p>
+          ),
           popoverProps: { size: 'medium' },
         }}
       />

--- a/src/app/collective-rewards/rewards/builders/EstimatedRewards.tsx
+++ b/src/app/collective-rewards/rewards/builders/EstimatedRewards.tsx
@@ -104,7 +104,8 @@ export const EstimatedRewards: FC<EstimatedRewardsProps> = ({ tokens: { rif, rbt
         title="Estimated rewards"
         data-testid="EstimatedRewards"
         tooltip={{
-          text: 'The information displayed is dynamic and may vary based on total rewards available and user activity. This data is provided for informational purposes only. Please note that the final reward amount will be determined at the end of the cycle.',
+          text: `Your estimated rewards which will become claimable at the start of the next Cycle. 
+          The displayed information is dynamic and may vary based on total rewards and user activity. This data is for informational purposes only.`,
           popoverProps: { size: 'medium' },
         }}
       />

--- a/src/app/collective-rewards/rewards/builders/EstimatedRewards.tsx
+++ b/src/app/collective-rewards/rewards/builders/EstimatedRewards.tsx
@@ -105,13 +105,13 @@ export const EstimatedRewards: FC<EstimatedRewardsProps> = ({ tokens: { rif, rbt
         data-testid="EstimatedRewards"
         tooltip={{
           text: (
-            <p>
+            <>
               Your estimated rewards which will become claimable at the start of the next Cycle.
               <br />
               <br />
               The displayed information is dynamic and may vary based on total rewards and user activity. This
               data is for informational purposes only.
-            </p>
+            </>
           ),
           popoverProps: { size: 'medium' },
         }}

--- a/src/app/collective-rewards/rewards/components/Tooltip.tsx
+++ b/src/app/collective-rewards/rewards/components/Tooltip.tsx
@@ -1,6 +1,6 @@
-import { FC } from 'react'
-import { Popover, PopoverProps } from '../../../../components/Popover'
-import { Button, ButtonProps } from '../../../../components/Button'
+import { FC, ReactNode } from 'react'
+import { Popover, PopoverProps } from '@/components/Popover'
+import { Button } from '@/components/Button'
 
 const TooltipSvg = () => (
   <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -22,7 +22,7 @@ const TooltipSvg = () => (
 )
 
 export type TooltipProps = {
-  text: string
+  text: ReactNode
   popoverProps?: Pick<PopoverProps, 'size' | 'position'>
 }
 
@@ -30,7 +30,7 @@ export const Tooltip: FC<TooltipProps> = ({ text, popoverProps }) => (
   <>
     <Popover
       content={
-        <div className="text-[12px] font-bold mb-1">
+        <div className="text-[12px] mb-1 font-rootstock-sans">
           <p data-testid="tooltip">{text}</p>
         </div>
       }

--- a/src/app/collective-rewards/shared/components/CRWhitepaperLink.tsx
+++ b/src/app/collective-rewards/shared/components/CRWhitepaperLink.tsx
@@ -1,0 +1,15 @@
+import { Link } from '@/components/Link'
+import { FC } from 'react'
+
+export const CRWhitepaperLink: FC = () => (
+  <Link
+    className="text-[#E56B1A]"
+    href={
+      'https://file.notion.so/f/f/5c274ed5-ccaa-43f3-9086-7ff7fed02299/2d5ab5ff-a08b-428f-b8ef-1fb642dcaf42/20241128_RootstockCollective_Rewards_Whitepaper_V1_0.pdf?table=block&id=14c1ca6b-0b02-8093-beba-c642396e4e09&spaceId=5c274ed5-ccaa-43f3-9086-7ff7fed02299&expirationTimestamp=1733918400000&signature=0fXpO_3zOse-KRipYdYjHuOFRMqBcbKy5gHR2T5yyZQ&downloadName=20241128_RootstockCollective_Rewards_Whitepaper_V1_0.pdf'
+    }
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    Whitepaper
+  </Link>
+)

--- a/src/app/collective-rewards/shared/components/Table/TableHeaders.tsx
+++ b/src/app/collective-rewards/shared/components/Table/TableHeaders.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils'
 import { Popover } from '@/components/Popover'
 import { FaRegQuestionCircle } from 'react-icons/fa'
 import { RiArrowUpSFill, RiArrowDownSFill } from 'react-icons/ri'
+import { TooltipProps } from '@/app/collective-rewards/rewards'
 
 export type ISortConfig = {
   key: string
@@ -13,7 +14,7 @@ export type ISortConfig = {
 export type TableHeader = {
   label: string
   className: string
-  tooltip?: string
+  tooltip?: TooltipProps
   sortKey?: string
 }
 
@@ -38,7 +39,13 @@ export const TableHeaderCell: FC<TableHeaderProps> = ({
     >
       <div className="flex flex-row">
         {tooltip && (
-          <Popover content={tooltip} className="font-normal text-sm" size="small" trigger="hover">
+          <Popover
+            content={tooltip.text}
+            className="font-normal text-sm"
+            size="small"
+            trigger="hover"
+            {...tooltip.popoverProps}
+          >
             <FaRegQuestionCircle className="mr-1 self-center" />
           </Popover>
         )}

--- a/src/app/collective-rewards/shared/components/index.ts
+++ b/src/app/collective-rewards/shared/components/index.ts
@@ -1,2 +1,3 @@
 export * from './Table'
 export * from './Search'
+export * from './CRWhitepaperLink'


### PR DESCRIPTION
## What

- [x] Update the Tooltip on 'Total Allocations'
- [x] Update the text under Leaderboard.
- [x] Update the text on ‘Manage Allocations’ screen
- [x] Add a Tooltip to Last Cycle Rewards
- [x] Add a Tooltip to Est. Backers Rewards
- [x] Add a Tooltip to Claimable Rewards (Builder)
- [x] Add a Tooltip to Estimated Rewards (Builder)
- [x] Add a Tooltip to Claimable Rewards (Backer)
- [x] Add a Tooltip to Estimated Rewards (Backer)
- [x] Add a Tooltip to Claimable Rewards (table)
- [x] Add a Tooltip to Estimated Rewards (table)