### PR TITLE
TOK-610: temp remove backers all-time share

### DIFF
--- a/src/app/collective-rewards/rewards/backers/Rewards.tsx
+++ b/src/app/collective-rewards/rewards/backers/Rewards.tsx
@@ -67,9 +67,12 @@ const RewardsContent: FC<RewardsProps> = ({ builder, gauges, tokens }) => {
           }}
         />
       </MetricContainer>
+      {/* 
+      // Removed until RBI% is introduced (TOK-610)
       <MetricContainer>
         <BackerAllTimeShare gauges={gauges} tokens={tokens} />
       </MetricContainer>
+      */}
     </>
   )
 }


### PR DESCRIPTION
All time share metric is removed until RBI% is introduced.

<img width="923" alt="Screenshot 2025-02-04 at 15 44 39" src="https://github.com/user-attachments/assets/e23b08ea-860a-4e6f-b346-e5a56afb01bf" />

[Task](https://rsklabs.atlassian.net/browse/TOK-610)