### PR TITLE
refactor: get rid of necessity to use wallet 

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,6 @@
 'use client'
-import { useAccount } from 'wagmi'
-import { Login } from './login'
 import User from './user/page'
 
 export default function Home() {
-  const { isConnected } = useAccount()
-  if (isConnected) {
-    return <User />
-  }
-  return <Login />
+  return <User />
 }

--- a/src/app/proposals/HeaderSection.tsx
+++ b/src/app/proposals/HeaderSection.tsx
@@ -3,23 +3,17 @@ import { Button } from '@/components/Button'
 import { Popover } from '@/components/Popover'
 import { useModal } from '@/app/user/Balances/hooks/useModal'
 import { ProposalSelectionModal } from '@/components/Modal/ProposalSelectionModal'
-import { formatUnits } from 'viem'
 
 interface Props {
-  createProposalDisabled: boolean
-  threshold: bigint
+  createProposalDisabledError: string | null
   isConnected: boolean
 }
 
-export const HeaderSection = ({
-  createProposalDisabled = true,
-  threshold = BigInt(0),
-  isConnected,
-}: Props) => (
+export const HeaderSection = ({ createProposalDisabledError, isConnected }: Props) => (
   <div className="flex flex-row justify-between container">
     <HeaderTitle>My Governance</HeaderTitle>
     <div className="flex flex-row gap-x-6">
-      {createProposalDisabled ? (
+      {createProposalDisabledError ? (
         <Popover
           content={
             !isConnected ? (
@@ -28,8 +22,7 @@ export const HeaderSection = ({
               </Paragraph>
             ) : (
               <Paragraph variant="normal" className="text-sm">
-                You need at least {formatUnits(threshold, 18)} Voting Power to create a proposal. The easiest
-                way to get more Voting Power is to Stake more RIF.
+                {createProposalDisabledError}
               </Paragraph>
             )
           }

--- a/src/app/proposals/HeaderSection.tsx
+++ b/src/app/proposals/HeaderSection.tsx
@@ -3,18 +3,35 @@ import { Button } from '@/components/Button'
 import { Popover } from '@/components/Popover'
 import { useModal } from '@/app/user/Balances/hooks/useModal'
 import { ProposalSelectionModal } from '@/components/Modal/ProposalSelectionModal'
+import { formatUnits } from 'viem'
 
-export const HeaderSection = ({ createProposalDisabled = true, threshold = '' }) => (
+interface Props {
+  createProposalDisabled: boolean
+  threshold: bigint
+  isConnected: boolean
+}
+
+export const HeaderSection = ({
+  createProposalDisabled = true,
+  threshold = BigInt(0),
+  isConnected,
+}: Props) => (
   <div className="flex flex-row justify-between container">
     <HeaderTitle>My Governance</HeaderTitle>
     <div className="flex flex-row gap-x-6">
       {createProposalDisabled ? (
         <Popover
           content={
-            <Paragraph variant="normal" className="text-sm">
-              You need at least {threshold} Voting Power to create a proposal. The easiest way to get more
-              Voting Power is to Stake more RIF.
-            </Paragraph>
+            !isConnected ? (
+              <Paragraph variant="normal" className="text-sm">
+                You need to connect your wallet to be able to Create a Proposal.
+              </Paragraph>
+            ) : (
+              <Paragraph variant="normal" className="text-sm">
+                You need at least {formatUnits(threshold, 18)} Voting Power to create a proposal. The easiest
+                way to get more Voting Power is to Stake more RIF.
+              </Paragraph>
+            )
           }
           trigger="hover"
           background="dark"

--- a/src/app/proposals/create/RemoveBuilderProposalForm.tsx
+++ b/src/app/proposals/create/RemoveBuilderProposalForm.tsx
@@ -25,6 +25,7 @@ import { Button } from '@/components/Button'
 import { isAddressRegex } from '@/app/proposals/shared/utils'
 import { isBaseError, isUserRejectedTxError } from '@/components/ErrorPage/commonErrors'
 import { useBuilderContext } from '../../collective-rewards/user'
+import { useCanCreateProposal } from '../hooks/useCanCreateProposal'
 
 const FormSchema = z.object({
   proposalName: z
@@ -44,7 +45,7 @@ export const RemoveBuilderProposalForm: FC = () => {
   const router = useRouter()
   const params = useSearchParams()
   const proposalId = params?.get('proposalId') ?? ''
-  const { isLoading: isVotingPowerLoading, canCreateProposal } = useVotingPower()
+  const { isLoading: isVotingPowerLoading, canCreateProposal } = useCanCreateProposal()
   const { setMessage } = useAlertContext()
   const { onRemoveBuilderProposal, isPublishing } = useRemoveBuilderProposal()
   const { getBuilderByAddress } = useBuilderContext()

--- a/src/app/proposals/create/TreasuryWithdrawProposalForm.tsx
+++ b/src/app/proposals/create/TreasuryWithdrawProposalForm.tsx
@@ -36,6 +36,7 @@ import { CreateProposalHeaderSection } from '@/app/proposals/create/CreatePropos
 import { isAddressRegex, isChecksumValid } from '@/app/proposals/shared/utils'
 import { isBaseError, isUserRejectedTxError } from '@/components/ErrorPage/commonErrors'
 import { TokenImage } from '@/components/TokenImage'
+import { useCanCreateProposal } from '../hooks/useCanCreateProposal'
 
 const rifMinimumAmount = ENV === 'mainnet' ? 10 : 1
 const rbtcMinimumAmount = ENV === 'mainnet' ? 0.0001 : 0.000001
@@ -71,7 +72,7 @@ const FormSchema = z
 export const TreasuryWithdrawProposalForm = () => {
   const router = useRouter()
   const prices = useGetSpecificPrices()
-  const { isLoading: isVotingPowerLoading, canCreateProposal } = useVotingPower()
+  const { isLoading: isVotingPowerLoading, canCreateProposal } = useCanCreateProposal()
   const { onCreateTreasuryTransferProposal, isPublishing } = useCreateTreasuryTransferProposal()
   const { setMessage } = useAlertContext()
 

--- a/src/app/proposals/hooks/useCanCreateProposal.ts
+++ b/src/app/proposals/hooks/useCanCreateProposal.ts
@@ -1,0 +1,21 @@
+import { formatUnits } from 'viem'
+import { useGovernorParams } from './useGovernorParams'
+import { useVotingPower } from './useVotingPower'
+
+export const useCanCreateProposal = () => {
+  const { totalVotingPower, isConnected, isLoading } = useVotingPower()
+  const { threshold } = useGovernorParams()
+
+  const canCreateProposal = totalVotingPower >= threshold
+
+  return {
+    isLoading,
+    isConnected,
+    canCreateProposal,
+    threshold,
+    totalVotingPower,
+    error: !canCreateProposal
+      ? `You need at least ${formatUnits(threshold, 18)} Voting Power to create a proposal. The easiest way to get more Voting Power is to Stake more RIF.`
+      : null,
+  }
+}

--- a/src/app/proposals/hooks/useCreateBuilderWhitelistProposal.ts
+++ b/src/app/proposals/hooks/useCreateBuilderWhitelistProposal.ts
@@ -6,10 +6,10 @@ import { GovernorAddress, BackersManagerAddress } from '@/lib/contracts'
 import { Address, encodeFunctionData, zeroAddress } from 'viem'
 import { useWriteContract } from 'wagmi'
 import { createProposal, encodeGovernorRelayCallData } from './proposalUtils'
-import { useVotingPower } from './useVotingPower'
+import { useCanCreateProposal } from './useCanCreateProposal'
 
 export const useCreateBuilderWhitelistProposal = () => {
-  const { canCreateProposal } = useVotingPower()
+  const { canCreateProposal } = useCanCreateProposal()
   const { writeContractAsync: propose, isPending: isPublishing, error: transactionError } = useWriteContract()
 
   const onCreateBuilderWhitelistProposal = async (builderAddress: Address, description: string) => {

--- a/src/app/proposals/hooks/useCreateTreasuryTransferProposal.ts
+++ b/src/app/proposals/hooks/useCreateTreasuryTransferProposal.ts
@@ -6,6 +6,7 @@ import { GovernorAbi } from '@/lib/abis/Governor'
 import { GovernorAddress, tokenContracts, TreasuryAddress } from '@/lib/contracts'
 import { Address, encodeFunctionData, parseEther, zeroAddress } from 'viem'
 import { useWriteContract } from 'wagmi'
+import { useCanCreateProposal } from './useCanCreateProposal'
 
 const DEFAULT_DAO_CONFIG = {
   abi: GovernorAbi,
@@ -13,7 +14,7 @@ const DEFAULT_DAO_CONFIG = {
 }
 
 export const useCreateTreasuryTransferProposal = () => {
-  const { canCreateProposal } = useVotingPower()
+  const { canCreateProposal } = useCanCreateProposal()
   const { writeContractAsync: propose, isPending: isPublishing } = useWriteContract()
 
   const onCreateTreasuryTransferProposal = async (

--- a/src/app/proposals/hooks/useGovernorParams.ts
+++ b/src/app/proposals/hooks/useGovernorParams.ts
@@ -1,0 +1,45 @@
+import { GovernorAbi } from '@/lib/abis/Governor'
+import { GovernorAddress } from '@/lib/contracts'
+import { Address } from 'viem'
+import { useReadContracts } from 'wagmi'
+
+export const useGovernorParams = () => {
+  const { data, isLoading } = useReadContracts({
+    allowFailure: false,
+    contracts: [
+      { abi: GovernorAbi, address: GovernorAddress, functionName: 'proposalThreshold' },
+      {
+        abi: GovernorAbi,
+        address: GovernorAddress,
+        functionName: 'guardian',
+      },
+      {
+        abi: GovernorAbi,
+        address: GovernorAddress,
+        functionName: 'name',
+      },
+      {
+        abi: GovernorAbi,
+        address: GovernorAddress,
+        functionName: 'owner',
+      },
+    ],
+  })
+
+  if (isLoading || !data) {
+    return {
+      isLoading,
+      threshold: BigInt(0),
+    }
+  }
+
+  const [threshold, guardian, name, owner] = data as [bigint, Address, string, Address]
+
+  return {
+    isLoading: false,
+    threshold,
+    name,
+    guardian,
+    owner,
+  }
+}

--- a/src/app/proposals/hooks/useRemoveBuilderProposal.ts
+++ b/src/app/proposals/hooks/useRemoveBuilderProposal.ts
@@ -6,9 +6,10 @@ import { Address, encodeFunctionData } from 'viem'
 import { useWriteContract } from 'wagmi'
 import { createProposal, encodeGovernorRelayCallData } from '@/app/proposals/hooks/proposalUtils'
 import { useVotingPower } from '@/app/proposals/hooks/useVotingPower'
+import { useCanCreateProposal } from './useCanCreateProposal'
 
 export const useRemoveBuilderProposal = () => {
-  const { canCreateProposal } = useVotingPower()
+  const { canCreateProposal } = useCanCreateProposal()
   const { writeContractAsync: propose, isPending: isPublishing, error: transactionError } = useWriteContract()
 
   const onRemoveBuilderProposal = async (builderAddress: Address, description: string) => {

--- a/src/app/proposals/hooks/useVotingPower.ts
+++ b/src/app/proposals/hooks/useVotingPower.ts
@@ -1,11 +1,9 @@
-import { GovernorAbi } from '@/lib/abis/Governor'
 import { StRIFTokenAbi } from '@/lib/abis/StRIFTokenAbi'
-import { tokenContracts, GovernorAddress } from '@/lib/contracts'
-import { formatUnits } from 'viem'
+import { tokenContracts } from '@/lib/contracts'
 import { useAccount, useReadContracts } from 'wagmi'
 
 export const useVotingPower = () => {
-  const { address } = useAccount()
+  const { address, isConnected } = useAccount()
 
   const { data, isLoading } = useReadContracts({
     allowFailure: false,
@@ -19,12 +17,6 @@ export const useVotingPower = () => {
       {
         abi: StRIFTokenAbi,
         address: tokenContracts.stRIF,
-        functionName: 'decimals',
-      },
-      { abi: GovernorAbi, address: GovernorAddress, functionName: 'proposalThreshold' },
-      {
-        abi: StRIFTokenAbi,
-        address: tokenContracts.stRIF,
         functionName: 'getVotes',
         args: [address!],
       },
@@ -35,17 +27,16 @@ export const useVotingPower = () => {
     return {
       isLoading,
       votingPower: '-',
-      canCreateProposal: false,
-      threshold: '',
+      isConnected,
     }
   }
 
-  const [balance, decimals, threshold, totalVotingPower] = data as [bigint, number, bigint, bigint]
+  const [balance, totalVotingPower] = data as [bigint, bigint]
+
   return {
     isLoading: false,
-    votingPower: formatUnits(balance, decimals),
-    canCreateProposal: totalVotingPower >= threshold,
-    threshold: formatUnits(threshold, decimals),
-    totalVotingPower: formatUnits(totalVotingPower, decimals),
+    votingPower: balance,
+    totalVotingPower,
+    isConnected,
   }
 }

--- a/src/app/proposals/hooks/useVotingPower.ts
+++ b/src/app/proposals/hooks/useVotingPower.ts
@@ -26,7 +26,8 @@ export const useVotingPower = () => {
   if (isLoading || !data) {
     return {
       isLoading,
-      votingPower: '-',
+      votingPower: BigInt(0),
+      totalVotingPower: BigInt(0),
       isConnected,
     }
   }

--- a/src/app/proposals/hooks/useVotingPowerRedirect.ts
+++ b/src/app/proposals/hooks/useVotingPowerRedirect.ts
@@ -1,10 +1,11 @@
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useVotingPower } from '@/app/proposals/hooks/useVotingPower'
+import { useCanCreateProposal } from './useCanCreateProposal'
 
 export const useVotingPowerRedirect = () => {
   const router = useRouter()
-  const { isLoading: isVotingPowerLoading, canCreateProposal } = useVotingPower()
+  const { isLoading: isVotingPowerLoading, canCreateProposal } = useCanCreateProposal()
 
   useEffect(() => {
     if (!isVotingPowerLoading && !canCreateProposal) {

--- a/src/app/proposals/page.tsx
+++ b/src/app/proposals/page.tsx
@@ -9,25 +9,19 @@ import { TxStatusMessage } from '@/components/TxStatusMessage/TxStatusMessage'
 import { Paragraph, Span } from '@/components/Typography'
 import { useRouter } from 'next/navigation'
 import { FaRegQuestionCircle } from 'react-icons/fa'
-import { useVotingPower } from './hooks/useVotingPower'
 import { useMemo } from 'react'
 import { formatNumberWithCommas } from '@/lib/utils'
-import { useGovernorParams } from './hooks/useGovernorParams'
+import { useCanCreateProposal } from './hooks/useCanCreateProposal'
 
 export default function Proposals() {
-  const { totalVotingPower = BigInt(0), isConnected } = useVotingPower()
-  const { threshold } = useGovernorParams()
+  const { isConnected, totalVotingPower, error } = useCanCreateProposal()
   const { latestProposals } = useFetchAllProposals()
 
   const memoizedProposals = useMemo(() => latestProposals.slice(0, 5), [latestProposals])
   return (
     <MainContainer>
       <TxStatusMessage messageType="proposal" />
-      <HeaderSection
-        isConnected={isConnected}
-        createProposalDisabled={!(totalVotingPower >= threshold)}
-        threshold={threshold}
-      />
+      <HeaderSection isConnected={isConnected} createProposalDisabledError={error} />
       <div className="grid grid-rows-1 gap-[32px] mb-[100px]">
         <div>
           <VotingPowerPopover />

--- a/src/app/proposals/page.tsx
+++ b/src/app/proposals/page.tsx
@@ -12,16 +12,22 @@ import { FaRegQuestionCircle } from 'react-icons/fa'
 import { useVotingPower } from './hooks/useVotingPower'
 import { useMemo } from 'react'
 import { formatNumberWithCommas } from '@/lib/utils'
+import { useGovernorParams } from './hooks/useGovernorParams'
 
 export default function Proposals() {
-  const { canCreateProposal, threshold, totalVotingPower = '' } = useVotingPower()
+  const { totalVotingPower = BigInt(0), isConnected } = useVotingPower()
+  const { threshold } = useGovernorParams()
   const { latestProposals } = useFetchAllProposals()
 
-  const memoizedProposals = useMemo(() => latestProposals, [latestProposals])
+  const memoizedProposals = useMemo(() => latestProposals.slice(0, 5), [latestProposals])
   return (
     <MainContainer>
       <TxStatusMessage messageType="proposal" />
-      <HeaderSection createProposalDisabled={!canCreateProposal} threshold={threshold} />
+      <HeaderSection
+        isConnected={isConnected}
+        createProposalDisabled={!(totalVotingPower >= threshold)}
+        threshold={threshold}
+      />
       <div className="grid grid-rows-1 gap-[32px] mb-[100px]">
         <div>
           <VotingPowerPopover />

--- a/src/app/user/Delegation/DelegationSection.tsx
+++ b/src/app/user/Delegation/DelegationSection.tsx
@@ -8,7 +8,7 @@ import { useWaitForTransactionReceipt } from 'wagmi'
 import { Hash } from 'viem'
 import { useAlertContext } from '@/app/providers'
 import { TX_MESSAGES } from '@/shared/txMessages'
-import { HeaderTitle } from '@/components/Typography'
+import { HeaderTitle, Paragraph } from '@/components/Typography'
 import { useAccount } from 'wagmi'
 import { RenderTotalBalance } from '../Balances/RenderTotalBalance'
 import { BalancesProvider } from '../Balances/context/BalancesContext'
@@ -17,9 +17,10 @@ import { ReclaimCell } from './ReclaimCell'
 import { DelegationAction } from './type'
 import { useGetExternalDelegatedAmount } from '@/shared/hooks/useGetExternalDelegatedAmount'
 import { TokenValue } from '@/app/user/Delegation/TokenValue'
+import { Popover } from '@/components/Popover'
 
 export const DelegationSection = () => {
-  const { address } = useAccount()
+  const { address, isConnected } = useAccount()
   const { delegateeAddress } = useGetDelegates(address)
 
   const [isDelegateModalOpened, setIsDelegateModalOpened] = useState(false)
@@ -63,9 +64,24 @@ export const DelegationSection = () => {
       {/* Header Components*/}
       <div className="flex flex-row justify-between mb-6">
         <HeaderTitle>DELEGATION</HeaderTitle>
-        <Button onClick={() => setIsDelegateModalOpened(true)} data-testid="Delegate">
-          Delegate
-        </Button>
+        <Popover
+          content={
+            <Paragraph variant="normal" className="text-sm">
+              You need to connect your wallet to be able to delegate.
+            </Paragraph>
+          }
+          trigger="hover"
+          background="dark"
+          size="small"
+        >
+          <Button
+            disabled={!isConnected}
+            onClick={() => setIsDelegateModalOpened(true)}
+            data-testid="Delegate"
+          >
+            Delegate
+          </Button>
+        </Popover>
       </div>
       <BalancesProvider>
         {!isExternalDelegatedAmountLoading && <Table data={[delegatedToMe]} />}

--- a/src/app/user/page.tsx
+++ b/src/app/user/page.tsx
@@ -14,7 +14,7 @@ import { useAccount } from 'wagmi'
 import { useIsBuilderOrBacker } from '../collective-rewards/rewards/hooks/useIsBuilderOrBacker'
 import { useHandleErrors } from '../collective-rewards/utils'
 
-type MyHoldingsProps = {
+interface MyHoldingsProps {
   showBuilderButton?: boolean
 }
 
@@ -29,15 +29,13 @@ const MyHoldings = ({ showBuilderButton = false }: MyHoldingsProps) => (
 
 const TabsListWithButton = withBuilderButton(TabsList)
 
-const values = ['holdings', 'rewards'] as const
-type TabValue = (typeof values)[number]
-type Tabs = {
-  [key in TabValue]: {
-    value: key
-    title: string
-  }
+type TabValue = 'holdings' | 'rewards'
+interface Tab {
+  value: TabValue
+  title: string
 }
-const tabs: Tabs = {
+
+const tabs: Record<TabValue, Tab> = {
   holdings: {
     value: 'holdings',
     title: 'My Holdings',
@@ -67,13 +65,13 @@ function User() {
       {!isLoading && isBuilderOrBacker ? (
         <Tabs defaultValue={defaultTabValue}>
           <TabsListWithButton>
-            <TabsTrigger value={tabs.holdings.value}>
-              <TabTitle>{tabs.holdings.title}</TabTitle>
-            </TabsTrigger>
-            <TabsTrigger value={tabs.rewards.value}>
-              <TabTitle>{tabs.rewards.title}</TabTitle>
-            </TabsTrigger>
+            {Object.values(tabs).map((t, i) => (
+              <TabsTrigger value={t.value} key={i + t.value}>
+                <TabTitle>{t.title}</TabTitle>
+              </TabsTrigger>
+            ))}
           </TabsListWithButton>
+
           <TabsContent value={tabs.holdings.value}>
             <MyHoldings />
           </TabsContent>

--- a/src/components/MainContainer/MainContainer.tsx
+++ b/src/components/MainContainer/MainContainer.tsx
@@ -76,9 +76,7 @@ export const MainContainer: FC<Props> = ({ children, notProtected = false }) => 
             {message && (
               <Alert {...message} onDismiss={message.onDismiss === null ? null : () => setMessage(null)} />
             )}
-            <MainContainerContent notProtected={notProtected} setMessage={setMessage}>
-              {children}
-            </MainContainerContent>
+            <MainContainerContent setMessage={setMessage}>{children}</MainContainerContent>
           </main>
           <Footer variant="container" />
         </div>

--- a/src/components/MainContainer/MainContainerContent.tsx
+++ b/src/components/MainContainer/MainContainerContent.tsx
@@ -7,12 +7,12 @@ import { ProtectedContent } from '../ProtectedContent/ProtectedContent'
 import { usePathname } from 'next/navigation'
 
 interface Props {
-  notProtected: boolean
   setMessage: (message: any) => void
   children: ReactNode
+  isProtected?: boolean
 }
 
-export const MainContainerContent: FC<Props> = ({ notProtected, setMessage, children }) => {
+export const MainContainerContent: FC<Props> = ({ isProtected = false, setMessage, children }) => {
   const { isConnected, chainId } = useAccount()
   const { switchChain } = useSwitchChain()
   const pathname = usePathname()
@@ -56,5 +56,5 @@ export const MainContainerContent: FC<Props> = ({ notProtected, setMessage, chil
     return null
   }
 
-  return <>{notProtected ? children : <ProtectedContent>{children}</ProtectedContent>}</>
+  return <>{isProtected ? <ProtectedContent>{children}</ProtectedContent> : children}</>
 }

--- a/src/components/Modal/BecomeABuilderModal.tsx
+++ b/src/components/Modal/BecomeABuilderModal.tsx
@@ -4,10 +4,10 @@ import { Header, Paragraph, Typography } from '@/components/Typography'
 import { Button } from '@/components/Button'
 import { useRouter } from 'next/navigation'
 import { SupportedActionAbiName, SupportedProposalActionName } from '@/app/proposals/shared/supportedABIs'
-import { useVotingPower } from '@/app/proposals/hooks/useVotingPower'
 import { Popover } from '../Popover'
+import { useCanCreateProposal } from '@/app/proposals/hooks/useCanCreateProposal'
 
-type DisclaimerProps = {
+interface DisclaimerProps {
   onAccept: () => void
   onDecline: () => void
 }
@@ -77,7 +77,7 @@ const ActionButton: FC<ActionButtonProps> = ({ content, ...props }) => (
 )
 
 const BecomeABuilder: FC = () => {
-  const { canCreateProposal, threshold } = useVotingPower()
+  const { error } = useCanCreateProposal()
   const router = useRouter()
   const contractName: SupportedActionAbiName = 'BuilderRegistryAbi'
   const action: SupportedProposalActionName = 'communityApproveBuilder'
@@ -106,12 +106,11 @@ const BecomeABuilder: FC = () => {
           icon={<JoinTheClubSvg />}
           text="Join the Club"
           button={
-            !canCreateProposal ? (
+            error ? (
               <Popover
                 content={
                   <Paragraph variant="normal" className="text-sm">
-                    You need at least {threshold} Voting Power to create a proposal. The easiest way to get
-                    more Voting Power is to Stake more RIF.
+                    {error}
                   </Paragraph>
                 }
                 trigger="hover"

--- a/src/pages/proposals/[id].tsx
+++ b/src/pages/proposals/[id].tsx
@@ -54,6 +54,7 @@ import React from 'react'
 import { ProposalState } from '@/shared/types'
 import { isUserRejectedTxError } from '@/components/ErrorPage/commonErrors'
 import { useGovernorParams } from '@/app/proposals/hooks/useGovernorParams'
+import { useCanCreateProposal } from '@/app/proposals/hooks/useCanCreateProposal'
 
 export default function ProposalView() {
   const {
@@ -90,8 +91,7 @@ const PageWithProposal = (proposal: ParsedProposal) => {
   const { blocksUntilClosure } = useGetProposalDeadline(proposalId)
 
   const { votingPowerAtSnapshot, doesUserHasEnoughThreshold } = useVotingPowerAtSnapshot(snapshot as bigint)
-  const { totalVotingPower = BigInt(0) } = useVotingPower()
-  const { threshold } = useGovernorParams()
+  const { canCreateProposal } = useCanCreateProposal()
 
   const {
     onVote,
@@ -236,7 +236,7 @@ const PageWithProposal = (proposal: ParsedProposal) => {
         {(proposalType === 'communityApproveBuilder' || proposalType === 'whitelistBuilder') && (
           <DewhitelistButton
             proposal={proposal}
-            canCreateProposal={totalVotingPower >= threshold}
+            canCreateProposal={canCreateProposal}
             proposalState={proposalState as ProposalState}
           />
         )}

--- a/src/pages/proposals/[id].tsx
+++ b/src/pages/proposals/[id].tsx
@@ -53,6 +53,7 @@ import { VoteSubmittedModal } from '@/components/Modal/VoteSubmittedModal'
 import React from 'react'
 import { ProposalState } from '@/shared/types'
 import { isUserRejectedTxError } from '@/components/ErrorPage/commonErrors'
+import { useGovernorParams } from '@/app/proposals/hooks/useGovernorParams'
 
 export default function ProposalView() {
   const {
@@ -89,7 +90,8 @@ const PageWithProposal = (proposal: ParsedProposal) => {
   const { blocksUntilClosure } = useGetProposalDeadline(proposalId)
 
   const { votingPowerAtSnapshot, doesUserHasEnoughThreshold } = useVotingPowerAtSnapshot(snapshot as bigint)
-  const { canCreateProposal } = useVotingPower()
+  const { totalVotingPower = BigInt(0) } = useVotingPower()
+  const { threshold } = useGovernorParams()
 
   const {
     onVote,
@@ -234,7 +236,7 @@ const PageWithProposal = (proposal: ParsedProposal) => {
         {(proposalType === 'communityApproveBuilder' || proposalType === 'whitelistBuilder') && (
           <DewhitelistButton
             proposal={proposal}
-            canCreateProposal={canCreateProposal}
+            canCreateProposal={totalVotingPower >= threshold}
             proposalState={proposalState as ProposalState}
           />
         )}
@@ -524,7 +526,7 @@ const CalldataDisplay = ({ functionName, args, inputs }: DecodedData) => (
   </div>
 )
 
-type DewhitelistButton = {
+interface DewhitelistButton {
   proposal: ParsedProposal
   canCreateProposal: boolean
   proposalState: ProposalState


### PR DESCRIPTION
@Ken-li-iov It correctly works if:
- You can navigate throughout the app except for the parts where you need to sign transactions: create proposals, delegate, voting, retracting votes, sending money(stRIF) etc
- The buttons for the "signing" are disabled