### PR TITLE
Add scrollable container to DelegateModal table

### DIFF
--- a/src/app/user/Delegation/DelegateModal.tsx
+++ b/src/app/user/Delegation/DelegateModal.tsx
@@ -217,7 +217,15 @@ export const DelegateModal = ({ onClose, onDelegateTxStarted }: DelegateModalPro
               <Image src={questionImg} alt="Tooltip" className="w-[14px] opacity-40 cursor-pointer" />
             </Popover>
           </div>
-          <StatefulTable table={table} equalColumns data-testid="TableShepherds" />
+          <div
+            className="max-h-[350px] overflow-y-auto 
+            [&::-webkit-scrollbar]:w-3
+            [&::-webkit-scrollbar-thumb]:rounded-full
+            [&::-webkit-scrollbar-track]:bg-foreground
+            [&::-webkit-scrollbar-thumb]:bg-primary"
+          >
+            <StatefulTable table={table} equalColumns data-testid="TableShepherds" />
+          </div>
           {error && (
             <p className="text-st-error">
               {error}


### PR DESCRIPTION
## What

Add scroll bar to the delegate modal when displaying shepherds dataset larger than 5 items.

- More than 5 items:

<img width="987" alt="Screenshot 2025-02-24 at 20 00 40" src="https://github.com/user-attachments/assets/677ebde6-e538-4270-aa97-6065a94b07b5" />

- Exactly five items and less (no scrollbar):

<img width="946" alt="Screenshot 2025-02-24 at 20 01 52" src="https://github.com/user-attachments/assets/6e28dc10-46f2-4640-913a-b5e309b880fa" />


## Issue

[DAO-1079](https://rsklabs.atlassian.net/browse/DAO-1079)