### PR TITLE
Change deactivation URL to internal link and refactor ArrowLink component

### DIFF
--- a/src/app/proposals/choose/components/info-panel/arrow-link.tsx
+++ b/src/app/proposals/choose/components/info-panel/arrow-link.tsx
@@ -10,8 +10,8 @@ export function ArrowLink({ children, className, ...props }: AnchorHTMLAttribute
     <a
       {...props}
       className={cn(
-        className,
         'mt-2 w-fit block leading-none hover:underline decoration-primary text-primary',
+        className,
       )}
     >
       {children}

--- a/src/app/proposals/choose/components/info-panel/arrow-link.tsx
+++ b/src/app/proposals/choose/components/info-panel/arrow-link.tsx
@@ -1,17 +1,18 @@
-import { PropsWithChildren } from 'react'
+import { AnchorHTMLAttributes } from 'react'
 import ArrowIcon from './icons/arrow-icon'
+import { cn } from '@/lib/utils'
 
-interface OrangeLinkProps extends PropsWithChildren {
-  href: string
-}
-
-export function ArrowLink({ href, children }: OrangeLinkProps) {
+/**
+ * Link with a trailing orange arrow
+ */
+export function ArrowLink({ children, className, ...props }: AnchorHTMLAttributes<HTMLAnchorElement>) {
   return (
     <a
-      className="mt-2 w-fit block leading-none hover:underline decoration-primary text-primary"
-      target="_blank"
-      rel="noopener noreferrer"
-      href={href}
+      {...props}
+      className={cn(
+        className,
+        'mt-2 w-fit block leading-none hover:underline decoration-primary text-primary',
+      )}
     >
       {children}
       &nbsp;

--- a/src/app/proposals/choose/components/info-panel/deactivation-footer.tsx
+++ b/src/app/proposals/choose/components/info-panel/deactivation-footer.tsx
@@ -7,7 +7,7 @@ export function DeactivationFooter({ className, ...props }: HTMLAttributes<HTMLD
   return (
     <div className={cn(className, 'flex flex-col')} {...props}>
       <HeaderTitle className="text-[14px] uppercase leading-none">A builder needs to leave ?</HeaderTitle>
-      <ArrowLink href="https://gov.rootstockcollective.xyz/c/collective-rewards/7">
+      <ArrowLink href="/proposals/create?contract=BuilderRegistryAbi&action=dewhitelistBuilder">
         <Typography className="inline text-sm font-[600]">Propose a builder Deactivation</Typography>
       </ArrowLink>
     </div>

--- a/src/app/proposals/choose/components/info-panel/info-panel.tsx
+++ b/src/app/proposals/choose/components/info-panel/info-panel.tsx
@@ -34,7 +34,7 @@ export function InfoPanel({ proposal, className }: InfoPanelProps) {
                     <Typography>{i + 1}.</Typography>
                     <Text className="leading-tight" />
                   </div>
-                  <ArrowLink href={linkUrl}>
+                  <ArrowLink target="_blank" rel="noopener noreferrer" href={linkUrl}>
                     <LinkText className="inline text-lg font-[600] leading-tight text-primary" />
                   </ArrowLink>
                 </li>


### PR DESCRIPTION
Update the deactivation URL to use an internal link and refactor the ArrowLink component to accept additional props and improve its functionality.

## Ref

https://rsklabs.atlassian.net/browse/DAO-1045

<img width="329" alt="Screenshot 2025-02-07 at 21 20 21" src="https://github.com/user-attachments/assets/05523ee0-8e02-4abc-8eb7-4c97f69fb152" />
