### PR TITLE
fix: tabs underline interferance

### DIFF
--- a/src/app/treasury/TabsSection.tsx
+++ b/src/app/treasury/TabsSection.tsx
@@ -17,6 +17,7 @@ export function TabsSection() {
 
   return (
     <UnderlineTabs
+      layoutId="treasury-tab"
       tabs={Object.keys(cards).map(value => ({ value: value as keyof typeof cards }))}
       activeTab={activeTab}
       onTabChange={setActiveTab}

--- a/src/app/user/page.tsx
+++ b/src/app/user/page.tsx
@@ -40,6 +40,7 @@ export default function User() {
     <>
       {!isConnected && <HeroSection />}
       <UnderlineTabs
+        layoutId="user-tab"
         tabs={tabs}
         activeTab={activeTab}
         onTabChange={(newTab: TabValue) => router.push(`${pathName}?${new URLSearchParams({ tab: newTab })}`)}


### PR DESCRIPTION
# What

Introduce layout IDs for UnderlineTabs components on different pages 

# Why

Without being identified, animated elements (underlines) jump from User page to Treasury page and other way around