### PR TITLE
Override elliptic's version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3225,25 +3225,6 @@
         "hash.js": "1.1.7"
       }
     },
-    "node_modules/@ethersproject/signing-key/node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "node_modules/@ethersproject/signing-key/node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
     "node_modules/@ethersproject/solidity": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,9 @@
     "typescript": "^5",
     "vitest": "^3.0.5"
   },
+  "overrides": {
+    "elliptic": "6.6.1"
+  },
   "engines": {
     "node": "^22.0.0"
   }


### PR DESCRIPTION
- will [resolve dependabot 37](https://github.com/RootstockCollective/dao-frontend/security/dependabot/37)

Along with this commit, I have also pushed tag `v1.8.0-rc.1`. This branch and tag was created based of the tag `v1.8.0-rc.0`
