### PR TITLE
TOK-663: only show booster card on active campaign page 

### DIFF
--- a/src/app/communities/nft/[address]/page.tsx
+++ b/src/app/communities/nft/[address]/page.tsx
@@ -350,7 +350,7 @@ export default function Page() {
                     )}
                   </div>
 
-                  <SelfContainedNFTBoosterCard forceRender={showNFTBoost} />
+                  {showNFTBoost && <SelfContainedNFTBoosterCard />}
 
                   {/* `Add to wallet button` */}
                   {!isNftInWallet?.[nftAddress]?.[tokenId] && (


### PR DESCRIPTION


Resolves:
[Task](https://rsklabs.atlassian.net/browse/TOK-663)