### PR TITLE
feat: display rns domain in grid view

### DIFF
--- a/src/app/communities/nft/[address]/_sections/NftHoldersSection.tsx
+++ b/src/app/communities/nft/[address]/_sections/NftHoldersSection.tsx
@@ -67,13 +67,13 @@ const Card = ({ image, id, holderAddress }: CardProps) => {
 }
 
 interface CardViewProps {
-  nfts: { image_url: string; id: string; owner: string }[]
+  nfts: { image_url: string; id: string; owner: string; ens_domain_name: string }[]
 }
 
 const CardView = ({ nfts }: CardViewProps) => (
   <div className="grid 2xl:grid-cols-4 xl:grid-cols-3 lg:grid-cols-2 md:grid-cols-1 gap-y-4">
-    {nfts.map(({ image_url, id, owner }) => (
-      <Card key={id} image={image_url} id={id} holderAddress={owner} />
+    {nfts.map(({ image_url, id, owner, ens_domain_name }) => (
+      <Card key={id} image={image_url} id={id} holderAddress={ens_domain_name || owner} />
     ))}
   </div>
 )

--- a/src/app/communities/nft/[address]/_sections/NftHoldersSection.tsx
+++ b/src/app/communities/nft/[address]/_sections/NftHoldersSection.tsx
@@ -67,7 +67,7 @@ const Card = ({ image, id, holderAddress }: CardProps) => {
 }
 
 interface CardViewProps {
-  nfts: { image_url: string; id: string; owner: string; ens_domain_name: string }[]
+  nfts: { image_url: string; id: string; owner: string; ens_domain_name?: string }[]
 }
 
 const CardView = ({ nfts }: CardViewProps) => (


### PR DESCRIPTION
This PR fixes the bug reported in this [ticket](https://rsklabs.atlassian.net/browse/DAO-1147)

Previous Render(rns domain not displayed)
<img width="1214" alt="Screenshot 2025-03-31 at 11 34 10 AM" src="https://github.com/user-attachments/assets/80302b04-c85d-4024-9d39-b2a7aef6dd85" />

Current Render(rns domain displayed)
<img width="1214" alt="Screenshot 2025-03-31 at 11 33 43 AM" src="https://github.com/user-attachments/assets/e45dbb3e-a809-4e09-97ae-e793578442c6" />
