### PR TITLE
DAO-1155 fix add to wallet button

### DIFF
--- a/src/app/communities/nft/[address]/CommunityNFTContext.tsx
+++ b/src/app/communities/nft/[address]/CommunityNFTContext.tsx
@@ -175,6 +175,8 @@ export function CommunityNFTProvider({ children, nftAddress }: CommunityNFTProvi
     isMember,
     tokenId,
     membersCount,
+    isMintable: nftInfo?.isMintable,
+
     nftName,
     nftSymbol,
     nftMeta,

--- a/src/app/communities/nft/[address]/_sections/MembershipNFTSection.tsx
+++ b/src/app/communities/nft/[address]/_sections/MembershipNFTSection.tsx
@@ -1,13 +1,13 @@
 'use client'
 import { useAccount } from 'wagmi'
-import { Span } from '@/components/Typography'
+import { Paragraph, Span } from '@/components/Typography'
 import Image from 'next/image'
 import { UserMemberSection } from './UserMemberSection'
 import { ClaimItButton } from '../_components/ClaimItButton'
 import { useCommunityNFT } from '@/app/communities/nft/[address]/CommunityNFTContext'
 
 export const MembershipNFTSection = () => {
-  const { name, image, isMember, tokenId, isMintable } = useCommunityNFT()
+  const { name, image, isMember, tokenId, isMintable, tokensAvailable } = useCommunityNFT()
   const { isConnected } = useAccount()
 
   return (
@@ -29,8 +29,7 @@ export const MembershipNFTSection = () => {
               <Span>By joining to the community you will receive one of the NFTs</Span>
               {isMintable && isConnected && (
                 <>
-                  {/* @TODO was this removed from design? */}
-                  {/*<Paragraph size="small">{tokensAvailable} NFTs left to claim.</Paragraph>*/}
+                  <Paragraph size="small">{tokensAvailable} NFTs left to claim.</Paragraph>
                   <ClaimItButton />
                 </>
               )}

--- a/src/app/communities/nft/[address]/_sections/UserMemberSection.tsx
+++ b/src/app/communities/nft/[address]/_sections/UserMemberSection.tsx
@@ -29,7 +29,9 @@ export const UserMemberSection = () => {
 
       <SelfContainedNFTBoosterCard forceRender={showNFTBoost && isBoosted} />
 
-      <AddToWalletButton />
+      <div>
+        <AddToWalletButton />
+      </div>
 
       <Span className="inline-block text-[14px] tracking-wide font-light">{description}</Span>
     </div>


### PR DESCRIPTION
Fixed add to wallet width when description exists
Brought back tokens available as it was removed per design when it was not supposed to
Fixed claim it button - was missing isMintable in the context