### PR TITLE
Feat/dao 1204

### DIFF
--- a/src/app/collective-rewards/user/components/Button/BecomeABuilderButton.test.tsx
+++ b/src/app/collective-rewards/user/components/Button/BecomeABuilderButton.test.tsx
@@ -54,6 +54,7 @@ describe('BecomeABuilderButton', () => {
     vi.mocked(useAlertContext).mockReturnValue({
       setMessage: setAlertMessageSpy,
       message: null,
+      preserveCurrentAlert: () => undefined,
     })
   })
 

--- a/src/app/user/Stake/StakingSteps.tsx
+++ b/src/app/user/Stake/StakingSteps.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useCallback } from 'react'
 import { StakingProvider } from '@/app/user/Stake/StakingContext'
 import { useSteps } from '@/app/user/Stake/hooks/useSteps'
 import { Modal } from '@/components/Modal/Modal'
@@ -7,6 +7,7 @@ import { StakingToken } from '@/app/user/Stake/types'
 import { tokenContracts } from '@/lib/contracts'
 import { stakingSteps } from './Steps/stepsUtils'
 import { useStakeRIF } from '@/app/user/Stake/hooks/useStakeRIF'
+import { useAlertContext } from '@/app/providers'
 
 interface StakingStepsProps {
   onCloseModal: () => void
@@ -15,12 +16,11 @@ interface StakingStepsProps {
 export const StakingSteps = ({ onCloseModal }: StakingStepsProps) => {
   const { step, onGoNext, onGoBack } = useSteps(4)
   const { balances, prices } = useBalancesContext()
+  const { preserveCurrentAlert } = useAlertContext()
 
   const currentStep = useMemo(() => stakingSteps[step], [step])
 
   const StepComponent = currentStep.stepComponent
-
-  const stepsFunctions = { onGoNext, onGoBack, onCloseModal }
 
   const tokenToSend: StakingToken = useMemo(
     () => ({
@@ -41,6 +41,15 @@ export const StakingSteps = ({ onCloseModal }: StakingStepsProps) => {
     }),
     [balances.stRIF.balance, balances.stRIF.symbol, prices.stRIF?.price],
   )
+
+  // Enhanced close handler
+  const handleCloseModal = useCallback(() => {
+    preserveCurrentAlert() // Preserve any current alert
+    onCloseModal()
+  }, [onCloseModal, preserveCurrentAlert])
+
+  const stepsFunctions = { onGoNext, onGoBack, onCloseModal: handleCloseModal }
+
   return (
     <StakingProvider
       tokenToSend={tokenToSend}

--- a/src/app/user/Stake/Steps/StepTwo.tsx
+++ b/src/app/user/Stake/Steps/StepTwo.tsx
@@ -53,7 +53,6 @@ export const StepTwo = ({ onGoNext, onCloseModal = () => {} }: StepProps) => {
       onGoNext?.()
     } catch (err: any) {
       if (!isUserRejectedTxError(err)) {
-        // setMessage(TX_MESSAGES.staking.error)
         switch (actionName) {
           case 'STAKE':
             setMessage(TX_MESSAGES.staking.error)

--- a/src/app/user/Stake/UnStakingSteps.tsx
+++ b/src/app/user/Stake/UnStakingSteps.tsx
@@ -1,12 +1,13 @@
 import { useSteps } from '@/app/user/Stake/hooks/useSteps'
 import { useBalancesContext } from '@/app/user/Balances/context/BalancesContext'
-import { useMemo } from 'react'
+import { useMemo, useCallback } from 'react'
 import { steps } from '@/app/user/Stake/Steps/stepsUtils'
 import { StakingToken } from '@/app/user/Stake/types'
 import { tokenContracts } from '@/lib/contracts'
 import { StakingProvider } from '@/app/user/Stake/StakingContext'
 import { Modal } from '@/components/Modal/Modal'
 import { useUnstakeStRIF } from '@/app/user/Stake/hooks/useUnstakeStRIF'
+import { useAlertContext } from '@/app/providers'
 
 interface StakingStepsProps {
   onCloseModal: () => void
@@ -15,12 +16,11 @@ interface StakingStepsProps {
 export const UnStakingSteps = ({ onCloseModal }: StakingStepsProps) => {
   const { step, onGoNext, onGoBack } = useSteps()
   const { balances, prices } = useBalancesContext()
+  const { preserveCurrentAlert } = useAlertContext()
 
   const currentStep = useMemo(() => steps[step], [step])
 
   const StepComponent = currentStep.stepComponent
-
-  const stepsFunctions = { onGoNext, onGoBack, onCloseModal }
 
   const tokenToSend: StakingToken = useMemo(
     () => ({
@@ -41,6 +41,18 @@ export const UnStakingSteps = ({ onCloseModal }: StakingStepsProps) => {
     }),
     [balances.RIF.balance, balances.RIF.symbol, prices.RIF?.price],
   )
+
+  // Create an enhanced close handler that preserves alerts
+  const handleCloseModal = useCallback(() => {
+    preserveCurrentAlert() // Preserve any current alert before closing
+    onCloseModal() // Then execute the original close function
+  }, [onCloseModal, preserveCurrentAlert])
+
+  const stepsFunctions = {
+    onGoNext,
+    onGoBack,
+    onCloseModal: handleCloseModal,
+  }
 
   return (
     <StakingProvider


### PR DESCRIPTION
This PR addresses this [ticket](https://rsklabs.atlassian.net/browse/DAO-1204)

Previous behaviour:
When you complete a staking/unstaking flow, the alerts only show when you click on the Go to Balances btn

New Behaviour:
The alerts now show regardless of how you close the modal 