### PR TITLE
TOK-594: batch multiple requests

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -18,8 +18,12 @@ const rskRegtest = defineChain({
 export const config = createConfig({
   chains: [rskRegtest, rootstockTestnet, rootstock],
   transports: {
-    [rootstock.id]: http(),
-    [rootstockTestnet.id]: http(),
+    [rootstock.id]: http(undefined, {
+      batch: true,
+    }),
+    [rootstockTestnet.id]: http(undefined, {
+      batch: true,
+    }),
     [rskRegtest.id]: http(),
   },
   connectors: [injected()],


### PR DESCRIPTION
## What

- batch multiple requests when possible

## Why

- to reduce the number of http requests made by the dapp

## Reference

- [wagmi batch](https://wagmi.sh/core/api/transports/http#batch)