### PR TITLE
Fix joined words in community names (add spaces)

### DIFF
--- a/src/app/user/Communities/CommunitiesSection.tsx
+++ b/src/app/user/Communities/CommunitiesSection.tsx
@@ -103,12 +103,6 @@ const NftInfo = ({
     return <CardPlaceholder />
   }
 
-  // DAO FIXME: the nftName from data is in CapitaCamelCase but also with abbreviations,
-  // so it renders as single word atm (e.g. "OGFOUNDERS" instead of "OG FOUNDERS")
-  // one option is to use the hardcoded data from communitiesMapByContract to get the name by address;
-  // another option is to use the nftName from data and split it by capital letters, w/ some exceptions for abbreviations (e.g. "OGFounders" -> "OG FOUNDERS" and not "O G FOUNDERS");
-  // however there are so many exceptions to this rule that it might be better to just use the hardcoded data, failing the ability to enforce a proper name format upon the nft creation (or the storage of metadata).
-  // NOTE! Also consider that the data in metadata does not match the hardcoded data, so now, the names in users communities are not the same as the ones on the communities page.
   if (data.nftName && data.isMember) {
     return (
       <CommunityCard

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import Big from '@/lib/big'
-import { formatCurrency, formatNumberWithCommas, millify } from '@/lib/utils'
+import { formatCurrency, formatNumberWithCommas, millify, splitWords } from '@/lib/utils'
 import { describe, expect, it } from 'vitest'
 
 describe('formatCurrency', () => {
@@ -141,5 +141,36 @@ describe('millify', () => {
     expect(millify(1372499)).toBe('1.372M')
     expect(millify(1372510)).toBe('1.372M')
     expect(millify(1372000000)).toBe('1.372B')
+  })
+})
+
+describe('splitWords', () => {
+  it('splits camelCase words', () => {
+    expect(splitWords('camelCase')).toBe('camel Case')
+    expect(splitWords('thisIsCamelCase')).toBe('this Is Camel Case')
+  })
+
+  it('splits PascalCase words', () => {
+    expect(splitWords('PascalCase')).toBe('Pascal Case')
+    expect(splitWords('ThisIsPascalCase')).toBe('This Is Pascal Case')
+  })
+
+  it('handles acronyms correctly', () => {
+    expect(splitWords('JSONParser')).toBe('JSON Parser')
+    expect(splitWords('parseXMLDocument')).toBe('parse XML Document')
+    expect(splitWords('ABCdef')).toBe('AB Cdef')
+    expect(splitWords('OGFounders')).toBe('OG Founders')
+    expect(splitWords('OGContributors')).toBe('OG Contributors')
+    expect(splitWords('EarlyAdopters')).toBe('Early Adopters')
+  })
+
+  it('handles single word inputs', () => {
+    expect(splitWords('hello')).toBe('hello')
+    expect(splitWords('Hello')).toBe('Hello')
+  })
+
+  it('handles empty string', () => {
+    expect(splitWords('')).toBe('')
+    expect(splitWords(undefined)).toBe('')
   })
 })

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -307,3 +307,18 @@ export function millify(num: BigSource | bigint, separator = '', units = shortDe
 
   return formatNumberWithCommas(bigNum)
 }
+
+/**
+ * Splits a string by inserting spaces between camelCase and PascalCase words.
+ * 
+ * @param str - The input string to split
+ * @returns The string with spaces inserted between word boundaries
+ * 
+ * @example
+ * splitWords("camelCase") // returns "camel Case"
+ * splitWords("PascalCase") // returns "Pascal Case"
+ * splitWords("ABCdef") // returns "AB Cdef"
+ */
+export function splitWords(str?: string) {
+  return str ? str.replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2').replace(/([a-z])([A-Z])/g, '$1 $2') : ''
+}

--- a/src/shared/hooks/useCommunity.ts
+++ b/src/shared/hooks/useCommunity.ts
@@ -8,7 +8,7 @@ import { NftMeta, CommunityData } from '../types'
 import { config } from '@/config'
 import Big from '@/lib/big'
 import { useQuery } from '@tanstack/react-query'
-import { axiosInstance } from '@/lib/utils'
+import { axiosInstance, splitWords } from '@/lib/utils'
 import { NftDataFromAddressesReturnType } from '@/app/user/api/communities/route'
 
 /**
@@ -82,7 +82,7 @@ export const useContractData = (nftAddress?: Address) => {
       tokensAvailable: Number(tokensAvailable),
       isMember: Big(balanceOf?.result?.toString() ?? 0).gt(0),
       tokenId: typeof tokenId?.result === 'bigint' ? Number(tokenId.result) : undefined,
-      nftName: nftName,
+      nftName: splitWords(nftName),
       nftSymbol: symbol,
       nftUri: URI?.[0].result,
       stRifThreshold: stRifThreshold ? BigInt(stRifThreshold) : undefined,


### PR DESCRIPTION
- Introduce a utility function to split camelCase and PascalCase strings into separate words, enhancing readability. 
- Update the NFT name formatting to utilize this new function.