### PR TITLE
Use consistent names and comments to workflow and evm files

### DIFF
--- a/.github/workflows/cr.qa.deploy.yaml
+++ b/.github/workflows/cr.qa.deploy.yaml
@@ -1,4 +1,7 @@
 name: Deploy to Amazon ECS (CR QA)
+# Deploys to: https://qa.cr.rootstockcollective.xyz
+# Triggers when a branch is merged into develop
+# Uses the `.env.cr.qa` env file
 
 on:
   workflow_dispatch: # Manually triggered from GitHub Actions tab
@@ -30,6 +33,8 @@ jobs:
       github.event_name == 'workflow_dispatch' || github.event.label.name == 'deploy to QA'
     environment:
       name: CR-QA
+      url: https://qa.cr.rootstockcollective.xyz
+
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/dev.deploy.yaml
+++ b/.github/workflows/dev.deploy.yaml
@@ -1,4 +1,7 @@
 name: Deploy to Amazon ECS (dev)
+# Deploys to: https://dev.app.rootstockcollective.xyz/
+# Triggers when a branch is merged into develop
+# Uses the `.env.dev` env file
 
 on:
   push:
@@ -28,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: dev
+      url: https://dev.app.rootstockcollective.xyz
 
     permissions:
       id-token: write

--- a/.github/workflows/mainnet.deploy.yaml
+++ b/.github/workflows/mainnet.deploy.yaml
@@ -1,4 +1,7 @@
 name: Deploy to Amazon ECS (Mainnet)
+# Deploys to: https://app.rootstockcollective.xyz/
+# Triggers when a release is created
+# Uses the `.env.mainnet` env file.
 
 on:
   release:

--- a/.github/workflows/release-candidate.deploy.yaml
+++ b/.github/workflows/release-candidate.deploy.yaml
@@ -2,6 +2,7 @@ name: Deploy to Amazon ECS (release candidate staging)
 # Deploys to: https://staging.app.rootstockcollective.xyz/
 # Triggers on when a tag is pushed to the repo in the format of vX.X.X-rc.X
 # where X are numbers. An example: v1.5.0-rc.1
+# Uses the `.env.release-candidate` env file
 
 on:
   push:
@@ -30,7 +31,8 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     environment:
-      name: staging
+      name: release-candidate
+      url: https://staging.app.rootstockcollective.xyz
 
     permissions:
       id-token: write

--- a/.github/workflows/testnet.deploy.yaml
+++ b/.github/workflows/testnet.deploy.yaml
@@ -1,4 +1,8 @@
 name: Deploy to Amazon ECS (Testnet)
+# Deploys to: https://testnet.app.rootstockcollective.xyz/
+# Triggers when a branch is merged into develop
+# Uses the `.env.testnet` env file
+# NOTE: Will be deprecated soon and replaced with the release candidate workflow.
 
 on:
   release:


### PR DESCRIPTION
Standardizes the .env and .github/workflow files to be consistent.

The only one that does not match is `release-candidate.deploy.yaml` deploys to staging.app.... URL. I'll open a conversation in slack around this.
