### PR TITLE
DAO-1124: remove proposal category, remove arrow icon, and include proposal states

### DIFF
--- a/src/app/proposals/[id]/page.tsx
+++ b/src/app/proposals/[id]/page.tsx
@@ -308,12 +308,12 @@ const PageWithProposal = (proposal: ParsedProposal) => {
         </div>
         <div>
           {!isConnected && (
-            <ConnectWorkflow
-              ConnectComponent={({ onClick }) => (
-                <Button variant="secondary" onClick={onClick} data-testid="VoteOnChain">
-                  Vote on chain
-                </Button>
-              )}
+            <DisconnectedAction
+              proposalState={proposalState}
+              proposalNeedsQueuing={proposalNeedsQueuing}
+              proposalStateHuman={proposalStateHuman}
+              isExecuting={isExecuting}
+              isPendingExecution={isPendingExecution}
             />
           )}
           {isConnected && proposalState === ProposalState.Active && (
@@ -481,6 +481,63 @@ const PageWithProposal = (proposal: ParsedProposal) => {
       </div>
     </div>
   )
+}
+interface DisconnectedActionProps {
+  proposalState: number | undefined
+  proposalNeedsQueuing: boolean | undefined
+  proposalStateHuman: string
+  isExecuting: boolean
+  isPendingExecution: boolean
+}
+const DisconnectedAction = ({
+  proposalState,
+  proposalNeedsQueuing,
+  proposalStateHuman,
+  isExecuting,
+  isPendingExecution,
+}: DisconnectedActionProps) => {
+  if (proposalState === ProposalState.Active) {
+    return (
+      <ConnectWorkflow
+        ConnectComponent={({ onClick }) => (
+          <Button variant="secondary" onClick={onClick} data-testid="VoteOnChain">
+            Vote on chain
+          </Button>
+        )}
+      />
+    )
+  }
+  if (proposalNeedsQueuing && proposalStateHuman === 'Succeeded') {
+    return (
+      <ConnectWorkflow
+        ConnectComponent={({ onClick }) => (
+          <Button variant="secondary" onClick={onClick} className="mt-2" data-testid="PutOnQueue">
+            Put on Queue
+          </Button>
+        )}
+      />
+    )
+  }
+  if (proposalState === ProposalState.Queued) {
+    return (
+      <ConnectWorkflow
+        ConnectComponent={({ onClick }) => (
+          <Button variant="secondary" onClick={onClick} className="mt-2 ml-auto" data-testid="Execute">
+            Execute
+          </Button>
+        )}
+      />
+    )
+  }
+  if (isExecuting || isPendingExecution) {
+    return (
+      <Span variant="light" className="inline-block mt-2">
+        Pending transaction confirmation <br />
+        to complete execution.
+      </Span>
+    )
+  }
+  return null
 }
 
 interface CalldataRowsData {

--- a/src/app/proposals/components/LatestProposalsTable.tsx
+++ b/src/app/proposals/components/LatestProposalsTable.tsx
@@ -186,11 +186,6 @@ const LatestProposalsTable = ({ proposals, onEmitActiveProposal }: LatestProposa
         return dominantA.priority - dominantB.priority
       },
     }),
-    accessor('category', {
-      id: 'category',
-      header: 'Category',
-      cell: info => <CategoryColumn proposalCategory={info.row.original.category} />,
-    }),
     accessor('proposalState', {
       id: 'status',
       header: 'Status',

--- a/src/app/proposals/components/table-columns/ProposalNameColumn.tsx
+++ b/src/app/proposals/components/table-columns/ProposalNameColumn.tsx
@@ -1,6 +1,5 @@
 import { Link } from '@/components/Link'
 import { splitCombinedName } from '../../shared/utils'
-import { ArrowUpRightIcon } from '@/components/Icons'
 
 interface ProposalNameColumnProps {
   name: string
@@ -9,11 +8,5 @@ interface ProposalNameColumnProps {
 
 export const ProposalNameColumn = ({ name, proposalId }: ProposalNameColumnProps) => {
   const { proposalName } = splitCombinedName(name)
-  const proposalToDisplay = proposalName.length > 50 ? `${proposalName.slice(0, 50)}...` : proposalName
-  return (
-    <Link href={`/proposals/${proposalId}`}>
-      {proposalToDisplay}
-      <ArrowUpRightIcon size={18} />
-    </Link>
-  )
+  return <Link href={`/proposals/${proposalId}`}>{proposalName.slice(0, 50)}</Link>
 }


### PR DESCRIPTION
# Ticket
https://rsklabs.atlassian.net/browse/DAO-1124
## Description
1. Remove category column
2. Remove Arrow for proposal name
3. If the user goes to a proposal that is successful or on queue, should display the correct button “Put to queue” or “Execute” and prompt the disclaimer, same as vote does

![Screenshot 2025-03-13 at 1 03 41 PM](https://github.com/user-attachments/assets/dc965d6c-65b0-4786-b77f-a683f58b978c)
![Screenshot 2025-03-13 at 1 04 25 PM](https://github.com/user-attachments/assets/2f6f6928-9116-4c7e-9b64-d002b7291d5b)
![Screenshot 2025-03-13 at 1 04 38 PM](https://github.com/user-attachments/assets/50443bd5-c333-455c-bf9c-aa6b68cd77f6)
