### PR TITLE
TOK-603: fix wrong modal data

### DIFF
--- a/src/components/Modal/VoteSubmittedModal.tsx
+++ b/src/components/Modal/VoteSubmittedModal.tsx
@@ -1,3 +1,4 @@
+import { splitCombinedName } from '@/app/proposals/shared/utils'
 import { Button } from '@/components/Button'
 import { Modal } from '@/components/Modal/Modal'
 import { Header, Paragraph } from '@/components/Typography'
@@ -31,7 +32,9 @@ export const VoteSubmittedModal: FC<Props> = ({ onClose, proposal, vote }) => {
         <div className="mt-8">
           <div className="flex justify-between items-center mb-2">
             <span className="w-1/3 text-sm">Proposal</span>
-            <span className="w-2/3 text-sm truncate text-right">{proposal.name}</span>
+            <span className="w-2/3 text-sm truncate text-right">
+              {splitCombinedName(proposal.name).proposalName}
+            </span>
           </div>
           <div className="flex justify-between items-center mb-2">
             <span className="w-1/3 text-sm">Proposal ID</span>


### PR DESCRIPTION
The proposal vote submitted modal was using wrong data for the proposal name.
This PR fixes that.

<img width="670" alt="Screenshot 2025-02-04 at 14 02 42" src="https://github.com/user-attachments/assets/75f87ccd-51bd-45db-b80b-494c31109aca" />

[Task](https://rsklabs.atlassian.net/browse/TOK-603)

> [!NOTE]
> Did not refactor as the whole component needs improvement (eg [proposal type](https://github.com/RootstockCollective/dao-frontend/blob/ce830ff37a269dfd109aeea2650333ccb5ef4733/src/components/Modal/VoteSubmittedModal.tsx#L12))