### PR TITLE
fix: don't show holders section at all for community with 0 holders

### DIFF
--- a/src/app/communities/nft/[address]/_sections/NftHoldersSection.tsx
+++ b/src/app/communities/nft/[address]/_sections/NftHoldersSection.tsx
@@ -149,6 +149,11 @@ export const NftHoldersSection = ({ address }: HoldersSectionProps) => {
     }
   })
 
+  // Don't render the section at all if there are no holders and we're not loading
+  if (currentResults.length === 0 && !isLoading) {
+    return null
+  }
+
   return (
     <div className="pl-4 relative">
       <HeaderTitle className="mb-[24px]">


### PR DESCRIPTION
This PR addresses this jira [ticket](https://rsklabs.atlassian.net/browse/DAO-1200)

Previous Renders
![Screenshot 2025-04-30 at 12 58 06 PM](https://github.com/user-attachments/assets/a70a4ab7-40fa-43a7-b87f-a8540cd51ac0)
![Screenshot 2025-04-30 at 12 58 27 PM](https://github.com/user-attachments/assets/f9c159eb-2a52-4217-a019-cca5b1cf945c)


Current Renders of OG partners and Beta builders when they have 0 holders
![Screenshot 2025-04-30 at 12 54 06 PM](https://github.com/user-attachments/assets/189e5ed9-a63d-4dc8-854f-8d5bc71095c2)
![Screenshot 2025-04-30 at 12 53 32 PM](https://github.com/user-attachments/assets/18822594-7aaa-43ce-8d14-7a5d4b6ecc09)

