### PR TITLE
Refactor style handling in GlowingLabel component

### DIFF
--- a/src/components/Label/GlowingLabel.tsx
+++ b/src/components/Label/GlowingLabel.tsx
@@ -7,12 +7,14 @@ export type GlowingLabelProps = HTMLAttributes<HTMLDivElement> & {
 }
 
 export const GlowingLabel: FC<GlowingLabelProps> = ({ children, showGlow, faded, className, ...props }) => {
+  const backgroundStyle: CSSProperties['background'] = faded
+    ? 'linear-gradient(270deg, #4B171A -8.88%, #C0F7FF 31.43%, #E3FFEB 78.65%)'
+    : 'linear-gradient(270deg, #4B171A -456.96%, #C0F7FF -195.47%, #E3FFEB 110.84%)'
+
   const style: CSSProperties =
     showGlow || faded
       ? {
-          background: faded
-            ? 'linear-gradient(270deg, #4B171A -8.88%, #C0F7FF 31.43%, #E3FFEB 78.65%)'
-            : 'linear-gradient(270deg, #4B171A -456.96%, #C0F7FF -195.47%, #E3FFEB 110.84%)',
+          background: backgroundStyle,
           backgroundClip: 'text',
           WebkitBackgroundClip: 'text',
           WebkitTextFillColor: 'transparent',

--- a/src/components/Label/GlowingLabel.tsx
+++ b/src/components/Label/GlowingLabel.tsx
@@ -1,30 +1,38 @@
 import { cn } from '@/lib/utils'
-import { FC, HTMLAttributes } from 'react'
+import { FC, HTMLAttributes, CSSProperties } from 'react'
 
 export type GlowingLabelProps = HTMLAttributes<HTMLDivElement> & {
   showGlow?: boolean
   faded?: boolean
 }
 
-export const GlowingLabel: FC<GlowingLabelProps> = ({ children, showGlow, faded, className, ...rest }) => (
-  <div
-    data-testid="glowingLabel"
-    className={cn(
-      'text-[#4b171a] text-base',
-      faded ? 'font-normal font-kk-topo uppercase' : 'font-bold font-rootstock-sans',
-      className,
-    )}
-    style={{
-      background: faded
-        ? 'linear-gradient(270deg, #4B171A -8.88%, #C0F7FF 31.43%, #E3FFEB 78.65%)'
-        : 'linear-gradient(270deg, #4B171A -456.96%, #C0F7FF -195.47%, #E3FFEB 110.84%)',
-      backgroundClip: 'text',
-      WebkitBackgroundClip: 'text',
-      WebkitTextFillColor: 'transparent',
-      textShadow: showGlow ? '0px 0px 8.1px rgb(192, 247, 255, 0.65)' : 'inherit',
-    }}
-    {...rest}
-  >
-    {children}
-  </div>
-)
+export const GlowingLabel: FC<GlowingLabelProps> = ({ children, showGlow, faded, className, ...props }) => {
+  const style: CSSProperties =
+    showGlow || faded
+      ? {
+          background: faded
+            ? 'linear-gradient(270deg, #4B171A -8.88%, #C0F7FF 31.43%, #E3FFEB 78.65%)'
+            : 'linear-gradient(270deg, #4B171A -456.96%, #C0F7FF -195.47%, #E3FFEB 110.84%)',
+          backgroundClip: 'text',
+          WebkitBackgroundClip: 'text',
+          WebkitTextFillColor: 'transparent',
+          textShadow: showGlow ? '0px 0px 8.1px rgba(192, 247, 255, 0.65)' : 'inherit',
+        }
+      : {
+          color: 'white',
+        }
+  return (
+    <div
+      data-testid="glowingLabel"
+      className={cn(
+        'text-base',
+        faded ? 'font-normal font-kk-topo uppercase' : 'font-bold font-rootstock-sans',
+        className,
+      )}
+      style={style}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
# What

Fix header (title) appearance in GlowingLabel component. Make the header text color white when glow modifiers are not applied (previously it was green)

# Why

Requested by [QA in the ticket](https://rsklabs.atlassian.net/browse/DAO-1162)

## Before

<img width="316" alt="Screenshot 2025-04-02 at 11 00 16" src="https://github.com/user-attachments/assets/416e3168-215f-48d7-af92-db0be13b4318" />

## After

<img width="309" alt="Screenshot 2025-04-02 at 11 00 47" src="https://github.com/user-attachments/assets/cf688968-7e74-458c-bc37-246fbff32016" />


