### PR TITLE
Remove deprecated IPFS gateway URL

### DIFF
--- a/src/config/ipfsGateways.ts
+++ b/src/config/ipfsGateways.ts
@@ -2,5 +2,4 @@ export const ipfsGateways = [
   'https://red-legislative-meadowlark-461.mypinata.cloud/ipfs/',
   'https://ipfs.io/ipfs/',
   'https://gateway.pinata.cloud/ipfs/',
-  'https://dweb.link/ipfs/',
 ]


### PR DESCRIPTION
Eliminate the use of a deprecated IPFS gateway URL from the configuration.