### PR TITLE
TOK-655: lowercase addresses in gen data

### DIFF
--- a/.github/scripts/nft_boost/activateBoost.ts
+++ b/.github/scripts/nft_boost/activateBoost.ts
@@ -39,6 +39,10 @@ const nftActiveBoostPath = `${boostDataFolder}/latest`
   let holders: Holders = {}
   for (let i = 0; i < nftTransferEvents.length; i++) {
     const event = nftTransferEvents[i]
+    /* FIXME: lower case addresses for v1.7
+     * getAddress(`0x${event.topics[2].slice(-40)}`).toLowerCase()
+     *   on v1.6.0 this will not work, as the address is not lower cased in the consumer
+     */
     const holderAddress = getAddress(`0x${event.topics[2].slice(-40)}`)
     if (holderAddress === zeroAddress) continue
 
@@ -60,6 +64,7 @@ const nftActiveBoostPath = `${boostDataFolder}/latest`
         estimatedRIFRewards: 0n,
       }),
     )
+
     holders[holderAddress] = {
       estimatedRBTCRewards,
       estimatedRIFRewards,

--- a/.github/scripts/nft_boost/process.utils.ts
+++ b/.github/scripts/nft_boost/process.utils.ts
@@ -9,7 +9,7 @@ export type Args = {
 }
 const { nftContractAddress, boostPercentage, env } = args.reduce<Args>((acc, val) => {
   if (val.startsWith('--nft')) {
-    acc.nftContractAddress = getAddress(val.split('=')[1])
+    acc.nftContractAddress = getAddress(val.split('=')[1]).toLowerCase() as Address
   }
 
   if (val.startsWith('--boost')) {

--- a/.github/workflows/booster.yaml
+++ b/.github/workflows/booster.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       boost:
-        description: 'The amount of backers to boost'
+        description: 'The reward boost percentage (0-100)'
         required: true
       nft:
         description: 'The address of the NFT contract'
@@ -55,10 +55,6 @@ jobs:
           git checkout $BOOST_DATA_BRANCH --force || git checkout -b $BOOST_DATA_BRANCH
 
           git apply boost.diff --3way --theirs
-
-      - name: Commit and push changes
-        run: |
-          # Stage all changes
           git add .
 
           # Create a commit; if there are no changes, this command will fail, so we ignore that error.


### PR DESCRIPTION
# What

Lowercase the nft address only in the script

> ![IMPORTANT]
> lowecase backer addresses, as well, for the next release

# Why

To not break the currently implemented logic in v1.6.0
