### PR TITLE
Replace IPFS gateways list with a single one

### DIFF
--- a/src/app/user/Balances/actions.ts
+++ b/src/app/user/Balances/actions.ts
@@ -11,7 +11,6 @@ import {
 } from '@/lib/endpoints'
 import { tokenContracts, GovernorAddress } from '@/lib/contracts'
 import { NftMeta } from '@/shared/types'
-import { ipfsGateways } from '@/config'
 import {
   NextPageParams,
   NftHolderItem,
@@ -19,6 +18,7 @@ import {
   TokenHoldersResponse,
 } from '@/app/user/Balances/types'
 import { BackendEventByTopic0ResponseValue } from '@/shared/utils'
+import { ipfsGateway } from '@/lib/constants'
 
 export const fetchAddressTokens = (address: string, chainId = 31) =>
   axiosInstance
@@ -108,13 +108,9 @@ export async function fetchIpfsUri(
   ipfsUri: string,
   responseType: 'json' | 'blob' = 'json',
 ): Promise<NftMeta | Blob> {
-  return Promise.any(
-    ipfsGateways.map(async gateway => {
-      const httpsUrl = ipfsUri.replace('ipfs://', gateway)
-      const { data } = await axiosInstance.get(httpsUrl, { responseType })
-      return data
-    }),
-  )
+  const httpsUrl = ipfsUri.replace('ipfs://', ipfsGateway)
+  const { data } = await axiosInstance.get(httpsUrl, { responseType })
+  return data
 }
 
 export const fetchNftInfo = (address: string) =>

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,2 +1,1 @@
 export * from './config'
-export { ipfsGateways } from './ipfsGateways'

--- a/src/config/ipfsGateways.ts
+++ b/src/config/ipfsGateways.ts
@@ -1,5 +1,0 @@
-export const ipfsGateways = [
-  'https://red-legislative-meadowlark-461.mypinata.cloud/ipfs/',
-  'https://ipfs.io/ipfs/',
-  'https://gateway.pinata.cloud/ipfs/',
-]

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -46,3 +46,4 @@ export const proposalQuickFilters = ['Grant', 'Activation', 'Wave 4', 'Wave 5']
 
 export const MAX_NAME_LENGTH_FOR_PROPOSAL = 100
 export const TALLY_DESCRIPTION_SEPARATOR = '  ' // Tally uses double spaces to separate name and description
+export const ipfsGateway = 'https://red-legislative-meadowlark-461.mypinata.cloud/ipfs/'


### PR DESCRIPTION
Simplify IPFS URI fetching by using a single gateway constant instead of multiple gateways. This change will ensure the use of only one reliable IPFS node.