### PR TITLE
fix(cr): disable hooks when no wallet

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,6 +1,6 @@
 import { ENV } from '@/lib/constants'
-import { defineChain, HttpTransportConfig } from 'viem'
-import { rootstockTestnet, rootstock } from 'viem/chains'
+import { Chain, defineChain } from 'viem'
+import { rootstock, rootstockTestnet } from 'viem/chains'
 import { createConfig, http } from 'wagmi'
 import { injected } from 'wagmi/connectors'
 
@@ -10,28 +10,28 @@ const rskRegtest = defineChain({
   nativeCurrency: { name: 'tRBTC', symbol: 'tRBTC', decimals: 18 },
   rpcUrls: {
     default: {
-      http: [process.env.REGTEST_URL || 'http://localhost:4444'],
+      http: [process.env.NEXT_PUBLIC_REGTEST_URL || 'http://localhost:4444'],
     },
   },
 })
 
-const httpTransportConfig: HttpTransportConfig = {
-  batch: {
-    // this is the default value configured in RSKj
-    batchSize: 100,
-  },
-}
+const envChains = {
+  mainnet: rootstock,
+  testnet: rootstockTestnet,
+  regtest: rskRegtest,
+} as const
+
+const currentEnvChain: Chain = envChains[ENV as keyof typeof envChains]
 
 export const config = createConfig({
-  chains: [rskRegtest, rootstockTestnet, rootstock],
+  chains: [currentEnvChain],
   transports: {
-    [rootstock.id]: http(undefined, {
-      ...httpTransportConfig,
+    [currentEnvChain.id]: http(undefined, {
+      batch: {
+        // this is the default value configured in RSKj
+        batchSize: 100,
+      },
     }),
-    [rootstockTestnet.id]: http(undefined, {
-      ...httpTransportConfig,
-    }),
-    [rskRegtest.id]: http(),
   },
   connectors: [injected()],
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,15 @@
-import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   plugins: [react()],
   test: {
     environment: 'jsdom',
     setupFiles: './vitest.setup.ts',
+    env: {
+      NEXT_PUBLIC_ENV: 'testnet',
+      NEXT_PUBLIC_CHAIN_ID: '31',
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
- instantiates the wagmi network configuration with only the network required by the current environment.

- adds env vars to vitest config to avoid issues in tests

Resolves [bug](https://rsklabs.atlassian.net/browse/TOK-675).