### PR TITLE
fix: events loading and last cycle backer rewards

### DIFF
--- a/src/app/collective-rewards/rewards/backers/hooks/useGetGaugesBackerRewardsClaimed.ts
+++ b/src/app/collective-rewards/rewards/backers/hooks/useGetGaugesBackerRewardsClaimed.ts
@@ -15,6 +15,10 @@ export const useGetGaugesBackerRewardsClaimed = (
   const { data: eventsData, isLoading, error } = useGetGaugesEvents(gauges, 'BackerRewardsClaimed')
 
   const data = useMemo(() => {
+    if (!eventsData) {
+      return {}
+    }
+
     return Object.keys(eventsData).reduce((acc: { [key: string]: (typeof eventsData)[Address] }, key) => {
       let events = eventsData[key as Address]
       if (backer) {

--- a/src/app/collective-rewards/rewards/builders/hooks/useGetBuildersRewards.ts
+++ b/src/app/collective-rewards/rewards/builders/hooks/useGetBuildersRewards.ts
@@ -105,8 +105,8 @@ export const useGetBuildersRewards = ({ rif, rbtc }: { [token: string]: Token },
     lastCycleAfterDistribution.toSeconds(),
     endDistributionWindow.toSeconds(),
   )
-  const rifBuildersRewardsAmount = getNotifyRewardAmount(notifyRewardEventLastCycle, rif, 'builderAmount_')
-  const rbtcBuildersRewardsAmount = getNotifyRewardAmount(notifyRewardEventLastCycle, rbtc, 'builderAmount_')
+  const rifBuildersRewardsAmount = getNotifyRewardAmount(notifyRewardEventLastCycle, rif, 'backersAmount_')
+  const rbtcBuildersRewardsAmount = getNotifyRewardAmount(notifyRewardEventLastCycle, rbtc, 'backersAmount_')
 
   // get the backer reward percentage for each builder we want to show
   const buildersAddress = builders.map(({ address }) => address)

--- a/src/app/collective-rewards/rewards/hooks/useGetGaugesEvents.ts
+++ b/src/app/collective-rewards/rewards/hooks/useGetGaugesEvents.ts
@@ -36,9 +36,8 @@ export const useGetGaugesEvents = <T extends EventName>(gauges: Address[], event
         return acc
       }, {})
     },
-    queryKey: ['useGetGaugesEvents', eventName],
+    queryKey: ['useGetGaugesEvents', eventName, gauges],
     refetchInterval: AVERAGE_BLOCKTIME,
-    initialData: {},
   })
 
   return {

--- a/src/app/collective-rewards/rewards/hooks/useGetGaugesNotifyReward.ts
+++ b/src/app/collective-rewards/rewards/hooks/useGetGaugesNotifyReward.ts
@@ -11,6 +11,10 @@ export const useGetGaugesNotifyReward = (
   const { data: eventsData, isLoading, error } = useGetGaugesEvents(gauges, 'NotifyReward')
 
   const data = useMemo(() => {
+    if (!eventsData) {
+      return {}
+    }
+
     return Object.keys(eventsData).reduce((acc: { [key: string]: (typeof eventsData)[Address] }, key) => {
       let events = eventsData[key as Address]
       if (rewardToken) {


### PR DESCRIPTION
## What

- Fix the loading state when getting events from all the gauges
- Fix the last cycle rewards from the leaderboard since it needs to show the backers rewards