### PR TITLE
DAO-807: Hide claim button for OG Founders

### DIFF
--- a/src/app/communities/communityUtils.tsx
+++ b/src/app/communities/communityUtils.tsx
@@ -61,7 +61,7 @@ export const ogFounders: CommunityItem = {
   nftAddress: nftContracts.OG_FOUNDERS,
   numberOfMembers: 0,
   cover: '/images/nfts/founders-cover.png',
-  isMintable: true,
+  isMintable: false,
   longDescription: (
     <>
       <p className="mt-4">


### PR DESCRIPTION
We're hiding the claim button for OG Founders for all environments as in mainnet we no longer have NFTs available to be minted. Although the correct implementation would be comparing when the user staked stRIF to the requirement date. Let's keep simple for now.