### PR TITLE
TOK-677: ensure totalPotentialRewards is BigInt

### DIFF
--- a/src/app/collective-rewards/allocations/context/AllocationsContext.tsx
+++ b/src/app/collective-rewards/allocations/context/AllocationsContext.tsx
@@ -56,10 +56,10 @@ interface AllocationsContext {
 const DEFAULT_CONTEXT: AllocationsContext = {
   initialState: {
     backer: {
-      balance: BigInt(0),
-      amountToAllocate: BigInt(0),
+      balance: 0n,
+      amountToAllocate: 0n,
       allocationsCount: 0,
-      cumulativeAllocation: BigInt(0),
+      cumulativeAllocation: 0n,
     },
     allocations: {},
   },
@@ -67,10 +67,10 @@ const DEFAULT_CONTEXT: AllocationsContext = {
     selections: {},
     allocations: {},
     backer: {
-      balance: BigInt(0),
-      amountToAllocate: BigInt(0),
+      balance: 0n,
+      amountToAllocate: 0n,
       allocationsCount: 0,
-      cumulativeAllocation: BigInt(0),
+      cumulativeAllocation: 0n,
     },
     isContextLoading: true,
     contextError: null,
@@ -153,12 +153,13 @@ export const AllocationsContextProvider: FC<{ children: ReactNode }> = ({ childr
       acc[builder.address] = {
         ...builder,
         backerRewardPercentage: {
-          active: backerRewards[index]?.active ?? BigInt(0),
-          previous: backerRewards[index]?.previous ?? BigInt(0),
-          next: backerRewards[index]?.next ?? BigInt(0),
-          cooldown: backerRewards[index]?.cooldown ?? BigInt(0),
+          active: BigInt(backerRewards[index]?.active ?? 0n),
+          previous: BigInt(backerRewards[index]?.previous ?? 0n),
+          next: BigInt(backerRewards[index]?.next ?? 0n),
+          cooldown: BigInt(backerRewards[index]?.cooldown ?? 0n),
         },
       }
+
       return acc
     }, {} as Builders)
   }, [rawBuilders, backerRewards])
@@ -201,6 +202,7 @@ export const AllocationsContextProvider: FC<{ children: ReactNode }> = ({ childr
         backerRewardsError,
     )
   }, [allRawAllocationsError, buildersError, totalAllocationError, votingPowerError, backerRewardsError])
+
   useEffect(() => {
     setIsContextLoading(
       isLoadingBuilders ||
@@ -236,8 +238,8 @@ export const AllocationsContextProvider: FC<{ children: ReactNode }> = ({ childr
     return {
       backer: {
         allocationsCount,
-        balance: votingPower ?? BigInt(0),
-        amountToAllocate: totalOnchainAllocation ?? BigInt(0),
+        balance: BigInt(votingPower ?? 0n),
+        amountToAllocate: BigInt(totalOnchainAllocation ?? 0n),
         allocationCount: Object.entries(initialAllocations).length,
         cumulativeAllocation: initialCumulativeAllocations,
       },
@@ -256,7 +258,7 @@ export const AllocationsContextProvider: FC<{ children: ReactNode }> = ({ childr
         backer,
         initialAllocations: initialState.allocations,
         currentAllocations: allocations,
-        totalOnchainAllocation: totalOnchainAllocation as bigint,
+        totalOnchainAllocation: BigInt(totalOnchainAllocation ?? 0n),
       }),
     [backer, allocations, totalOnchainAllocation, initialState.allocations],
   )
@@ -298,7 +300,7 @@ function createInitialAllocations(
 ): [Allocations, bigint, number] {
   return rawAllocations.reduce(
     (acc, rawAllocation, index) => {
-      const allocation = rawAllocation ?? 0n
+      const allocation = BigInt(rawAllocation ?? 0n)
       const builderAddress = rawBuilders[index].address
       if (allocation > 0n || selections[builderAddress]) {
         acc[0][builderAddress] = allocation

--- a/src/app/collective-rewards/allocations/hooks/useBuildersWithBackerRewardPercentage.ts
+++ b/src/app/collective-rewards/allocations/hooks/useBuildersWithBackerRewardPercentage.ts
@@ -41,7 +41,7 @@ export const useGetBackerRewards: UseGetBackerRewards = builders => {
         previous,
         next,
         cooldown,
-        active: activePercPerBuilder[index] as bigint,
+        active: BigInt(activePercPerBuilder[index] ?? 0n),
       } as BackerRewardsConfig
     })
   }, [backerRewardsPercPerBuilder, activePercPerBuilder])

--- a/src/app/collective-rewards/rewards/builders/EstimatedRewards.tsx
+++ b/src/app/collective-rewards/rewards/builders/EstimatedRewards.tsx
@@ -34,7 +34,7 @@ const TokenRewards: FC<TokenRewardsProps> = ({ builder, gauge, token: { id, symb
 
   useEffect(() => {
     if (tokenRewards && tokenRewards.data) {
-      setRewards(tokenRewards.data ?? 0n)
+      setRewards(BigInt(tokenRewards.data ?? 0n))
     }
     if (tokenRewards && tokenRewards.error) {
       setRewardsError(tokenRewards.error)
@@ -45,14 +45,14 @@ const TokenRewards: FC<TokenRewardsProps> = ({ builder, gauge, token: { id, symb
   }, [tokenRewards, symbol])
 
   const {
-    data: totalPotentialRewards,
+    data: rawTotalPotentialRewards,
     isLoading: totalPotentialRewardsLoading,
     error: totalPotentialRewardsError,
   } = useReadBackersManager({
     functionName: 'totalPotentialReward',
   })
   const {
-    data: rewardShares,
+    data: rawRewardShares,
     isLoading: rewardSharesLoading,
     error: rewardSharesError,
   } = useReadGauge({ address: gauge, functionName: 'rewardShares' })
@@ -87,6 +87,9 @@ const TokenRewards: FC<TokenRewardsProps> = ({ builder, gauge, token: { id, symb
   useHandleErrors({ error, title: 'Error loading estimated rewards' })
 
   const { prices } = usePricesContext()
+
+  const totalPotentialRewards = BigInt(rawTotalPotentialRewards ?? 0n)
+  const rewardShares = BigInt(rawRewardShares ?? 0n)
 
   const rewardsAmount =
     isRewarded && rewardShares && totalPotentialRewards

--- a/src/app/collective-rewards/rewards/types.ts
+++ b/src/app/collective-rewards/rewards/types.ts
@@ -17,7 +17,6 @@ export interface Reward {
   logo?: JSX.Element
 }
 export type TokenRewards = Record<string, Reward>
-// FIXME: change builder to user, so that it can be used in the context of both builders and backers
 export interface RewardDetails {
   builder: Address
   gauges: Address[]

--- a/src/app/collective-rewards/rewards/utils/formatter.ts
+++ b/src/app/collective-rewards/rewards/utils/formatter.ts
@@ -1,9 +1,9 @@
 import Big from '@/lib/big'
-import { BigSource } from 'big.js'
 import { formatCurrency } from '@/lib/utils'
+import { BigSource } from 'big.js'
 
 export const formatMetrics = (amount: bigint, price: BigSource, symbol: string, currency: string) => {
-  const fiatAmount = getFiatAmount(amount, price)
+  const fiatAmount = getFiatAmount(BigInt(amount), price)
 
   return {
     amount: `${formatSymbol(amount, symbol)} ${symbol}`,

--- a/src/app/collective-rewards/shared/components/Table/TableCells.tsx
+++ b/src/app/collective-rewards/shared/components/Table/TableCells.tsx
@@ -15,16 +15,16 @@ import {
 import { AddressOrAliasWithCopy } from '@/components/Address'
 import { Button } from '@/components/Button'
 import { Jdenticon } from '@/components/Header/Jdenticon'
+import { ArrowDownIcon, ArrowUpIcon, CircleIcon } from '@/components/Icons'
 import { Popover } from '@/components/Popover'
 import { ProgressBar } from '@/components/ProgressBar'
 import { TableCell } from '@/components/Table'
 import { Label, Paragraph, Typography } from '@/components/Typography'
 import { cn, shortAddress } from '@/lib/utils'
+import { ConnectButtonComponentSecondary, ConnectWorkflow } from '@/shared/walletConnection'
 import { FC, memo, useContext, useMemo } from 'react'
-import { ArrowDownIcon, ArrowUpIcon, CircleIcon } from '@/components/Icons'
 import { Address, isAddress, parseEther } from 'viem'
 import { useAccount } from 'wagmi'
-import { ConnectButtonComponentSecondary, ConnectWorkflow } from '@/shared/walletConnection'
 
 type TableCellProps = {
   className?: string
@@ -150,7 +150,7 @@ type BackerRewardsPercentageProps = TableCellProps & {
   percentage: BackerRewardPercentage | null
 }
 
-const toPercentage = (value: bigint) => Number((value * 100n) / parseEther('1'))
+const toPercentage = (value: bigint = 0n) => Number((BigInt(value) * 100n) / parseEther('1'))
 export const BackerRewardsPercentage: FC<BackerRewardsPercentageProps> = ({ className, percentage }) => {
   const renderDelta = useMemo(() => {
     if (!percentage) return null

--- a/src/app/collective-rewards/shared/hooks/useGetEstimatedBackersRewardsPct.test.tsx
+++ b/src/app/collective-rewards/shared/hooks/useGetEstimatedBackersRewardsPct.test.tsx
@@ -1,0 +1,178 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook } from '@testing-library/react'
+import { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useGetEstimatedBackersRewardsPct } from './useGetEstimatedBackersRewardsPct'
+
+type SetupMocksProps = {
+  totalPotentialReward: bigint | undefined
+  backersRewardPercentage: Record<string, { current: bigint }> | undefined
+  gaugesData: Record<string, bigint> | undefined
+  userData:
+    | Array<{
+        address: string
+        gauge: string
+        stateFlags: {
+          rewardable: boolean
+        }
+      }>
+    | undefined
+}
+
+const queryClient = new QueryClient()
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+)
+
+/**
+ * Sets up mocks for various modules.
+ * @param totalPotentialReward - The total potential reward to be returned by the mock.
+ * @param backersRewardPercentage - The backers reward percentage to be returned by the mock.
+ * @param gaugesData - The gauges data to be returned by the mock.
+ * @param userData - The user data to be returned by the mock.
+ */
+const setupMocks = ({
+  totalPotentialReward,
+  backersRewardPercentage,
+  gaugesData,
+  userData,
+}: SetupMocksProps) => {
+  vi.doMock('@/app/collective-rewards/user', () => ({
+    useGetBuildersByState: () => ({
+      data: userData,
+      isLoading: false,
+      error: null,
+    }),
+  }))
+
+  vi.doMock('@/app/collective-rewards/rewards', () => ({
+    useGetTotalPotentialReward: () => ({
+      data: totalPotentialReward,
+      isLoading: false,
+      error: null,
+    }),
+    useGetBackersRewardPercentage: () => ({
+      data: backersRewardPercentage,
+      isLoading: false,
+      error: null,
+    }),
+  }))
+
+  vi.doMock('@/app/collective-rewards/shared', () => ({
+    useGaugesGetFunction: () => ({
+      data: gaugesData,
+      isLoading: false,
+      error: null,
+    }),
+  }))
+
+  vi.doMock('@/app/collective-rewards/utils', () => ({
+    isBuilderRewardable: () => true,
+  }))
+}
+
+describe('useGetEstimatedBackersRewardsPct', () => {
+  describe('with defined data', () => {
+    beforeEach(async () => {
+      vi.resetModules()
+      setupMocks({
+        totalPotentialReward: 100n,
+        backersRewardPercentage: { builder1: { current: 50n } },
+        gaugesData: { gauge1: 200n },
+        userData: [
+          {
+            address: 'builder1',
+            gauge: 'gauge1',
+            stateFlags: { rewardable: true },
+          },
+        ],
+      })
+    })
+
+    it('computes estimatedBackerRewardsPct without type error when mixing types', async () => {
+      expect(() => renderHook(() => useGetEstimatedBackersRewardsPct(), { wrapper })).not.toThrow(TypeError)
+    })
+  })
+
+  describe('with undefined tempTotalPotentialReward', () => {
+    beforeEach(async () => {
+      vi.resetModules()
+      setupMocks({
+        totalPotentialReward: undefined,
+        backersRewardPercentage: { builder1: { current: 50n } },
+        gaugesData: { gauge1: 200n },
+        userData: [
+          {
+            address: 'builder1',
+            gauge: 'gauge1',
+            stateFlags: { rewardable: true },
+          },
+        ],
+      })
+    })
+
+    it('computes estimatedBackerRewardsPct without type error when data is undefined', async () => {
+      expect(() => renderHook(() => useGetEstimatedBackersRewardsPct(), { wrapper })).not.toThrow(TypeError)
+    })
+  })
+
+  describe('with undefined backersRewardPercentage', () => {
+    beforeEach(async () => {
+      vi.resetModules()
+      setupMocks({
+        totalPotentialReward: 100n,
+        backersRewardPercentage: undefined,
+        gaugesData: { gauge1: 200n },
+        userData: [
+          {
+            address: 'builder1',
+            gauge: 'gauge1',
+            stateFlags: { rewardable: true },
+          },
+        ],
+      })
+    })
+
+    it('computes estimatedBackerRewardsPct without type error when data is undefined', async () => {
+      expect(() => renderHook(() => useGetEstimatedBackersRewardsPct(), { wrapper })).not.toThrow(TypeError)
+    })
+  })
+
+  describe('with undefined gaugesData', () => {
+    beforeEach(async () => {
+      vi.resetModules()
+      setupMocks({
+        totalPotentialReward: 100n,
+        backersRewardPercentage: { builder1: { current: 50n } },
+        gaugesData: undefined,
+        userData: [
+          {
+            address: 'builder1',
+            gauge: 'gauge1',
+            stateFlags: { rewardable: true },
+          },
+        ],
+      })
+    })
+
+    it('computes estimatedBackerRewardsPct without type error when data is undefined', async () => {
+      expect(() => renderHook(() => useGetEstimatedBackersRewardsPct(), { wrapper })).not.toThrow(TypeError)
+    })
+  })
+
+  describe('with undefined userData', () => {
+    beforeEach(async () => {
+      vi.resetModules()
+      setupMocks({
+        totalPotentialReward: 100n,
+        backersRewardPercentage: { builder1: { current: 50n } },
+        gaugesData: { gauge1: 200n },
+        userData: undefined,
+      })
+    })
+
+    it('computes estimatedBackerRewardsPct without type error when data is undefined', async () => {
+      expect(() => renderHook(() => useGetEstimatedBackersRewardsPct(), { wrapper })).not.toThrow(TypeError)
+    })
+  })
+})

--- a/src/app/collective-rewards/shared/hooks/useGetEstimatedBackersRewardsPct.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetEstimatedBackersRewardsPct.ts
@@ -20,7 +20,7 @@ export const useGetEstimatedBackersRewardsPct = () => {
   const buildersAddress = builders.map(({ address }) => address)
 
   const {
-    data: totalPotentialRewards,
+    data: rawTotalPotentialRewards,
     isLoading: totalPotentialRewardsLoading,
     error: totalPotentialRewardsError,
   } = useReadBackersManager({
@@ -40,15 +40,16 @@ export const useGetEstimatedBackersRewardsPct = () => {
 
   const data = useMemo(() => {
     return builders.reduce<EstimatedBackerRewards[]>((acc, builder, i) => {
-      const { address, gauge, stateFlags } = builder
-      const builderRewardShares = rewardShares[i] ?? 0n
+      const { address, stateFlags } = builder
+      const builderRewardShares = BigInt(rewardShares?.[i] ?? 0n)
       const rewardPercentage = backersRewardsPct[address] ?? null
-      const rewardPercentageToApply = rewardPercentage?.current ?? 0n
+      const rewardPercentageToApply = BigInt(rewardPercentage?.current ?? 0n)
+      const totalPotentialRewards = BigInt(rawTotalPotentialRewards ?? 0n)
 
       const isRewarded = isBuilderRewardable(stateFlags)
 
       const estimatedBackerRewardsPct =
-        totalPotentialRewards && isRewarded
+        rawTotalPotentialRewards && isRewarded
           ? (builderRewardShares * rewardPercentageToApply) / totalPotentialRewards
           : 0n
 
@@ -61,7 +62,7 @@ export const useGetEstimatedBackersRewardsPct = () => {
         },
       ]
     }, [])
-  }, [backersRewardsPct, builders, rewardShares, totalPotentialRewards])
+  }, [backersRewardsPct, builders, rewardShares, rawTotalPotentialRewards])
 
   const isLoading =
     buildersLoading || totalPotentialRewardsLoading || rewardSharesLoading || backersRewardsPctLoading

--- a/src/app/communities/nft/[address]/CommunityNFTContext.tsx
+++ b/src/app/communities/nft/[address]/CommunityNFTContext.tsx
@@ -1,14 +1,14 @@
 'use client'
-import { ReactNode, createContext, useContext, useState } from 'react'
-import { Address } from 'viem'
-import { useRouter } from 'next/navigation'
+import { communitiesMapByContract, CommunityItem } from '@/app/communities/communityUtils'
+import { nftAlertMessages } from '@/app/communities/nft/[address]/constants'
+import { useAlertContext } from '@/app/providers'
+import { applyPinataImageOptions } from '@/lib/ipfs'
 import { useCommunity } from '@/shared/hooks/useCommunity'
 import { useStRif } from '@/shared/hooks/useStRIf'
-import { communitiesMapByContract, CommunityItem } from '@/app/communities/communityUtils'
-import { useAlertContext } from '@/app/providers'
+import { useRouter } from 'next/navigation'
+import { createContext, ReactNode, useContext, useState } from 'react'
+import { Address } from 'viem'
 import { useAccount } from 'wagmi'
-import { nftAlertMessages } from '@/app/communities/nft/[address]/constants'
-import { applyPinataImageOptions } from '@/lib/ipfs'
 
 interface CommunityNFTContextProps {
   // NFT Information Management
@@ -129,8 +129,7 @@ export function CommunityNFTProvider({ children, nftAddress }: CommunityNFTProvi
   }
 
   const handleMinting = async () => {
-    // check if user's stRIF Balance is more than required threshold to get a reward NFT
-    if (stRifBalance < (stRifThreshold ?? 0n))
+    if (stRifBalance < BigInt(stRifThreshold ?? 0n))
       return setMessage(
         nftAlertMessages.NFT_BALANCE_ALERT(nftInfo?.title, stRifThreshold as bigint, () =>
           router.push('/user?action=stake'),

--- a/src/app/proposals/[id]/page.tsx
+++ b/src/app/proposals/[id]/page.tsx
@@ -1,4 +1,6 @@
 'use client'
+import { getCombinedFiatAmount } from '@/app/collective-rewards/utils'
+import { ProposalQuorum } from '@/app/proposals/components/ProposalQuorum'
 import { useFetchAllProposals } from '@/app/proposals/hooks/useFetchLatestProposals'
 import { useGetProposalDeadline } from '@/app/proposals/hooks/useGetProposalDeadline'
 import { useGetProposalSnapshot } from '@/app/proposals/hooks/useGetProposalSnapshot'
@@ -18,36 +20,34 @@ import {
 } from '@/app/proposals/shared/supportedABIs'
 import { DecodedData, getEventArguments, splitCombinedName } from '@/app/proposals/shared/utils'
 import { useAlertContext } from '@/app/providers'
-import { useModal } from '@/shared/hooks/useModal'
 import { AddressOrAlias as AddressComponent } from '@/components/Address'
 import { Button } from '@/components/Button'
 import { CopyButton } from '@/components/CopyButton'
+import { isUserRejectedTxError } from '@/components/ErrorPage/commonErrors'
+import { MinusIcon } from '@/components/Icons'
 import { MetricsCard } from '@/components/MetricsCard'
+import { Vote, VoteProposalModal } from '@/components/Modal/VoteProposalModal'
+import { VoteSubmittedModal } from '@/components/Modal/VoteSubmittedModal'
 import { Popover } from '@/components/Popover'
 import { Header, Paragraph, Span, Typography } from '@/components/Typography'
-import { ProposalQuorum } from '@/app/proposals/components/ProposalQuorum'
 import { config } from '@/config'
+import Big from '@/lib/big'
 import { RIF, RIF_ADDRESS } from '@/lib/constants'
-import { formatNumberWithCommas, truncateMiddle, formatCurrency } from '@/lib/utils'
+import { tokenContracts } from '@/lib/contracts'
+import { formatCurrency, formatNumberWithCommas, truncateMiddle } from '@/lib/utils'
+import { usePricesContext } from '@/shared/context/PricesContext'
 import { useExecuteProposal } from '@/shared/hooks/useExecuteProposal'
+import { useModal } from '@/shared/hooks/useModal'
 import { useQueueProposal } from '@/shared/hooks/useQueueProposal'
 import { useVoteOnProposal } from '@/shared/hooks/useVoteOnProposal'
 import { TX_MESSAGES } from '@/shared/txMessages'
-import { waitForTransactionReceipt } from '@wagmi/core'
-import { useRouter, useParams } from 'next/navigation'
-import { FC, useEffect, useMemo, useRef, useState } from 'react'
-import { MinusIcon } from '@/components/Icons'
-import { getAddress, formatEther, zeroAddress } from 'viem'
-import { type BaseError, useAccount } from 'wagmi'
-import { Vote, VoteProposalModal } from '@/components/Modal/VoteProposalModal'
-import { VoteSubmittedModal } from '@/components/Modal/VoteSubmittedModal'
 import { ProposalState } from '@/shared/types'
-import { isUserRejectedTxError } from '@/components/ErrorPage/commonErrors'
-import Big from '@/lib/big'
-import { usePricesContext } from '@/shared/context/PricesContext'
-import { getCombinedFiatAmount } from '@/app/collective-rewards/utils'
-import { tokenContracts } from '@/lib/contracts'
 import { ConnectWorkflow } from '@/shared/walletConnection'
+import { waitForTransactionReceipt } from '@wagmi/core'
+import { useParams, useRouter } from 'next/navigation'
+import { FC, useEffect, useMemo, useRef, useState } from 'react'
+import { formatEther, getAddress, zeroAddress } from 'viem'
+import { type BaseError, useAccount } from 'wagmi'
 
 export default function ProposalView() {
   const { id } = useParams<{ id: string }>() ?? {}
@@ -80,7 +80,7 @@ const PageWithProposal = (proposal: ParsedProposal) => {
   const snapshot = useGetProposalSnapshot(proposalId)
 
   const { blocksUntilClosure } = useGetProposalDeadline(proposalId)
-  const { votingPowerAtSnapshot, doesUserHasEnoughThreshold } = useVotingPowerAtSnapshot(snapshot as bigint)
+  const { votingPowerAtSnapshot, doesUserHasEnoughThreshold } = useVotingPowerAtSnapshot(snapshot)
   const { canCreateProposal } = useVotingPower()
 
   const {
@@ -614,7 +614,7 @@ const CalldataDisplay = (props: DecodedData) => {
 
               let newPrice = getCombinedFiatAmount([
                 {
-                  value: inputValue as bigint,
+                  value: BigInt(inputValue),
                   price: tokenPrice.price,
                   symbol: tokenSymbol,
                   currency: 'USD',

--- a/src/app/proposals/hooks/useGetProposalSnapshot.ts
+++ b/src/app/proposals/hooks/useGetProposalSnapshot.ts
@@ -1,6 +1,6 @@
-import { useReadContract } from 'wagmi'
 import { GovernorAbi } from '@/lib/abis/Governor'
 import { GovernorAddress } from '@/lib/contracts'
+import { useReadContract } from 'wagmi'
 
 export const useGetProposalSnapshot = (proposalId: string) => {
   const { data } = useReadContract({
@@ -10,5 +10,5 @@ export const useGetProposalSnapshot = (proposalId: string) => {
     args: [BigInt(proposalId)],
   })
 
-  return data
+  return BigInt(data ?? 0n)
 }

--- a/src/shared/hooks/useStRIf.ts
+++ b/src/shared/hooks/useStRIf.ts
@@ -1,7 +1,7 @@
-import { useReadContracts, useAccount } from 'wagmi'
 import { StRIFTokenAbi } from '@/lib/abis/StRIFTokenAbi'
 import { tokenContracts } from '@/lib/contracts'
 import { useMemo } from 'react'
+import { useAccount, useReadContracts } from 'wagmi'
 
 const stRifContract = {
   abi: StRIFTokenAbi,
@@ -24,7 +24,7 @@ export function useStRif() {
   return useMemo(() => {
     const [balance] = data ?? []
     return {
-      stRifBalance: balance?.result ?? 0n,
+      stRifBalance: BigInt(balance?.result ?? 0n),
     }
   }, [data])
 }


### PR DESCRIPTION
- ensures that `totalPotentialRewards` is always `bigint` type before calculations in the [`useGetEstimatedBackersRewardsPct`](https://github.com/RootstockCollective/dao-frontend/pull/901/files#diff-57ff3a1ff7dab9ef20b259861372d27a38435beae3e80db723aeede3a505ca0d) hook
- enforces `bigint` in runtime on other supposedly `bigint` variables in other files, trying to stay as close to the source as possible without changing the code much
- tests and guards for potentially undefined variables in runtime, such as those coming from a network when packets are lost

Resolves [TOK-677](https://rsklabs.atlassian.net/browse/TOK-677)

To test:
- run `src/app/collective-rewards/shared/hooks/useGetEstimatedBackersRewardsPct.test.ts` to verify the stability of `totalPotentialRewards`.
- for the other vars just regression