### PR TITLE
DAO-1134 Delegation address mismatch

### DIFF
--- a/src/app/user/Delegation/DelegateModal.tsx
+++ b/src/app/user/Delegation/DelegateModal.tsx
@@ -46,7 +46,7 @@ export const DelegateModal = ({ onClose, onDelegateTxStarted }: DelegateModalPro
   const { onDelegate, isPending } = useDelegateToAddress()
 
   const onAddressChange = (value: string) => {
-    setAddressToDelegateTo(value)
+    setAddressToDelegateTo(value.toLowerCase())
     setError('')
     setIsInputValid(false)
     setDomainValidationStatus('')
@@ -73,7 +73,7 @@ export const DelegateModal = ({ onClose, onDelegateTxStarted }: DelegateModalPro
 
       if (resolvedAddress) {
         setValidRnsAddress(domain)
-        setAddressToDelegateTo(resolvedAddress)
+        setAddressToDelegateTo(resolvedAddress.toLowerCase())
         setDomainValidationStatus('valid')
         setIsInputValid(true)
         setError('')

--- a/src/components/Modal/ConfirmationModal.tsx
+++ b/src/components/Modal/ConfirmationModal.tsx
@@ -18,6 +18,14 @@ interface ConfirmationModalProps {
    */
   title: string
   /**
+   * Controls whether the modal is visible
+   */
+  isOpen: boolean
+  /**
+   * Callback triggered when the modal is closed
+   */
+  onClose: () => void
+  /**
    * Pass the main modal text to the `children` prop
    */
   children?: ReactNode
@@ -33,14 +41,6 @@ interface ConfirmationModalProps {
    * When defined, replaces accept/decline buttons
    */
   buttons?: ReactNode
-  /**
-   * Controls whether the modal is visible
-   */
-  isOpen: boolean
-  /**
-   * Callback triggered when the modal is closed
-   */
-  onClose: () => void
   /**
    * Test identifier for unit and integration tests
    */

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -6,9 +6,9 @@ import { cn } from '@/lib/utils'
 import { createPortal } from 'react-dom'
 
 interface Props {
-  className?: string
   children: ReactNode
   onClose: () => void
+  className?: string
   width?: number
   'data-testid'?: string
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/f93a2249-fe70-461c-81ea-e8a0141ba875

### Why
 the addresses of shepherds was uppercase addresses whereas in the rest of the dApp they are lowercase
### What:
 added lowercasing when we set address
### Extra
While searching found minor code readability issue with optional dependencies preceding required.