### PR TITLE
feat: update status labels with new design

### DIFF
--- a/src/app/proposals/components/LatestProposalsTable.tsx
+++ b/src/app/proposals/components/LatestProposalsTable.tsx
@@ -22,7 +22,8 @@ import { Button } from '@/components/Button'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Big from '@/lib/big'
 import { proposalQuickFilters } from '@/lib/constants'
-import { CategoryColumn } from '@/app/proposals/components/table-columns/CategoryColumn'
+
+import { ProposalState } from '@/shared/types'
 
 interface LatestProposalsTableProps {
   proposals: LatestProposalResponse[]
@@ -53,8 +54,9 @@ const LatestProposalsTable = ({ proposals, onEmitActiveProposal }: LatestProposa
   useEffect(() => {
     if (onEmitActiveProposal) {
       onEmitActiveProposal(
-        proposalListData.filter(proposal => ['Pending', 'Active'].includes(proposal.proposalState)).length ||
-          0,
+        proposalListData.filter(proposal =>
+          [ProposalState.Pending, ProposalState.Active].includes(proposal.proposalState),
+        ).length || 0,
       )
     }
   }, [onEmitActiveProposal, proposalListData])

--- a/src/app/proposals/components/table-columns/StatusColumn.tsx
+++ b/src/app/proposals/components/table-columns/StatusColumn.tsx
@@ -1,28 +1,13 @@
 import { Status } from '@/components/Status'
-import { type StatusSeverity } from '@/components/Status/types'
-
-const StatusByProposalState = {
-  Pending: 'in-progress',
-  Active: 'in-progress',
-  Canceled: 'canceled',
-  Defeated: 'rejected',
-  Succeeded: 'success',
-  Queued: 'queue',
-  Expired: 'rejected',
-  Executed: 'success',
-  undefined: null,
-}
+import { ProposalState } from '@/shared/types'
 
 interface StatusColumnProps {
-  proposalState?: string
+  proposalState?: ProposalState
 }
 
 export const StatusColumn = ({ proposalState }: StatusColumnProps) => {
-  const statusMap = StatusByProposalState[
-    proposalState as keyof typeof StatusByProposalState
-  ] as StatusSeverity
   if (typeof proposalState === 'undefined') {
     return null
   }
-  return <Status severity={statusMap} label={proposalState} />
+  return <Status proposalState={proposalState} />
 }

--- a/src/app/proposals/hooks/useProposalListData.ts
+++ b/src/app/proposals/hooks/useProposalListData.ts
@@ -76,7 +76,7 @@ export function useProposalListData({ proposals }: Props) {
           votingPeriod: deadlineBlock.minus(creationBlock),
           quorumAtSnapshot: Big(formatEther(quorum?.[i].result ?? 0n)).round(undefined, Big.roundHalfEven),
           proposalDeadline: deadlineBlock,
-          proposalState: ProposalState[Big(state?.[i].result?.toString() ?? 0).toNumber()],
+          proposalState: Number(state?.[i].result ?? 0n) as ProposalState,
           category,
           ...eventArgs,
         }

--- a/src/components/Status/Status.stories.tsx
+++ b/src/components/Status/Status.stories.tsx
@@ -1,4 +1,5 @@
 import { Status } from '@/components/Status'
+import { ProposalState } from '@/shared/types'
 import type { Meta, StoryObj } from '@storybook/react'
 import { expect, spyOn, userEvent, within } from '@storybook/test'
 
@@ -13,31 +14,55 @@ type Story = StoryObj<typeof meta>
 
 export const Success: Story = {
   args: {
-    severity: 'success',
+    proposalState: ProposalState.Succeeded,
   },
 }
 
-export const InProgress: Story = {
+export const Pending: Story = {
   args: {
-    severity: 'in-progress',
+    proposalState: ProposalState.Pending,
   },
 }
 
-export const Rejected: Story = {
+export const Active: Story = {
   args: {
-    severity: 'rejected',
+    proposalState: ProposalState.Active,
+  },
+}
+
+export const Executed: Story = {
+  args: {
+    proposalState: ProposalState.Executed,
+  },
+}
+
+export const Queued: Story = {
+  args: {
+    proposalState: ProposalState.Queued,
+  },
+}
+
+export const Defeated: Story = {
+  args: {
+    proposalState: ProposalState.Defeated,
   },
 }
 
 export const Canceled: Story = {
   args: {
-    severity: 'canceled',
+    proposalState: ProposalState.Canceled,
+  },
+}
+
+export const Expired: Story = {
+  args: {
+    proposalState: ProposalState.Expired,
   },
 }
 
 export const TestDivEvent: Story = {
   args: {
-    severity: 'success',
+    proposalState: ProposalState.Succeeded,
     onClick: () => console.log('Clicked'),
   },
   play: async ({ canvasElement }) => {

--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -1,38 +1,67 @@
-import { StatusSeverity } from '@/components/Status/types'
-import { Paragraph } from '@/components/Typography/Paragraph'
+import { Paragraph } from '../TypographyNew'
 import { cn } from '@/lib/utils'
 import { FC, JSX } from 'react'
+import { ProposalState } from '@/shared/types'
 
 type Props = JSX.IntrinsicElements['div'] & {
-  severity: StatusSeverity
-  label?: string
+  proposalState?: ProposalState
 }
 
-const DEFAULT_CLASSES = 'inline-block text-white text-center rounded-[4px] px-1 py-[3px] w-[86px] h-[26px]'
+const VARIANTS = {
+  [ProposalState.Active]: {
+    label: 'Active',
+    classes: 'bg-brand-rootstock-lime text-text-0',
+  },
+  [ProposalState.Executed]: {
+    label: 'Executed',
+    classes: 'bg-bg-40',
+  },
+  [ProposalState.Defeated]: {
+    label: 'Defeated',
+    classes: 'bg-error text-text-0',
+  },
+  [ProposalState.Succeeded]: {
+    label: 'Success',
+    classes: 'bg-success text-text-0',
+  },
+  [ProposalState.Canceled]: {
+    label: 'Cancelled',
+    classes: 'bg-bg-40',
+  },
+  [ProposalState.Expired]: {
+    label: 'Expired',
+    classes: 'bg-bg-40',
+  },
+  [ProposalState.Queued]: {
+    label: 'On queue',
+    classes: 'bg-brand-rootstock-purple text-text-0',
+  },
+  [ProposalState.Pending]: {
+    label: 'Pending',
+    classes: 'bg-bg-40',
+  },
+} satisfies Record<ProposalState, { label: string; classes: string }>
 
-const parseDefaultLabel = (severity: string) => {
-  const label = severity.charAt(0).toUpperCase() + severity.slice(1)
-  return label.replace('-', ' ')
+const getVariants = (proposalState?: ProposalState): (typeof VARIANTS)[keyof typeof VARIANTS] => {
+  return proposalState === undefined
+    ? { label: 'Unknown', classes: 'bg-bg-40 text-text-100' }
+    : VARIANTS[proposalState]
 }
 
-export const Status: FC<Props> = ({ severity = 'success', label, ...rest }) => {
-  const classes = cn({
-    [DEFAULT_CLASSES]: true,
-    'bg-st-success': severity === 'success',
-    'bg-st-info': severity === 'in-progress',
-    'bg-st-error': severity === 'rejected',
-    'bg-st-white': severity === 'canceled',
-    'bg-st-queue': severity === 'queue',
-    'text-black': severity === 'canceled',
-  })
-
-  let labelToUse = !label ? parseDefaultLabel(severity) : label
+export const Status: FC<Props> = ({ proposalState, className, ...rest }) => {
+  const { label, classes } = getVariants(proposalState)
 
   return (
-    <div className={classes} {...rest}>
-      <Paragraph variant="semibold" className="text-[12px]">
-        {labelToUse}
-      </Paragraph>
+    <div
+      className={cn(
+        'px-1 py-[3px] w-[68px] h-[26px]',
+        'inline-flex items-center justify-center ',
+        'rounded-full text-text-100 overflow-hidden',
+        classes,
+      )}
+      {...rest}
+    >
+      <Paragraph className="text-xs">{label}</Paragraph>
     </div>
   )
 }

--- a/src/components/Status/types.ts
+++ b/src/components/Status/types.ts
@@ -1,1 +1,0 @@
-export type StatusSeverity = 'success' | 'rejected' | 'in-progress' | 'canceled' | 'queue'

--- a/src/theme/base.css
+++ b/src/theme/base.css
@@ -57,6 +57,7 @@
   --color-brand-rootstock-purple: var(--brand-rootstock-purple);
   --color-brand-rootstock-pink: var(--brand-rootstock-pink);
   --color-brand-rootstock-green: var(--brand-rootstock-green);
+  --color-brand-rootstock-lime: var(--brand-rootstock-lime);
 
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;

--- a/src/theme/default.css
+++ b/src/theme/default.css
@@ -91,6 +91,7 @@ html[data-theme='default'] {
   --brand-rootstock-purple: #9e76ff;
   --brand-rootstock-pink: #ff71e1;
   --brand-rootstock-green: #79c600;
+  --brand-rootstock-lime: #DEFF1A;
 
   /* TODO: replace these main layout colors with New Design 2025 colors */
   --v-charcoal: rgba(37, 33, 30, 1);


### PR DESCRIPTION
# What

Refactor and redesign Proposal Status labels (Status component)
<img width="80" alt="Screenshot 2025-06-13 at 06 36 36" src="https://github.com/user-attachments/assets/82701e98-4a6f-4199-954e-eec9d380f7ce" />
<img width="78" alt="Screenshot 2025-06-13 at 06 36 48" src="https://github.com/user-attachments/assets/e9da22f9-1f41-4886-b4d8-e16a45372e3e" />
<img width="80" alt="Screenshot 2025-06-13 at 06 37 01" src="https://github.com/user-attachments/assets/9a26bf01-4f06-449e-b645-7157fd13c5fa" />
<img width="78" alt="Screenshot 2025-06-13 at 06 37 14" src="https://github.com/user-attachments/assets/4836b3e3-ecd0-45ad-8a9a-0bcf480f9855" />
<img width="78" alt="Screenshot 2025-06-13 at 06 37 28" src="https://github.com/user-attachments/assets/c9542afa-96b2-4413-8c44-58e17723458f" />
<img width="77" alt="Screenshot 2025-06-13 at 06 37 40" src="https://github.com/user-attachments/assets/f15a51a8-d514-4f85-819c-366dea78d2a3" />
<img width="77" alt="Screenshot 2025-06-13 at 06 37 53" src="https://github.com/user-attachments/assets/ceaf01c4-afc2-4ba2-addd-16bf25e7aa19" />
<img width="80" alt="Screenshot 2025-06-13 at 06 38 05" src="https://github.com/user-attachments/assets/209d90fd-1361-493f-9b62-f106339e043b" />



# Details

This pull request refactors the handling of proposal states across the codebase by replacing string-based states with a strongly-typed `ProposalState` enum. It simplifies the logic for mapping proposal states to UI components, improves type safety, and enhances maintainability. Additionally, it introduces a new color variable for better visual representation of the "Active" state.

# Why

For the redesigned proposals list page

# Jira

[DAO-1312](https://rsklabs.atlassian.net/browse/DAO-1312)