### PR TITLE
TOK-717: change target SC addr for dewhitelist

### DIFF
--- a/src/app/proposals/hooks/useRemoveBuilderProposal.ts
+++ b/src/app/proposals/hooks/useRemoveBuilderProposal.ts
@@ -1,11 +1,11 @@
+import { createProposal, encodeGovernorRelayCallData } from '@/app/proposals/hooks/proposalUtils'
+import { useVotingPower } from '@/app/proposals/hooks/useVotingPower'
 import { NoVotingPowerError } from '@/app/proposals/shared/errors'
 import { GovernorAbi } from '@/lib/abis/Governor'
 import { BuilderRegistryAbi } from '@/lib/abis/v2/BuilderRegistryAbi'
-import { GovernorAddress, BackersManagerAddress } from '@/lib/contracts'
+import { BuilderRegistryAddress, GovernorAddress } from '@/lib/contracts'
 import { Address, encodeFunctionData } from 'viem'
 import { useWriteContract } from 'wagmi'
-import { createProposal, encodeGovernorRelayCallData } from '@/app/proposals/hooks/proposalUtils'
-import { useVotingPower } from '@/app/proposals/hooks/useVotingPower'
 
 export const useRemoveBuilderProposal = () => {
   const { canCreateProposal } = useVotingPower()
@@ -17,7 +17,7 @@ export const useRemoveBuilderProposal = () => {
     }
 
     const calldata = encodeRemoveBuilderCalldata(builderAddress)
-    const relayCallData = encodeGovernorRelayCallData(BackersManagerAddress, calldata)
+    const relayCallData = encodeGovernorRelayCallData(BuilderRegistryAddress, calldata)
 
     const { proposal } = createProposal([GovernorAddress], [0n], [relayCallData], description)
 


### PR DESCRIPTION

Changes the SC target address for the dewhitelist call from backers manager to builder registry, where this function now resides

Resolves [TOK-717](https://rsklabs.atlassian.net/browse/TOK-717)