### PR TITLE
fix(cr): disable hooks when no wallet

### DIFF
--- a/src/app/collective-rewards/metrics/hooks/useGetCycleNext.ts
+++ b/src/app/collective-rewards/metrics/hooks/useGetCycleNext.ts
@@ -1,11 +1,13 @@
-import { CycleTimeKeeperAbi } from '@/lib/abis/v2/CycleTimeKeeperAbi'
-import { BackersManagerAddress } from '@/lib/contracts'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-import { useQuery } from '@tanstack/react-query'
-import { readContract } from 'wagmi/actions'
 import { config } from '@/config'
+import { CycleTimeKeeperAbi } from '@/lib/abis/v2/CycleTimeKeeperAbi'
+import { AVERAGE_BLOCKTIME } from '@/lib/constants'
+import { BackersManagerAddress } from '@/lib/contracts'
+import { useQuery } from '@tanstack/react-query'
+import { useAccount } from 'wagmi'
+import { readContract } from 'wagmi/actions'
 
 export const useGetCycleNext = (timestamp: bigint) => {
+  const { address } = useAccount()
   const { data, isLoading, error } = useQuery({
     queryFn: async () => {
       return readContract(config, {
@@ -18,6 +20,7 @@ export const useGetCycleNext = (timestamp: bigint) => {
     queryKey: ['cycleNext'],
     refetchInterval: AVERAGE_BLOCKTIME,
     initialData: 0n,
+    enabled: !!address,
   })
 
   return {

--- a/src/app/collective-rewards/metrics/hooks/useGetCycleStart.ts
+++ b/src/app/collective-rewards/metrics/hooks/useGetCycleStart.ts
@@ -1,11 +1,13 @@
-import { CycleTimeKeeperAbi } from '@/lib/abis/v2/CycleTimeKeeperAbi'
-import { BackersManagerAddress } from '@/lib/contracts'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-import { useQuery } from '@tanstack/react-query'
-import { readContract } from 'wagmi/actions'
 import { config } from '@/config'
+import { CycleTimeKeeperAbi } from '@/lib/abis/v2/CycleTimeKeeperAbi'
+import { AVERAGE_BLOCKTIME } from '@/lib/constants'
+import { BackersManagerAddress } from '@/lib/contracts'
+import { useQuery } from '@tanstack/react-query'
+import { useAccount } from 'wagmi'
+import { readContract } from 'wagmi/actions'
 
 export const useGetCycleStart = (timestamp: bigint) => {
+  const { address } = useAccount()
   const { data, isLoading, error } = useQuery({
     queryFn: async () => {
       return readContract(config, {
@@ -18,6 +20,7 @@ export const useGetCycleStart = (timestamp: bigint) => {
     queryKey: ['cycleStart'],
     refetchInterval: AVERAGE_BLOCKTIME,
     initialData: 0n,
+    enabled: !!address,
   })
 
   return {

--- a/src/app/collective-rewards/metrics/hooks/useGetCycleStartAndDuration.ts
+++ b/src/app/collective-rewards/metrics/hooks/useGetCycleStartAndDuration.ts
@@ -1,15 +1,17 @@
 import { CycleTimeKeeperAbi } from '@/lib/abis/v2/CycleTimeKeeperAbi'
-import { BackersManagerAddress } from '@/lib/contracts'
-import { useReadContract } from 'wagmi'
 import { AVERAGE_BLOCKTIME } from '@/lib/constants'
+import { BackersManagerAddress } from '@/lib/contracts'
+import { useAccount, useReadContract } from 'wagmi'
 
 export const useGetCycleStartAndDuration = () => {
+  const { address } = useAccount()
   const { data, isLoading, error } = useReadContract({
     address: BackersManagerAddress,
     abi: CycleTimeKeeperAbi,
     functionName: 'getCycleStartAndDuration',
     query: {
       refetchInterval: AVERAGE_BLOCKTIME,
+      enabled: !!address,
     },
   })
 

--- a/src/app/collective-rewards/metrics/hooks/useGetEndDistributionWindow.ts
+++ b/src/app/collective-rewards/metrics/hooks/useGetEndDistributionWindow.ts
@@ -1,11 +1,13 @@
-import { CycleTimeKeeperAbi } from '@/lib/abis/v2/CycleTimeKeeperAbi'
-import { BackersManagerAddress } from '@/lib/contracts'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-import { useQuery } from '@tanstack/react-query'
-import { readContract } from 'wagmi/actions'
 import { config } from '@/config'
+import { CycleTimeKeeperAbi } from '@/lib/abis/v2/CycleTimeKeeperAbi'
+import { AVERAGE_BLOCKTIME } from '@/lib/constants'
+import { BackersManagerAddress } from '@/lib/contracts'
+import { useQuery } from '@tanstack/react-query'
+import { useAccount } from 'wagmi'
+import { readContract } from 'wagmi/actions'
 
 export const useGetEndDistributionWindow = (timestamp: bigint) => {
+  const { address } = useAccount()
   const { data, isLoading, error } = useQuery({
     queryFn: async () => {
       return readContract(config, {
@@ -18,6 +20,7 @@ export const useGetEndDistributionWindow = (timestamp: bigint) => {
     queryKey: ['endDistributionWindow'],
     refetchInterval: AVERAGE_BLOCKTIME,
     initialData: 0n,
+    enabled: !!address,
   })
 
   return {

--- a/src/app/collective-rewards/metrics/hooks/useGetTimeUntilNextCycle.ts
+++ b/src/app/collective-rewards/metrics/hooks/useGetTimeUntilNextCycle.ts
@@ -1,11 +1,13 @@
-import { CycleTimeKeeperAbi } from '@/lib/abis/v2/CycleTimeKeeperAbi'
-import { BackersManagerAddress } from '@/lib/contracts'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-import { useQuery } from '@tanstack/react-query'
-import { readContract } from 'wagmi/actions'
 import { config } from '@/config'
+import { CycleTimeKeeperAbi } from '@/lib/abis/v2/CycleTimeKeeperAbi'
+import { AVERAGE_BLOCKTIME } from '@/lib/constants'
+import { BackersManagerAddress } from '@/lib/contracts'
+import { useQuery } from '@tanstack/react-query'
+import { useAccount } from 'wagmi'
+import { readContract } from 'wagmi/actions'
 
 export const useGetTimeUntilNextCycle = (timestamp: bigint) => {
+  const { address } = useAccount()
   const { data, isLoading, error } = useQuery({
     queryFn: async () => {
       return readContract(config, {
@@ -18,6 +20,7 @@ export const useGetTimeUntilNextCycle = (timestamp: bigint) => {
     queryKey: ['timeUntilNextCycle'],
     refetchInterval: AVERAGE_BLOCKTIME,
     initialData: 0n,
+    enabled: !!address,
   })
 
   return {

--- a/src/app/collective-rewards/rewards/hooks/useGetRewardsCoinbase.ts
+++ b/src/app/collective-rewards/rewards/hooks/useGetRewardsCoinbase.ts
@@ -1,15 +1,18 @@
 import { RewardDistributorAbi } from '@/lib/abis/v2/RewardDistributorAbi'
 import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { RewardDistributorAddress } from '@/lib/contracts'
-import { useReadContract } from 'wagmi'
+import { useAccount, useReadContract } from 'wagmi'
 
 export const useGetRewardsCoinbase = () => {
+  const { address } = useAccount()
+
   return useReadContract({
     address: RewardDistributorAddress,
     abi: RewardDistributorAbi,
     functionName: 'defaultRewardCoinbaseAmount',
     query: {
       refetchInterval: AVERAGE_BLOCKTIME,
+      enabled: !!address,
     },
   })
 }

--- a/src/app/collective-rewards/rewards/hooks/useGetRewardsERC20.ts
+++ b/src/app/collective-rewards/rewards/hooks/useGetRewardsERC20.ts
@@ -1,15 +1,18 @@
 import { RewardDistributorAbi } from '@/lib/abis/v2/RewardDistributorAbi'
 import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { RewardDistributorAddress } from '@/lib/contracts'
-import { useReadContract } from 'wagmi'
+import { useAccount, useReadContract } from 'wagmi'
 
 export const useGetRewardsERC20 = () => {
+  const { address } = useAccount()
+
   return useReadContract({
     address: RewardDistributorAddress,
     abi: RewardDistributorAbi,
     functionName: 'defaultRewardTokenAmount',
     query: {
       refetchInterval: AVERAGE_BLOCKTIME,
+      enabled: !!address,
     },
   })
 }

--- a/src/app/collective-rewards/rewards/hooks/useGetTotalPotentialRewards.ts
+++ b/src/app/collective-rewards/rewards/hooks/useGetTotalPotentialRewards.ts
@@ -1,15 +1,17 @@
 import { BackersManagerAbi } from '@/lib/abis/v2/BackersManagerAbi'
 import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BackersManagerAddress } from '@/lib/contracts'
-import { useReadContract } from 'wagmi'
+import { useAccount, useReadContract } from 'wagmi'
 
 export const useGetTotalPotentialReward = () => {
+  const { address } = useAccount()
   const { data, isLoading, error } = useReadContract({
     address: BackersManagerAddress,
     abi: BackersManagerAbi,
     functionName: 'totalPotentialReward',
     query: {
       refetchInterval: AVERAGE_BLOCKTIME,
+      enabled: !!address,
     },
   })
 

--- a/src/app/collective-rewards/user/hooks/useGetGaugesArray.ts
+++ b/src/app/collective-rewards/user/hooks/useGetGaugesArray.ts
@@ -1,10 +1,10 @@
-import { useReadContracts } from 'wagmi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-import { BuilderRegistryAbi } from '@/lib/abis/v2/BuilderRegistryAbi'
-import { AbiFunction, Address } from 'viem'
 import { useGetGaugesLength } from '@/app/collective-rewards/user'
-import { useMemo } from 'react'
+import { BuilderRegistryAbi } from '@/lib/abis/v2/BuilderRegistryAbi'
+import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BuilderRegistryAddress } from '@/lib/contracts'
+import { useMemo } from 'react'
+import { AbiFunction, Address } from 'viem'
+import { useAccount, useReadContracts } from 'wagmi'
 
 const gaugeTypeOptions = ['active', 'halted'] as const
 export type GaugeType = (typeof gaugeTypeOptions)[number]
@@ -18,6 +18,7 @@ const gaugeType: Record<GaugeType, FunctionName> = {
 }
 
 export const useGetGaugesArray = () => {
+  const { address } = useAccount()
   const { data: activeCalls, isLoading: isLoadingActive, error: errorActive } = useGetContractCalls('active')
   const { data: haltedCalls, isLoading: isLoadingHalted, error: errorHalted } = useGetContractCalls('halted')
 
@@ -31,6 +32,7 @@ export const useGetGaugesArray = () => {
     contracts: contractCalls,
     query: {
       refetchInterval: AVERAGE_BLOCKTIME,
+      enabled: !!address && !!contractCalls.length,
     },
   })
 
@@ -46,6 +48,7 @@ export const useGetGaugesArray = () => {
 }
 
 export const useGetGaugesArrayByType = (type: GaugeType) => {
+  const { address } = useAccount()
   const {
     data: calls,
     isLoading: contractCallsLoading,
@@ -60,6 +63,7 @@ export const useGetGaugesArrayByType = (type: GaugeType) => {
     contracts: calls,
     query: {
       refetchInterval: AVERAGE_BLOCKTIME,
+      enabled: !!address && !!calls.length,
     },
   })
 

--- a/src/app/collective-rewards/user/hooks/useGetGaugesLength.ts
+++ b/src/app/collective-rewards/user/hooks/useGetGaugesLength.ts
@@ -1,9 +1,9 @@
-import { useReadContract } from 'wagmi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-import { BuilderRegistryAbi } from '@/lib/abis/v2/BuilderRegistryAbi'
-import { AbiFunction } from 'viem'
 import { GaugeType } from '@/app/collective-rewards/user'
+import { BuilderRegistryAbi } from '@/lib/abis/v2/BuilderRegistryAbi'
+import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BuilderRegistryAddress } from '@/lib/contracts'
+import { AbiFunction } from 'viem'
+import { useAccount, useReadContract } from 'wagmi'
 
 type FunctionEntry = Extract<(typeof BuilderRegistryAbi)[number], AbiFunction>
 type FunctionName = Extract<FunctionEntry['name'], 'getGaugesLength' | 'getHaltedGaugesLength'>
@@ -14,12 +14,14 @@ const gaugeType: Record<GaugeType, FunctionName> = {
 }
 
 export const useGetGaugesLength = (type: GaugeType) => {
+  const { address } = useAccount()
   const { data, isLoading, error } = useReadContract({
     address: BuilderRegistryAddress,
     abi: BuilderRegistryAbi,
     functionName: gaugeType[type],
     query: {
       refetchInterval: AVERAGE_BLOCKTIME,
+      enabled: !!address,
     },
   })
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,6 +1,6 @@
 import { ENV } from '@/lib/constants'
 import { defineChain, HttpTransportConfig } from 'viem'
-import { rootstockTestnet, rootstock } from 'viem/chains'
+import { rootstock, rootstockTestnet } from 'viem/chains'
 import { createConfig, http } from 'wagmi'
 import { injected } from 'wagmi/connectors'
 
@@ -23,7 +23,7 @@ const httpTransportConfig: HttpTransportConfig = {
 }
 
 export const config = createConfig({
-  chains: [rskRegtest, rootstockTestnet, rootstock],
+  chains: [rootstock, rootstockTestnet, rskRegtest],
   transports: {
     [rootstock.id]: http(undefined, {
       ...httpTransportConfig,


### PR DESCRIPTION
- Enables contract reads only when an account is connected.
- Changes order of chain assignment to remove calls to localhost node when no wallet exists. @RootstockCollective/dao to check this (before this console will log errors regarding this on any page).

Resolves [bug](https://rsklabs.atlassian.net/browse/TOK-675).

For hotfix see https://github.com/RootstockCollective/dao-frontend/pull/885