### PR TITLE
TOK-677: Dapp BigInt value error

### DIFF
--- a/src/app/collective-rewards/allocations/components/AllocationAmount.tsx
+++ b/src/app/collective-rewards/allocations/components/AllocationAmount.tsx
@@ -70,7 +70,7 @@ export const AllocationAmount = () => {
               : ''
           }
           hint={
-            Number(amountToAllocate - cumulativeAllocation) < 0 || amountToAllocate > balance ? (
+            amountToAllocate - cumulativeAllocation < 0n || amountToAllocate > balance ? (
               <StakeHint />
             ) : undefined
           }

--- a/src/app/collective-rewards/allocations/context/AllocationsContext.tsx
+++ b/src/app/collective-rewards/allocations/context/AllocationsContext.tsx
@@ -5,11 +5,11 @@ import {
   useGetVotingPower,
 } from '@/app/collective-rewards/allocations/hooks'
 import { Builder } from '@/app/collective-rewards/types'
-import { createContext, FC, ReactNode, useEffect, useMemo, useState, useCallback } from 'react'
+import { createContext, FC, ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import { Address } from 'viem'
 import { useAccount } from 'wagmi'
-import { createActions } from './allocationsActions'
 import { useGetBackerRewards } from '../hooks/useBuildersWithBackerRewardPercentage'
+import { createActions } from './allocationsActions'
 import { validateAllocationsState } from './utils'
 
 export interface Allocations {
@@ -137,10 +137,10 @@ export const AllocationsContextProvider: FC<{ children: ReactNode }> = ({ childr
       acc[builder.address] = {
         ...builder,
         backerRewardPercentage: {
-          active: backerRewards[index]?.active ?? BigInt(0),
-          previous: backerRewards[index]?.previous ?? BigInt(0),
-          next: backerRewards[index]?.next ?? BigInt(0),
-          cooldown: backerRewards[index]?.cooldown ?? BigInt(0),
+          active: BigInt(backerRewards[index]?.active ?? 0n),
+          previous: BigInt(backerRewards[index]?.previous ?? 0n),
+          next: BigInt(backerRewards[index]?.next ?? 0n),
+          cooldown: BigInt(backerRewards[index]?.cooldown ?? 0n),
         },
       }
       return acc
@@ -240,7 +240,7 @@ export const AllocationsContextProvider: FC<{ children: ReactNode }> = ({ childr
         backer,
         initialAllocations: initialState.allocations,
         currentAllocations: allocations,
-        totalOnchainAllocation: totalOnchainAllocation as bigint,
+        totalOnchainAllocation: BigInt(totalOnchainAllocation ?? 0n),
       }),
     [backer, allocations, totalOnchainAllocation, initialState.allocations],
   )
@@ -285,7 +285,7 @@ function createInitialAllocations(
       const builderAddress = rawBuilders[index].address
       if (allocation > 0n || selections[builderAddress]) {
         acc[0][builderAddress] = allocation
-        acc[1] += allocation ?? BigInt(0) // cumulative allocation
+        acc[1] += BigInt(allocation ?? 0) // cumulative allocation
         acc[2] += 1 // allocations count
       }
       return acc

--- a/src/app/collective-rewards/allocations/hooks/useBackerTotalAllocation.ts
+++ b/src/app/collective-rewards/allocations/hooks/useBackerTotalAllocation.ts
@@ -21,7 +21,7 @@ export const useBackerTotalAllocation = (backer?: Address) => {
   })
 
   return {
-    data,
+    data: data ? BigInt(data.toString()) : null,
     isLoading,
     error,
   }
@@ -45,7 +45,7 @@ export const useGetAllAllocationOf = (builder: Builder[], backer?: Address) => {
     },
   })
 
-  const data = useMemo(() => gauges?.map(({ result }) => result as bigint), [gauges])
+  const data = useMemo(() => gauges?.map(({ result }) => BigInt(result as bigint)), [gauges])
 
   return {
     data,

--- a/src/app/collective-rewards/allocations/hooks/useBuildersWithBackerRewardPercentage.ts
+++ b/src/app/collective-rewards/allocations/hooks/useBuildersWithBackerRewardPercentage.ts
@@ -1,11 +1,11 @@
 import { BackerRewardsConfig, Builder } from '@/app/collective-rewards/types'
 import { BuilderRegistryAbi } from '@/lib/abis/v2/BuilderRegistryAbi'
 import { AVERAGE_BLOCKTIME } from '@/lib/constants'
+import { useMigrationContext } from '@/shared/context/MigrationContext'
 import { Modify } from '@/shared/utility'
 import { useMemo } from 'react'
 import { ContractFunctionReturnType, ReadContractErrorType } from 'viem'
 import { UseReadContractReturnType, useReadContracts } from 'wagmi'
-import { useMigrationContext } from '@/shared/context/MigrationContext'
 
 type RawBackerRewardPercentage = ContractFunctionReturnType<
   typeof BuilderRegistryAbi,
@@ -71,10 +71,10 @@ export const useGetBackerRewards: UseGetBackerRewards = builders => {
         const [previous, next, cooldown] = result as RawBackerRewardPercentage
 
         return {
-          previous,
-          next,
-          cooldown,
-          active: activePercentages[index]?.result as RawActivePercentage,
+          previous: BigInt(previous),
+          next: BigInt(next),
+          cooldown: BigInt(cooldown),
+          active: BigInt(activePercentages[index]?.result as RawActivePercentage),
         }
       }
     })

--- a/src/app/collective-rewards/metrics/context/CycleContext.tsx
+++ b/src/app/collective-rewards/metrics/context/CycleContext.tsx
@@ -1,5 +1,3 @@
-import { createContext, FC, ReactNode, useContext, useEffect, useMemo, useState } from 'react'
-import { DateTime, Duration } from 'luxon'
 import {
   useGetCycleNext,
   useGetCycleStart,
@@ -7,6 +5,8 @@ import {
   useGetEndDistributionWindow,
 } from '@/app/collective-rewards/metrics'
 import { AVERAGE_BLOCKTIME } from '@/lib/constants'
+import { DateTime, Duration } from 'luxon'
+import { createContext, FC, ReactNode, useContext, useEffect, useMemo, useState } from 'react'
 
 export type Cycle = {
   timestamp: bigint
@@ -74,11 +74,11 @@ export const CycleContextProvider: FC<CycleProviderProps> = ({ children }) => {
   const data = useMemo(
     () => ({
       timestamp,
-      cycleStart: DateTime.fromSeconds(Number(cycleStart ?? BigInt(0))),
-      cycleNext: DateTime.fromSeconds(Number(cycleNext ?? BigInt(0))),
-      cycleDuration: Duration.fromObject({ seconds: Number(cycleDuration ?? BigInt(0)) }),
-      fistCycleStart: DateTime.fromSeconds(Number(firstCycleStart ?? BigInt(0))),
-      endDistributionWindow: DateTime.fromSeconds(Number(endDistributionWindow ?? BigInt(0))),
+      cycleStart: DateTime.fromSeconds(Number(cycleStart ?? 0)),
+      cycleNext: DateTime.fromSeconds(Number(cycleNext ?? 0)),
+      cycleDuration: Duration.fromObject({ seconds: Number(cycleDuration ?? 0) }),
+      fistCycleStart: DateTime.fromSeconds(Number(firstCycleStart ?? 0)),
+      endDistributionWindow: DateTime.fromSeconds(Number(endDistributionWindow ?? 0)),
     }),
     [timestamp, firstCycleStart, cycleDuration, cycleStart, endDistributionWindow, cycleNext],
   )

--- a/src/app/collective-rewards/rewards/builders/EstimatedRewards.tsx
+++ b/src/app/collective-rewards/rewards/builders/EstimatedRewards.tsx
@@ -1,22 +1,22 @@
+import { useCycleContext } from '@/app/collective-rewards/metrics/context/CycleContext'
 import {
+  BuilderRewardDetails,
   formatMetrics,
   MetricsCard,
   MetricsCardTitle,
+  Token,
   TokenMetricsCardRow,
+  useGetBackerRewardPercentage,
+  useGetPerTokenRewards,
   useGetRewardShares,
   useGetTotalPotentialReward,
-  useGetPerTokenRewards,
-  Token,
-  BuilderRewardDetails,
-  useGetBackerRewardPercentage,
 } from '@/app/collective-rewards/rewards'
+import { useBuilderContext } from '@/app/collective-rewards/user'
 import { isBuilderRewardable, useHandleErrors } from '@/app/collective-rewards/utils'
+import { withSpinner } from '@/components/LoadingSpinner/withLoadingSpinner'
 import { usePricesContext } from '@/shared/context/PricesContext'
 import { FC, useEffect, useState } from 'react'
 import { Address, parseUnits } from 'viem'
-import { withSpinner } from '@/components/LoadingSpinner/withLoadingSpinner'
-import { useCycleContext } from '@/app/collective-rewards/metrics/context/CycleContext'
-import { useBuilderContext } from '@/app/collective-rewards/user'
 
 type TokenRewardsProps = {
   builder: Address
@@ -33,7 +33,7 @@ const TokenRewards: FC<TokenRewardsProps> = ({ builder, gauge, token: { id, symb
 
   useEffect(() => {
     if (tokenRewards && tokenRewards.data) {
-      setRewards(tokenRewards.data ?? 0n)
+      setRewards(BigInt(tokenRewards.data ?? 0n))
     }
     if (tokenRewards && tokenRewards.error) {
       setRewardsError(tokenRewards.error)
@@ -78,7 +78,7 @@ const TokenRewards: FC<TokenRewardsProps> = ({ builder, gauge, token: { id, symb
 
   const rewardsAmount =
     isRewarded && rewardShares && totalPotentialRewards
-      ? (rewards * rewardShares) / totalPotentialRewards
+      ? (rewards * rewardShares) / BigInt(totalPotentialRewards)
       : 0n
   // The complement of the reward percentage is applied to the estimated rewards since are from the builder's perspective
   const weiPerEther = parseUnits('1', 18)

--- a/src/app/collective-rewards/rewards/hooks/useGetBackerRewardPerTokenPaid.ts
+++ b/src/app/collective-rewards/rewards/hooks/useGetBackerRewardPerTokenPaid.ts
@@ -35,7 +35,7 @@ export const useGetBackerRewardPerTokenPaid = (backer: Address, token: Address =
 
   const data = useMemo(() => {
     return (backerRewardPerTokenPaidResults ?? []).reduce(
-      (acc, { result }) => acc + ((result as bigint) ?? 0n),
+      (acc, { result }) => acc + BigInt((result as bigint) ?? 0n),
       0n,
     )
   }, [backerRewardPerTokenPaidResults])

--- a/src/app/collective-rewards/rewards/hooks/useGetRewardShares.ts
+++ b/src/app/collective-rewards/rewards/hooks/useGetRewardShares.ts
@@ -14,7 +14,7 @@ export const useGetRewardShares = (gauge: Address) => {
   })
 
   return {
-    data,
+    data: data ? BigInt(data.toString()) : null,
     isLoading,
     error,
   }

--- a/src/app/collective-rewards/rewards/hooks/useGetTotalPotentialRewards.ts
+++ b/src/app/collective-rewards/rewards/hooks/useGetTotalPotentialRewards.ts
@@ -14,7 +14,7 @@ export const useGetTotalPotentialReward = () => {
   })
 
   return {
-    data,
+    data: data ? BigInt(data.toString()) : null,
     isLoading,
     error,
   }

--- a/src/app/collective-rewards/rewards/types.ts
+++ b/src/app/collective-rewards/rewards/types.ts
@@ -26,7 +26,7 @@ export interface RewardDetails {
 }
 
 export interface BuilderRewardDetails extends RewardDetails {
-  gauge: Address
+  gauge: Address // FIXME: what is going on here? why do we need both gauge and gauges?
 }
 
 export interface BackerRewardPercentage {

--- a/src/app/collective-rewards/rewards/utils/formatter.ts
+++ b/src/app/collective-rewards/rewards/utils/formatter.ts
@@ -1,9 +1,9 @@
 import Big from '@/lib/big'
-import { BigSource } from 'big.js'
 import { formatCurrency } from '@/lib/utils'
+import { BigSource } from 'big.js'
 
 export const formatMetrics = (amount: bigint, price: BigSource, symbol: string, currency: string) => {
-  const fiatAmount = getFiatAmount(amount, price)
+  const fiatAmount = getFiatAmount(BigInt(amount), price)
 
   return {
     amount: `${formatSymbol(amount, symbol)} ${symbol}`,

--- a/src/app/collective-rewards/shared/components/Table/TableCells.tsx
+++ b/src/app/collective-rewards/shared/components/Table/TableCells.tsx
@@ -15,16 +15,16 @@ import {
 import { AddressOrAliasWithCopy } from '@/components/Address'
 import { Button } from '@/components/Button'
 import { Jdenticon } from '@/components/Header/Jdenticon'
+import { ArrowDownIcon, ArrowUpIcon, CircleIcon } from '@/components/Icons'
 import { Popover } from '@/components/Popover'
 import { ProgressBar } from '@/components/ProgressBar'
 import { TableCell } from '@/components/Table'
 import { Label, Paragraph, Typography } from '@/components/Typography'
 import { cn, shortAddress } from '@/lib/utils'
+import { ConnectButtonComponentSecondary, ConnectWorkflow } from '@/shared/walletConnection'
 import { FC, memo, useContext, useMemo } from 'react'
-import { ArrowDownIcon, ArrowUpIcon, CircleIcon } from '@/components/Icons'
 import { Address, isAddress, parseEther } from 'viem'
 import { useAccount } from 'wagmi'
-import { ConnectButtonComponentSecondary, ConnectWorkflow } from '@/shared/walletConnection'
 
 type TableCellProps = {
   className?: string
@@ -150,7 +150,7 @@ type BackerRewardsPercentageProps = TableCellProps & {
   percentage: BackerRewardPercentage | null
 }
 
-const toPercentage = (value: bigint) => Number((value * 100n) / parseEther('1'))
+const toPercentage = (value: bigint) => Number((BigInt(value) * 100n) / parseEther('1'))
 export const BackerRewardsPercentage: FC<BackerRewardsPercentageProps> = ({ className, percentage }) => {
   const renderDelta = useMemo(() => {
     if (!percentage) return null

--- a/src/app/collective-rewards/shared/hooks/useGetEstimatedBackersRewardsPct.test.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetEstimatedBackersRewardsPct.test.ts
@@ -1,0 +1,52 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useGetEstimatedBackersRewardsPct } from './useGetEstimatedBackersRewardsPct'
+
+vi.mock('@/app/collective-rewards/user', () => ({
+  useGetBuildersByState: () => ({
+    data: [
+      {
+        address: 'builder1',
+        gauge: 'gauge1',
+        stateFlags: { rewardable: true },
+      },
+    ],
+    isLoading: false,
+    error: null,
+  }),
+}))
+
+vi.mock('@/app/collective-rewards/rewards', () => ({
+  // Deliberately return a number instead of BigInt to simulate the issue
+  useGetTotalPotentialReward: () => ({
+    data: 100,
+    isLoading: false,
+    error: null,
+  }),
+  useGetBackersRewardPercentage: () => ({
+    data: {
+      builder1: { current: 50n },
+    },
+    isLoading: false,
+    error: null,
+  }),
+}))
+
+vi.mock('@/app/collective-rewards/shared', () => ({
+  useGaugesGetFunction: () => ({
+    data: { gauge1: 200n },
+    isLoading: false,
+    error: null,
+  }),
+}))
+
+vi.mock('@/app/collective-rewards/utils', () => ({
+  isBuilderRewardable: (stateFlags: any) => stateFlags.rewardable,
+}))
+
+describe('useGetEstimatedBackersRewardsPct', () => {
+  it('computes estimatedBackerRewardsPct without type error when mixing types', () => {
+    // This will throw a TypeError if the hook fails to convert totalPotentialRewards to BigInt
+    expect(() => renderHook(() => useGetEstimatedBackersRewardsPct())).not.toThrow(TypeError)
+  })
+})

--- a/src/app/collective-rewards/shared/hooks/useGetEstimatedBackersRewardsPct.test.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetEstimatedBackersRewardsPct.test.ts
@@ -1,52 +1,183 @@
-import { renderHook } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
-import { useGetEstimatedBackersRewardsPct } from './useGetEstimatedBackersRewardsPct'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('@/app/collective-rewards/user', () => ({
-  useGetBuildersByState: () => ({
-    data: [
-      {
-        address: 'builder1',
-        gauge: 'gauge1',
-        stateFlags: { rewardable: true },
-      },
-    ],
-    isLoading: false,
-    error: null,
-  }),
-}))
+type SetupMocksProps = {
+  totalPotentialReward: bigint | undefined
+  backersRewardPercentage: Record<string, { current: bigint }> | undefined
+  gaugesData: Record<string, bigint> | undefined
+  userData:
+    | Array<{
+        address: string
+        gauge: string
+        stateFlags: {
+          rewardable: boolean
+        }
+      }>
+    | undefined
+}
 
-vi.mock('@/app/collective-rewards/rewards', () => ({
-  // Deliberately return a number instead of BigInt to simulate the issue
-  useGetTotalPotentialReward: () => ({
-    data: 100,
-    isLoading: false,
-    error: null,
-  }),
-  useGetBackersRewardPercentage: () => ({
-    data: {
-      builder1: { current: 50n },
-    },
-    isLoading: false,
-    error: null,
-  }),
-}))
+/**
+ * Sets up mocks for various modules.
+ * @param totalPotentialReward - The total potential reward to be returned by the mock.
+ * @param backersRewardPercentage - The backers reward percentage to be returned by the mock.
+ * @param gaugesData - The gauges data to be returned by the mock.
+ * @param userData - The user data to be returned by the mock.
+ */
+const setupMocks = ({
+  totalPotentialReward,
+  backersRewardPercentage,
+  gaugesData,
+  userData,
+}: SetupMocksProps) => {
+  vi.doMock('@/app/collective-rewards/user', () => ({
+    useGetBuildersByState: () => ({
+      data: userData,
+      isLoading: false,
+      error: null,
+    }),
+  }))
 
-vi.mock('@/app/collective-rewards/shared', () => ({
-  useGaugesGetFunction: () => ({
-    data: { gauge1: 200n },
-    isLoading: false,
-    error: null,
-  }),
-}))
+  vi.doMock('@/app/collective-rewards/rewards', () => ({
+    useGetTotalPotentialReward: () => ({
+      data: totalPotentialReward,
+      isLoading: false,
+      error: null,
+    }),
+    useGetBackersRewardPercentage: () => ({
+      data: backersRewardPercentage,
+      isLoading: false,
+      error: null,
+    }),
+  }))
 
-vi.mock('@/app/collective-rewards/utils', () => ({
-  isBuilderRewardable: (stateFlags: any) => stateFlags.rewardable,
-}))
+  vi.doMock('@/app/collective-rewards/shared', () => ({
+    useGaugesGetFunction: () => ({
+      data: gaugesData,
+      isLoading: false,
+      error: null,
+    }),
+  }))
+
+  vi.doMock('@/app/collective-rewards/utils', () => ({
+    isBuilderRewardable: () => true,
+  }))
+}
 
 describe('useGetEstimatedBackersRewardsPct', () => {
-  it('computes estimatedBackerRewardsPct without type error when mixing types', () => {
-    // This will throw a TypeError if the hook fails to convert totalPotentialRewards to BigInt
-    expect(() => renderHook(() => useGetEstimatedBackersRewardsPct())).not.toThrow(TypeError)
+  describe('with defined data', () => {
+    beforeEach(async () => {
+      vi.resetModules()
+      setupMocks({
+        totalPotentialReward: 100n,
+        backersRewardPercentage: { builder1: { current: 50n } },
+        gaugesData: { gauge1: 200n },
+        userData: [
+          {
+            address: 'builder1',
+            gauge: 'gauge1',
+            stateFlags: { rewardable: true },
+          },
+        ],
+      })
+    })
+
+    it('computes estimatedBackerRewardsPct without type error when mixing types', async () => {
+      const { useGetEstimatedBackersRewardsPct } = await import('./useGetEstimatedBackersRewardsPct')
+      const { renderHook } = await import('@testing-library/react')
+      expect(() => renderHook(() => useGetEstimatedBackersRewardsPct())).not.toThrow(TypeError)
+    })
+  })
+
+  describe('with undefined tempTotalPotentialReward', () => {
+    beforeEach(async () => {
+      vi.resetModules()
+      setupMocks({
+        totalPotentialReward: undefined,
+        backersRewardPercentage: { builder1: { current: 50n } },
+        gaugesData: { gauge1: 200n },
+        userData: [
+          {
+            address: 'builder1',
+            gauge: 'gauge1',
+            stateFlags: { rewardable: true },
+          },
+        ],
+      })
+    })
+
+    it('computes estimatedBackerRewardsPct without type error when data is undefined', async () => {
+      const { useGetEstimatedBackersRewardsPct } = await import('./useGetEstimatedBackersRewardsPct')
+      const { renderHook } = await import('@testing-library/react')
+      renderHook(() => useGetEstimatedBackersRewardsPct())
+      expect(() => renderHook(() => useGetEstimatedBackersRewardsPct())).not.toThrow(TypeError)
+    })
+  })
+
+  describe('with undefined backersRewardPercentage', () => {
+    beforeEach(async () => {
+      vi.resetModules()
+      setupMocks({
+        totalPotentialReward: 100n,
+        backersRewardPercentage: undefined,
+        gaugesData: { gauge1: 200n },
+        userData: [
+          {
+            address: 'builder1',
+            gauge: 'gauge1',
+            stateFlags: { rewardable: true },
+          },
+        ],
+      })
+    })
+
+    it('computes estimatedBackerRewardsPct without type error when data is undefined', async () => {
+      const { useGetEstimatedBackersRewardsPct } = await import('./useGetEstimatedBackersRewardsPct')
+      const { renderHook } = await import('@testing-library/react')
+      renderHook(() => useGetEstimatedBackersRewardsPct())
+      expect(() => renderHook(() => useGetEstimatedBackersRewardsPct())).not.toThrow(TypeError)
+    })
+  })
+
+  describe('with undefined gaugesData', () => {
+    beforeEach(async () => {
+      vi.resetModules()
+      setupMocks({
+        totalPotentialReward: 100n,
+        backersRewardPercentage: { builder1: { current: 50n } },
+        gaugesData: undefined,
+        userData: [
+          {
+            address: 'builder1',
+            gauge: 'gauge1',
+            stateFlags: { rewardable: true },
+          },
+        ],
+      })
+    })
+
+    it('computes estimatedBackerRewardsPct without type error when data is undefined', async () => {
+      const { useGetEstimatedBackersRewardsPct } = await import('./useGetEstimatedBackersRewardsPct')
+      const { renderHook } = await import('@testing-library/react')
+      renderHook(() => useGetEstimatedBackersRewardsPct())
+      expect(() => renderHook(() => useGetEstimatedBackersRewardsPct())).not.toThrow(TypeError)
+    })
+  })
+
+  describe('with undefined userData', () => {
+    beforeEach(async () => {
+      vi.resetModules()
+      setupMocks({
+        totalPotentialReward: 100n,
+        backersRewardPercentage: { builder1: { current: 50n } },
+        gaugesData: { gauge1: 200n },
+        userData: undefined,
+      })
+    })
+
+    it('computes estimatedBackerRewardsPct without type error when data is undefined', async () => {
+      const { useGetEstimatedBackersRewardsPct } = await import('./useGetEstimatedBackersRewardsPct')
+      const { renderHook } = await import('@testing-library/react')
+      renderHook(() => useGetEstimatedBackersRewardsPct())
+      expect(() => renderHook(() => useGetEstimatedBackersRewardsPct())).not.toThrow(TypeError)
+    })
   })
 })

--- a/src/app/collective-rewards/shared/hooks/useGetEstimatedBackersRewardsPct.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetEstimatedBackersRewardsPct.ts
@@ -15,13 +15,10 @@ export type EstimatedBackerRewards = RequiredBuilder & {
 }
 
 export const useGetEstimatedBackersRewardsPct = () => {
-  const {
-    data: builders,
-    isLoading: buildersLoading,
-    error: buildersError,
-  } = useGetBuildersByState<RequiredBuilder>()
-  const gauges = builders.map(({ gauge }) => gauge)
-  const buildersAddress = builders.map(({ address }) => address)
+  const { data, isLoading: buildersLoading, error: buildersError } = useGetBuildersByState<RequiredBuilder>()
+  const builders = data ?? []
+  const gauges = builders?.map(({ gauge }) => gauge)
+  const buildersAddress = builders?.map(({ address }) => address)
 
   const {
     data: totalPotentialRewards,
@@ -40,11 +37,11 @@ export const useGetEstimatedBackersRewardsPct = () => {
     error: backersRewardsPctError,
   } = useGetBackersRewardPercentage(buildersAddress)
 
-  const data = useMemo(() => {
+  const buildersRewardData = useMemo(() => {
     return builders.reduce<EstimatedBackerRewards[]>((acc, builder) => {
       const { address, gauge, stateFlags } = builder
-      const builderRewardShares = BigInt(rewardShares[gauge] ?? 0n)
-      const rewardPercentage = backersRewardsPct[address] ?? null
+      const builderRewardShares = BigInt((rewardShares && rewardShares[gauge]) ?? 0n)
+      const rewardPercentage = (backersRewardsPct && backersRewardsPct[address]) ?? null
       const rewardPercentageToApply = BigInt(rewardPercentage?.current ?? 0n)
 
       const isRewarded = isBuilderRewardable(stateFlags)
@@ -70,7 +67,7 @@ export const useGetEstimatedBackersRewardsPct = () => {
   const error = buildersError ?? totalPotentialRewardsError ?? rewardSharesError ?? backersRewardsPctError
 
   return {
-    data,
+    data: buildersRewardData,
     isLoading,
     error,
   }

--- a/src/app/collective-rewards/shared/hooks/useGetEstimatedBackersRewardsPct.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetEstimatedBackersRewardsPct.ts
@@ -1,13 +1,13 @@
-import { useMemo } from 'react'
 import {
   BackerRewardPercentage,
   useGetBackersRewardPercentage,
   useGetTotalPotentialReward,
 } from '@/app/collective-rewards/rewards'
+import { useGaugesGetFunction } from '@/app/collective-rewards/shared'
 import { RequiredBuilder } from '@/app/collective-rewards/types'
 import { useGetBuildersByState } from '@/app/collective-rewards/user'
 import { isBuilderRewardable } from '@/app/collective-rewards/utils'
-import { useGaugesGetFunction } from '@/app/collective-rewards/shared'
+import { useMemo } from 'react'
 
 export type EstimatedBackerRewards = RequiredBuilder & {
   estimatedBackerRewardsPct: bigint
@@ -43,15 +43,15 @@ export const useGetEstimatedBackersRewardsPct = () => {
   const data = useMemo(() => {
     return builders.reduce<EstimatedBackerRewards[]>((acc, builder) => {
       const { address, gauge, stateFlags } = builder
-      const builderRewardShares = rewardShares[gauge] ?? 0n
+      const builderRewardShares = BigInt(rewardShares[gauge] ?? 0n)
       const rewardPercentage = backersRewardsPct[address] ?? null
-      const rewardPercentageToApply = rewardPercentage?.current ?? 0n
+      const rewardPercentageToApply = BigInt(rewardPercentage?.current ?? 0n)
 
       const isRewarded = isBuilderRewardable(stateFlags)
 
       const estimatedBackerRewardsPct =
         totalPotentialRewards && isRewarded
-          ? (builderRewardShares * rewardPercentageToApply) / totalPotentialRewards
+          ? (builderRewardShares * rewardPercentageToApply) / BigInt(totalPotentialRewards)
           : 0n
 
       return [

--- a/src/app/collective-rewards/user/hooks/useGetGaugesArray.ts
+++ b/src/app/collective-rewards/user/hooks/useGetGaugesArray.ts
@@ -1,10 +1,10 @@
-import { useReadContracts } from 'wagmi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-import { BuilderRegistryAbi } from '@/lib/abis/v2/BuilderRegistryAbi'
-import { AbiFunction, Address } from 'viem'
 import { useGetGaugesLength } from '@/app/collective-rewards/user'
-import { useMemo } from 'react'
+import { BuilderRegistryAbi } from '@/lib/abis/v2/BuilderRegistryAbi'
+import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { useMigrationContext } from '@/shared/context/MigrationContext'
+import { useMemo } from 'react'
+import { AbiFunction, Address } from 'viem'
+import { useReadContracts } from 'wagmi'
 
 const gaugeTypeOptions = ['active', 'halted'] as const
 export type GaugeType = (typeof gaugeTypeOptions)[number]

--- a/src/app/communities/nft/[address]/CommunityNFTContext.tsx
+++ b/src/app/communities/nft/[address]/CommunityNFTContext.tsx
@@ -1,13 +1,13 @@
 'use client'
-import { ReactNode, createContext, useContext, useState } from 'react'
-import { Address } from 'viem'
-import { useRouter } from 'next/navigation'
+import { communitiesMapByContract, CommunityItem } from '@/app/communities/communityUtils'
+import { nftAlertMessages } from '@/app/communities/nft/[address]/constants'
+import { useAlertContext } from '@/app/providers'
 import { useCommunity } from '@/shared/hooks/useCommunity'
 import { useStRif } from '@/shared/hooks/useStRIf'
-import { communitiesMapByContract, CommunityItem } from '@/app/communities/communityUtils'
-import { useAlertContext } from '@/app/providers'
+import { useRouter } from 'next/navigation'
+import { createContext, ReactNode, useContext, useState } from 'react'
+import { Address } from 'viem'
 import { useAccount } from 'wagmi'
-import { nftAlertMessages } from '@/app/communities/nft/[address]/constants'
 
 interface CommunityNFTContextProps {
   // NFT Information Management
@@ -129,9 +129,9 @@ export function CommunityNFTProvider({ children, nftAddress }: CommunityNFTProvi
 
   const handleMinting = async () => {
     // check if user's stRIF Balance is more than required threshold to get a reward NFT
-    if (stRifBalance < (stRifThreshold ?? 0n))
+    if (stRifBalance < BigInt(stRifThreshold ?? 0n))
       return setMessage(
-        nftAlertMessages.NFT_BALANCE_ALERT(nftInfo?.title, stRifThreshold as bigint, () =>
+        nftAlertMessages.NFT_BALANCE_ALERT(nftInfo?.title, BigInt(stRifThreshold ?? 0n), () =>
           router.push('/user?action=stake'),
         ),
       )

--- a/src/app/proposals/[id]/page.tsx
+++ b/src/app/proposals/[id]/page.tsx
@@ -1,4 +1,6 @@
 'use client'
+import { getCombinedFiatAmount } from '@/app/collective-rewards/utils'
+import { ProposalQuorum } from '@/app/proposals/components/ProposalQuorum'
 import { useFetchAllProposals } from '@/app/proposals/hooks/useFetchLatestProposals'
 import { useGetProposalDeadline } from '@/app/proposals/hooks/useGetProposalDeadline'
 import { useGetProposalSnapshot } from '@/app/proposals/hooks/useGetProposalSnapshot'
@@ -18,37 +20,35 @@ import {
 } from '@/app/proposals/shared/supportedABIs'
 import { DecodedData, getEventArguments, splitCombinedName } from '@/app/proposals/shared/utils'
 import { useAlertContext } from '@/app/providers'
-import { useModal } from '@/shared/hooks/useModal'
 import { AddressOrAlias as AddressComponent } from '@/components/Address'
 import { Button } from '@/components/Button'
 import { CopyButton } from '@/components/CopyButton'
+import { isUserRejectedTxError } from '@/components/ErrorPage/commonErrors'
+import { MinusIcon } from '@/components/Icons'
 import { MetricsCard } from '@/components/MetricsCard'
+import { Vote, VoteProposalModal } from '@/components/Modal/VoteProposalModal'
+import { VoteSubmittedModal } from '@/components/Modal/VoteSubmittedModal'
 import { Popover } from '@/components/Popover'
 import { Header, Paragraph, Span, Typography } from '@/components/Typography'
-import { ProposalQuorum } from '@/app/proposals/components/ProposalQuorum'
 import { config } from '@/config'
+import Big from '@/lib/big'
 import { RIF, RIF_ADDRESS } from '@/lib/constants'
-import { formatNumberWithCommas, truncateMiddle, formatCurrency } from '@/lib/utils'
+import { tokenContracts } from '@/lib/contracts'
+import { formatCurrency, formatNumberWithCommas, truncateMiddle } from '@/lib/utils'
+import { usePricesContext } from '@/shared/context/PricesContext'
 import { useExecuteProposal } from '@/shared/hooks/useExecuteProposal'
+import { useModal } from '@/shared/hooks/useModal'
 import { useQueueProposal } from '@/shared/hooks/useQueueProposal'
 import { useVoteOnProposal } from '@/shared/hooks/useVoteOnProposal'
 import { TX_MESSAGES } from '@/shared/txMessages'
+import { ProposalState } from '@/shared/types'
+import { ConnectWorkflow } from '@/shared/walletConnection'
 import { waitForTransactionReceipt } from '@wagmi/core'
-import { useRouter, useParams } from 'next/navigation'
+import { formatUnits, ZeroAddress } from 'ethers'
+import { useParams, useRouter } from 'next/navigation'
 import { FC, useEffect, useMemo, useRef, useState } from 'react'
-import { MinusIcon } from '@/components/Icons'
 import { getAddress } from 'viem'
 import { type BaseError, useAccount } from 'wagmi'
-import { Vote, VoteProposalModal } from '@/components/Modal/VoteProposalModal'
-import { VoteSubmittedModal } from '@/components/Modal/VoteSubmittedModal'
-import { ProposalState } from '@/shared/types'
-import { isUserRejectedTxError } from '@/components/ErrorPage/commonErrors'
-import Big from '@/lib/big'
-import { formatUnits, ZeroAddress } from 'ethers'
-import { usePricesContext } from '@/shared/context/PricesContext'
-import { getCombinedFiatAmount } from '@/app/collective-rewards/utils'
-import { tokenContracts } from '@/lib/contracts'
-import { ConnectWorkflow } from '@/shared/walletConnection'
 
 export default function ProposalView() {
   const { id } = useParams<{ id: string }>() ?? {}
@@ -615,7 +615,7 @@ const CalldataDisplay = (props: DecodedData) => {
 
               let newPrice = getCombinedFiatAmount([
                 {
-                  value: inputValue as bigint,
+                  value: BigInt(inputValue),
                   price: tokenPrice.price,
                   symbol: tokenSymbol,
                   currency: 'USD',

--- a/src/app/proposals/hooks/useGetProposalSnapshot.ts
+++ b/src/app/proposals/hooks/useGetProposalSnapshot.ts
@@ -1,6 +1,6 @@
-import { useReadContract } from 'wagmi'
 import { GovernorAbi } from '@/lib/abis/Governor'
 import { GovernorAddress } from '@/lib/contracts'
+import { useReadContract } from 'wagmi'
 
 export const useGetProposalSnapshot = (proposalId: string) => {
   const { data } = useReadContract({
@@ -10,5 +10,5 @@ export const useGetProposalSnapshot = (proposalId: string) => {
     args: [BigInt(proposalId)],
   })
 
-  return data
+  return data ? BigInt(data.toString()) : null
 }

--- a/src/shared/hooks/useStRIf.ts
+++ b/src/shared/hooks/useStRIf.ts
@@ -1,7 +1,7 @@
-import { useReadContracts, useAccount } from 'wagmi'
 import { StRIFTokenAbi } from '@/lib/abis/StRIFTokenAbi'
 import { tokenContracts } from '@/lib/contracts'
 import { useMemo } from 'react'
+import { useAccount, useReadContracts } from 'wagmi'
 
 const stRifContract = {
   abi: StRIFTokenAbi,
@@ -24,7 +24,7 @@ export function useStRif() {
   return useMemo(() => {
     const [balance] = data ?? []
     return {
-      stRifBalance: balance?.result ?? 0n,
+      stRifBalance: BigInt(balance?.result ?? 0n),
     }
   }, [data])
 }


### PR DESCRIPTION
- ensures that `totalPotentialRewards` is always `bigint` type before calculations in the [`useGetEstimatedBackersRewardsPct`](https://github.com/RootstockCollective/dao-frontend/pull/901/files#diff-57ff3a1ff7dab9ef20b259861372d27a38435beae3e80db723aeede3a505ca0d) hook
- enforces `bigint` in runtime on other supposedly `bigint` variables in other files, trying to stay as close to the source as possible without changing the code much
- tests and guards for potentially undefined variables in runtime, such as those coming from a network when packets are lost

Resolves [TOK-677](https://rsklabs.atlassian.net/browse/TOK-677)

To test:
- run `src/app/collective-rewards/shared/hooks/useGetEstimatedBackersRewardsPct.test.ts` to verify the stability of `totalPotentialRewards`.
- for the other vars just regression