### PR TITLE
fix: fix issue causing lag in loading data/incorrect data for holders section

### DIFF
--- a/src/app/communities/nft/[address]/_sections/NftHoldersSection.tsx
+++ b/src/app/communities/nft/[address]/_sections/NftHoldersSection.tsx
@@ -148,7 +148,7 @@ export const NftHoldersSection = ({ address }: HoldersSectionProps) => {
       // Reset loading state when address changes
       setHasCompletedLoad(false)
       setCurrentAddress(address)
-    } else if (isLoading === false && !hasCompletedLoad) {
+    } else if (!isLoading && !hasCompletedLoad) {
       // Mark as completed once loading is done for the current address
       setHasCompletedLoad(true)
     }

--- a/src/app/communities/nft/[address]/_sections/NftHoldersSection.tsx
+++ b/src/app/communities/nft/[address]/_sections/NftHoldersSection.tsx
@@ -7,7 +7,7 @@ import { LoadingSpinner } from '@/components/LoadingSpinner'
 import { EXPLORER_URL } from '@/lib/constants'
 import { ExternalLinkIcon } from '@/components/Icons'
 import { truncateMiddle } from '@/lib/utils'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { TableIcon } from '@/app/communities/TableIcon'
 import { SquareIcon } from '@/app/communities/SquareIcon'
 import { ErrorMessageAlert } from '@/components/ErrorMessageAlert/ErrorMessageAlert'
@@ -133,12 +133,38 @@ interface HoldersSectionProps {
   address: Address
 }
 export const NftHoldersSection = ({ address }: HoldersSectionProps) => {
-  const { currentResults, paginationElement, isLoading, isError } = useFetchNftHolders(address)
+  // Track the current address to detect changes
+  const [currentAddress, setCurrentAddress] = useState<Address>(address)
 
+  // Local state to track if we've loaded data for the current address
+  const [hasCompletedLoad, setHasCompletedLoad] = useState(false)
+
+  const { currentResults, paginationElement, isLoading, isError } = useFetchNftHolders(address)
   const [view, setView] = useState<ViewState>('table')
+
+  // Reset state when address changes
+  useEffect(() => {
+    if (address !== currentAddress) {
+      // Reset loading state when address changes
+      setHasCompletedLoad(false)
+      setCurrentAddress(address)
+    } else if (isLoading === false && !hasCompletedLoad) {
+      // Mark as completed once loading is done for the current address
+      setHasCompletedLoad(true)
+    }
+  }, [address, currentAddress, isLoading, hasCompletedLoad])
 
   const onChangeView = (selectedView: ViewState) => {
     setView(selectedView)
+  }
+
+  // Only show content if we've completed a load for the current address
+  const hasHolders = currentResults.length > 0
+
+  // Don't render anything until we've completed at least one load cycle
+  // for the current address or we're actively loading
+  if (!hasHolders && hasCompletedLoad) {
+    return null
   }
 
   const holders = currentResults.map(({ owner, ens_domain_name, id, image_url }) => {
@@ -149,27 +175,26 @@ export const NftHoldersSection = ({ address }: HoldersSectionProps) => {
     }
   })
 
-  // Don't render the section at all if there are no holders and we're not loading
-  if (currentResults.length === 0 && !isLoading) {
-    return null
-  }
-
   return (
     <div className="pl-4 relative">
       <HeaderTitle className="mb-[24px]">
         Holders
-        <ViewIconHandler view={view} onChangeView={onChangeView} />
+        {hasHolders && <ViewIconHandler view={view} onChangeView={onChangeView} />}
       </HeaderTitle>
-      {isError ? (
+
+      {isLoading && <LoadingSpinner />}
+
+      {!isLoading && isError && hasCompletedLoad && (
         <ErrorMessageAlert message="An error occurred loading NFT Holders. Please try again shortly." />
-      ) : (
+      )}
+
+      {!isLoading && !isError && hasHolders && (
         <>
-          {view === 'table' && holders.length > 0 && <Table data={holders} />}
-          {view === 'images' && currentResults.length > 0 && <CardView nfts={currentResults} />}
+          {view === 'table' && <Table data={holders} />}
+          {view === 'images' && <CardView nfts={currentResults} />}
           <div className="mt-6">{paginationElement}</div>
         </>
       )}
-      {isLoading && <LoadingSpinner />}
     </div>
   )
 }


### PR DESCRIPTION
This PR addresses an additional bug reported on this [ticket](https://rsklabs.atlassian.net/browse/DAO-1200) which was initially fixed by this [PR](https://github.com/RootstockCollective/dao-frontend/pull/929)

**Bug**
When you move between different communities pages, the holders section list experience a slight lag where it updates that section from the previous list to the correct current list of the active community. And then in the case of a community with no holder, this incorrectly still renders the holders section showing an error.

Fixed inconsistent rendering behaviour when navigating between pages with and without NFT holders. The component now properly handles state transitions and prevents showing stale data or error messages.

**Changes**

Added tracking for address changes to detect navigation between different NFT collections
Implemented load completion state to ensure we only render based on fresh data
Fixed the "no holders" condition to prevent UI flickering during navigation
Improved error handling to only show errors for the current address

***Before***:
When navigating from a page with holders to one without, the component would momentarily show stale data or error messages before disappearing.

***After***:
Clean transitions between pages - component only renders when there are holders for the current address or when actively loading.