### PR TITLE
fix: set max height to paragraph

### DIFF
--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -33,7 +33,7 @@ export const Alert = ({ severity, title, content, onDismiss, 'data-testid': data
         {typeof content === 'string' ? (
           <Paragraph
             variant="light"
-            className="font-[600] text-[14px] text-white opacity-80 mb-[12px] break-all"
+            className="font-[600] text-[14px] text-white opacity-80 mb-[12px] break-all max-h-36 overflow-y-auto"
             data-testid="Content"
           >
             {content}


### PR DESCRIPTION
## What

- fix max height to error paragraph

## Why

- to avoid that an error content fill the whole page