### PR TITLE
feat: SectionHeader reusable component

### DIFF
--- a/src/components/Link/ExternalLink.tsx
+++ b/src/components/Link/ExternalLink.tsx
@@ -22,6 +22,7 @@ export const ExternalLink: FC<ExternalLinkProps> = ({
         'inline-flex items-center gap-1.5 font-sora underline underline-offset-2 underline-thick hover:cursor-pointer w-fit',
         { 'tracking-tight leading-tight text-base': variant === 'menu' },
         { 'leading-normal text-sm': variant === 'default' },
+        { 'leading-nornal text-base text-primary': variant === 'section-header' },
         // combines hardcoded styles with classes coming from props
         className,
       )}

--- a/src/components/Link/types.ts
+++ b/src/components/Link/types.ts
@@ -2,7 +2,7 @@ import type { AnchorHTMLAttributes, ElementType } from 'react'
 import { LinkProps as NextLinkProps } from 'next/link'
 
 export interface ExternalLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  variant?: 'default' | 'menu'
+  variant?: 'default' | 'menu' | 'section-header'
   component?: ElementType
 }
 

--- a/src/components/section-header/index.tsx
+++ b/src/components/section-header/index.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react'
+import { HeaderTitle, Typography } from '../Typography'
+
+interface Props {
+  name: string
+  description: string | ReactNode
+}
+
+export const SectionHeader = ({ name, description }: Props) => {
+  return (
+    <div>
+      <HeaderTitle>{name}</HeaderTitle>
+      <Typography className="mt-4 text-[14px] max-w-[60%]">{description}</Typography>
+    </div>
+  )
+}


### PR DESCRIPTION
<img width="622" alt="Screenshot 2025-03-05 at 12 59 44" src="https://github.com/user-attachments/assets/160885c9-3c83-47fd-8d4b-eda1aab75963" />
<img width="544" alt="Screenshot 2025-03-05 at 12 59 54" src="https://github.com/user-attachments/assets/4b3d56eb-e42d-4b54-9200-98c82198697a" />
Now you can use `SectionHeader` custom component for your sections as well. This will allow us not to modify use cases but rather just the component itself(for example when it becomes collapsable).