### PR TITLE
Update link URLs in info panel for grant proposals and governance forum

### DIFF
--- a/src/app/proposals/choose/components/info-panel/data.tsx
+++ b/src/app/proposals/choose/components/info-panel/data.tsx
@@ -27,7 +27,7 @@ export const infoPanelData: Record<ProposalType, MustHave[]> = {
           Learn about the ecosystem goals and steps on how to submit a <strong>Grant</strong> proposal
         </span>
       ),
-      linkUrl: 'https://rootstockcollective.xyz/collective-rewards-become-a-builder/',
+      linkUrl: 'https://rootstockcollective.xyz/submitting-a-grant-proposal/',
       Icon: DocIcon,
     },
     {
@@ -87,7 +87,7 @@ export const infoPanelData: Record<ProposalType, MustHave[]> = {
         </span>
       ),
       LinkText: props => <span {...props}>Go to Governance Forum on Discourse</span>,
-      linkUrl: 'https://gov.rootstockcollective.xyz/c/grants/5',
+      linkUrl: 'https://gov.rootstockcollective.xyz/c/collective-rewards/7',
       Icon: ChatIcon,
     },
     {


### PR DESCRIPTION
Correct the URLs in the info panel data to direct users to the appropriate pages for grant proposals and the governance forum.