### PR TITLE
TOK-638: show overflow and break the word if long

### DIFF
--- a/src/app/collective-rewards/leaderboard/BuildersLeaderBoardTable.tsx
+++ b/src/app/collective-rewards/leaderboard/BuildersLeaderBoardTable.tsx
@@ -131,7 +131,7 @@ export const BuildersLeaderBoardTable: FC = () => {
 
   return (
     <div className="flex flex-col gap-5 w-full">
-      <TableCore className="table-fixed">
+      <TableCore className="table-fixed overflow-visible">
         <TableHead>
           <TableRow className="normal-case">
             {tableHeaders.map(header => (

--- a/src/components/Address/AddressOrAlias.tsx
+++ b/src/components/Address/AddressOrAlias.tsx
@@ -12,7 +12,7 @@ export const AddressOrAlias: React.FC<AddressProps> = ({ addressOrAlias, classNa
   const key = isAddress(addressOrAlias) ? 'address' : 'alias'
 
   const addressClass = 'font-normal text-base leading-none text-text-primary'
-  const aliasClass = 'text-sm line-clamp-1'
+  const aliasClass = 'text-sm line-clamp-1 break-all'
 
   const renderedComponent = {
     alias: <Span className={cn(aliasClass, className)}>{addressOrAlias}</Span>,


### PR DESCRIPTION
## What

- fix the builder name in the leaderboard table

## Why

- the popover text is hidden
- the copy button is hidden