### PR TITLE
fix: use nft image instead of default for placeholder

### DIFF
--- a/src/app/communities/nft/[address]/_sections/NftHoldersSection.tsx
+++ b/src/app/communities/nft/[address]/_sections/NftHoldersSection.tsx
@@ -29,7 +29,7 @@ interface HoldersSectionProps {
   address: Address
 }
 
-const CardHolderParagraph = ({ address }: { address: string }) => (
+const CardHolderParagraph = ({ address, image }: { address: string; image: string }) => (
   <a
     href={`${EXPLORER_URL}/address/${address}`}
     target="_blank"
@@ -38,7 +38,7 @@ const CardHolderParagraph = ({ address }: { address: string }) => (
     <Paragraph fontFamily="kk-topo" size="large" className="pt-[6px]">
       HOLDER
     </Paragraph>
-    <img src="/images/treasury/holders.png" width={24} height={24} alt="Holders Image" />
+    <img src={image} width={24} height={24} alt="Holders Image" />
     <Span className="underline text-left overflow-hidden whitespace-nowrap text-[14px]">
       {truncateMiddle(address, 5, 5)}
     </Span>
@@ -60,7 +60,7 @@ const Card = ({ image, id, holderAddress }: CardProps) => {
         <Paragraph fontFamily="kk-topo" size="large">
           ID# {id}
         </Paragraph>
-        <CardHolderParagraph address={holderAddress} />
+        <CardHolderParagraph address={holderAddress} image={image} />
       </div>
     </div>
   )


### PR DESCRIPTION
This PR fixes the bug in this [ticket](https://rsklabs.atlassian.net/browse/DAO-801)

Current Render
Notice that the mini thumb image shows the same(default) image for all the holders.
![Screenshot 2025-03-18 at 4 24 16 PM](https://github.com/user-attachments/assets/fe2aba49-18c5-4013-9e54-36813cd786d6)

New Render
Notice that the mini thumb image now shows the nft image instead of the placeholder shown for all the holders.
![Screenshot 2025-03-18 at 4 15 44 PM](https://github.com/user-attachments/assets/57c6e554-ca3e-4d7b-8540-da86091b5034)
