### PR TITLE
fix: impl clear search input on active pill filter

### DIFF
--- a/src/components/DebounceSearch/DebounceSearch.tsx
+++ b/src/components/DebounceSearch/DebounceSearch.tsx
@@ -13,6 +13,12 @@ interface ProposalSearchProps {
    * Placeholder text for the search input.
    */
   placeholder: string
+
+  /**
+   * Optional function to set the clear handler.
+   * This is useful when the parent component needs to clear the search input.
+   */
+  setClearHandler?: (handler: () => void) => void
 }
 
 const SPINNER_DEBOUNCE_MS = 300 // Delay after the user stops typing before showing the spinner
@@ -29,7 +35,11 @@ const SEARCH_DEBOUNCE_MS = 700 // Additional delay before finalizing input and c
  * This design ensures the spinner is only displayed after the user stops typing, creating a
  * smooth and responsive UX. It prevents unnecessary actions or spinner flickering while typing.
  */
-export function DebounceSearch({ onSearchSubmit, placeholder = 'Search' }: ProposalSearchProps) {
+export function DebounceSearch({
+  onSearchSubmit,
+  placeholder = 'Search',
+  setClearHandler,
+}: ProposalSearchProps) {
   const [searchText, setSearchText] = useState('')
   // First debounce runs shortly after user stops typing. It launches spinner
   const [isUserStoppedTyping] = useDebounce(searchText, SPINNER_DEBOUNCE_MS)
@@ -53,6 +63,11 @@ export function DebounceSearch({ onSearchSubmit, placeholder = 'Search' }: Propo
   const handleChange = (val: string) => {
     setSearchText(val)
   }
+  useEffect(() => {
+    if (setClearHandler) {
+      setClearHandler(handleClear)
+    }
+  }, [])
   return (
     <Input
       value={searchText}


### PR DESCRIPTION
This PR addresses a bug where the text of the search input isn't cleared when the user selects a quick filter button as documented in this jira [ticket](https://rsklabs.atlassian.net/browse/DAO-931)