### PR TITLE
fix: wait until the data is ready before redirecting

### DIFF
--- a/src/app/collective-rewards/settings/Settings.tsx
+++ b/src/app/collective-rewards/settings/Settings.tsx
@@ -21,7 +21,7 @@ export const Settings: FC = () => {
   const { isConnected, address } = useAccount()
   const searchParams = useSearchParams()
   const router = useRouter()
-  const { data: gauge, isLoading: isLoadingGauge } = useGetBuilderToGauge(address!)
+  const { data: gauge, status } = useGetBuilderToGauge(address!)
 
   useEffect(() => {
     if (!isConnected) {
@@ -31,10 +31,13 @@ export const Settings: FC = () => {
 
   const isBuilder = gauge && gauge !== zeroAddress
   useEffect(() => {
+    if (status === 'pending') {
+      return
+    }
     if (!isBuilder) {
       router.replace('/')
     }
-  }, [gauge, router, isBuilder])
+  }, [gauge, router, isBuilder, status])
 
   const settingType = searchParams.get('type') as SettingType
   const isValidSettingType = searchParams && isSettingType(settingType)


### PR DESCRIPTION
## What

- wait until the builder info is ready before redirecting

## Why

- otherwise the Builder won't be able to access the page