### PR TITLE
TOK-838: Allocation bar adjustments

### DIFF
--- a/src/app/backing/BackingPage.tsx
+++ b/src/app/backing/BackingPage.tsx
@@ -129,6 +129,8 @@ export const BackingPage = () => {
         </ActionMetricsContainer>
       )}
 
+      {/* FIXME: we need to change the title based on the allocations */}
+
       <ActionsContainer
         title={
           <Header variant="h3" caps>

--- a/src/app/backing/BackingPage.tsx
+++ b/src/app/backing/BackingPage.tsx
@@ -23,6 +23,7 @@ import { BuilderAllocationBar } from './components/BuilderAllocationBar'
 import { AnnualBackingIncentives } from './components/Metrics/AnnualBackingIncentives'
 import { Spotlight } from './components/Spotlight'
 import { useBuilderContext } from '@/app/collective-rewards/user/context/BuilderContext'
+import { useRouter } from 'next/navigation'
 
 const NAME = 'Backing'
 
@@ -38,6 +39,7 @@ export const BackingPage = () => {
   } = useContext(AllocationsContext)
 
   const { randomBuilders } = useBuilderContext()
+  const router = useRouter()
 
   const rifPriceUsd = prices[RIF]?.price ?? 0
 
@@ -112,9 +114,7 @@ export const BackingPage = () => {
                 <AvailableBackingMetric
                   availableForBacking={availableForBackingLabel}
                   availableBackingUSD={availableBackingUSD}
-                  onStakeClick={() => {
-                    // FIXME: Implement staking page and update this navigation
-                  }}
+                  onStakeClick={() => router.push('/user?action=stake')}
                   onDistributeClick={handleDistributeClick}
                 />
               </div>

--- a/src/app/backing/BackingPage.tsx
+++ b/src/app/backing/BackingPage.tsx
@@ -12,7 +12,7 @@ import {
 import { formatSymbol, getFiatAmount } from '@/app/collective-rewards/rewards'
 import { ActionMetricsContainer, ActionsContainer, MetricsContainer } from '@/components/containers'
 import { Header, Span } from '@/components/TypographyNew'
-import { RIF } from '@/lib/constants'
+import { RIF, stRIF, USD } from '@/lib/constants'
 import { formatCurrency } from '@/lib/utils'
 import { usePricesContext } from '@/shared/context/PricesContext'
 import { useContext } from 'react'
@@ -48,13 +48,13 @@ export const BackingPage = () => {
   const hasAllocations = totalOnchainAllocation > 0n
 
   // Format values properly using formatter functions
-  const availableForBackingLabel = formatSymbol(availableForBacking, 'stRIF')
-  const totalBackingLabel = formatSymbol(totalBacking, 'stRIF')
+  const availableForBackingLabel = formatSymbol(availableForBacking, stRIF)
+  const totalBackingLabel = formatSymbol(totalBacking, stRIF)
   const availableBackingUSD =
     !availableForBacking || !rifPriceUsd
-      ? formatCurrency(0, { currency: 'USD', showCurrency: true })
+      ? formatCurrency(0, { currency: USD, showCurrency: true })
       : formatCurrency(getFiatAmount(availableForBacking, rifPriceUsd), {
-          currency: 'USD',
+          currency: USD,
           showCurrency: true,
         })
 
@@ -83,7 +83,7 @@ export const BackingPage = () => {
     <div data-testid={NAME} className="flex flex-col items-start w-full h-full pt-[0.13rem] gap-2 rounded-sm">
       <Header caps variant="h1" className="text-3xl leading-10 pb-[2.5rem]">
         {NAME}{' '}
-        {allocationsCount > 0 && (
+        {isConnected && allocationsCount > 0 && (
           <Span variant="tag" className="text-v3-bg-accent-0 text-lg font-normal normal-case">
             {allocationsCount} Builders
           </Span>
@@ -106,41 +106,46 @@ export const BackingPage = () => {
 
       {isConnected && (
         <ActionMetricsContainer className="flex flex-col items-start w-[1144px] p-6 gap-2 rounded-[4px] bg-v3-bg-accent-80">
-          <div className="basis-1/2">
-            <AvailableBackingMetric
-              availableForBacking={availableForBackingLabel}
-              availableBackingUSD={availableBackingUSD}
-              onStakeClick={() => {
-                // FIXME: Implement staking page and update this navigation
-              }}
-              onDistributeClick={handleDistributeClick}
-            />
-          </div>
-          <div className="flex items-start basis-1/2 gap-14">
-            <div className="basis-1/2">
-              <TotalBackingMetric totalBacking={totalBackingLabel} />
-            </div>
-            {hasAllocations && (
+          <div className="flex flex-col items-center gap-10 w-full">
+            <div className="flex items-start gap-14 w-full">
               <div className="basis-1/2">
-                <AnnualBackingIncentives />
+                <AvailableBackingMetric
+                  availableForBacking={availableForBackingLabel}
+                  availableBackingUSD={availableBackingUSD}
+                  onStakeClick={() => {
+                    // FIXME: Implement staking page and update this navigation
+                  }}
+                  onDistributeClick={handleDistributeClick}
+                />
               </div>
-            )}
+              <div className="flex items-start basis-1/2 gap-14">
+                <div className="basis-1/2">
+                  <TotalBackingMetric totalBacking={totalBackingLabel} />
+                </div>
+                {hasAllocations && (
+                  <div className="basis-1/2">
+                    <AnnualBackingIncentives />
+                  </div>
+                )}
+              </div>
+            </div>
+            {hasAllocations && <Spotlight />}
           </div>
         </ActionMetricsContainer>
       )}
 
-      {/* FIXME: we need to change the title based on the allocations */}
-
-      <ActionsContainer
-        title={
-          <Header variant="h3" caps>
-            {isConnected ? 'Builders that you may want to back' : 'In the spotlight'}
-          </Header>
-        }
-        className="bg-v3-bg-accent-80"
-      >
-        <Spotlight />
-      </ActionsContainer>
+      {!hasAllocations && (
+        <ActionsContainer
+          title={
+            <Header variant="h3" caps>
+              {isConnected ? 'Builders that you may want to back' : 'In the spotlight'}
+            </Header>
+          }
+          className="bg-v3-bg-accent-80"
+        >
+          <Spotlight />
+        </ActionsContainer>
+      )}
     </div>
   )
 }

--- a/src/app/backing/BackingPage.tsx
+++ b/src/app/backing/BackingPage.tsx
@@ -15,7 +15,7 @@ import { Header, Span } from '@/components/TypographyNew'
 import { RIF, stRIF, USD } from '@/lib/constants'
 import { formatCurrency } from '@/lib/utils'
 import { usePricesContext } from '@/shared/context/PricesContext'
-import { useContext } from 'react'
+import { useContext, useMemo } from 'react'
 import { Address } from 'viem'
 import { useAccount } from 'wagmi'
 import { AvailableBackingMetric, TotalBackingMetric } from './components'
@@ -23,7 +23,7 @@ import { BuilderAllocationBar } from './components/BuilderAllocationBar'
 import { AnnualBackingIncentives } from './components/Metrics/AnnualBackingIncentives'
 import { Spotlight } from './components/Spotlight'
 import { useBuilderContext } from '@/app/collective-rewards/user/context/BuilderContext'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 
 const NAME = 'Backing'
 
@@ -41,13 +41,16 @@ export const BackingPage = () => {
   const { randomBuilders } = useBuilderContext()
   const router = useRouter()
 
+  const searchParams = useSearchParams()
+  const userSelections = useMemo(() => searchParams.get('builders')?.split(',') as Address[], [searchParams])
+
   const rifPriceUsd = prices[RIF]?.price ?? 0
 
   const availableForBacking = !votingPower ? 0n : votingPower - totalOnchainAllocation
 
   const totalBacking = !totalOnchainAllocation ? 0n : totalOnchainAllocation
 
-  const hasAllocations = totalOnchainAllocation > 0n
+  const hasAllocations = useMemo(() => totalOnchainAllocation > 0n, [totalOnchainAllocation])
 
   // Format values properly using formatter functions
   const availableForBackingLabel = formatSymbol(availableForBacking, stRIF)
@@ -129,12 +132,12 @@ export const BackingPage = () => {
                 )}
               </div>
             </div>
-            {hasAllocations && <Spotlight />}
+            {(hasAllocations || userSelections) && <Spotlight />}
           </div>
         </ActionMetricsContainer>
       )}
 
-      {!hasAllocations && (
+      {!hasAllocations && !userSelections && (
         <ActionsContainer
           title={
             <Header variant="h3" caps>

--- a/src/app/backing/components/AllocationBar/AllocationBarSegment.tsx
+++ b/src/app/backing/components/AllocationBar/AllocationBarSegment.tsx
@@ -67,14 +67,18 @@ export const AllocationBarSegment = ({
   // Calculate the percentage width based on the actual value and total value
   const percentageWidth = valueToPercentage(value, totalValue)
 
+  // For segments with very small values, ensure they have a minimum visible width
+  // but only if the value is actually greater than 0
+  const effectiveWidth = value > 0 && percentageWidth < 0.5 ? 0.5 : percentageWidth
+
   const style: React.CSSProperties = {
     ...(item.isTemporary ? checkerboardStyle() : {}),
-    width: `${percentageWidth}%`,
+    width: `${effectiveWidth}%`,
     transform: CSS.Translate.toString(transform),
     backgroundColor: item.displayColor,
   }
 
-  const baseClasses = 'min-w-12 h-full relative overflow-visible flex items-stretch p-0'
+  const baseClasses = 'h-full relative overflow-visible flex items-stretch p-0'
   const transitionClasses =
     dragIndex !== null ? 'transition-none' : 'transition-transform duration-200 ease-out'
   const dragStateClasses = isDragging ? 'opacity-60 z-[99]' : 'opacity-100 z-1'

--- a/src/app/backing/components/AllocationInput/AllocationInput.tsx
+++ b/src/app/backing/components/AllocationInput/AllocationInput.tsx
@@ -2,7 +2,7 @@ import { getFiatAmount } from '@/app/collective-rewards/rewards'
 import { InputNumber } from '@/components/Input/InputNumber'
 import { Paragraph } from '@/components/TypographyNew'
 import { cn, formatCurrency } from '@/lib/utils'
-import { Dispatch, FC, SetStateAction, useState } from 'react'
+import { Dispatch, FC, SetStateAction } from 'react'
 import { PendingAllocation } from '../PendingAllocation/PendingAllocation'
 import { StickySlider } from '../StickySlider/StickySlider'
 import { RIFToken } from '../RIFToken/RIFToken'
@@ -46,6 +46,12 @@ export const AllocationInput: FC<AllocationInputProps> = ({
     onAllocationChange(newAllocation)
   }
 
+  const onMouseLeave = () => {
+    if (editing && allocation === existentAllocation) {
+      setEditing?.(false)
+    }
+  }
+
   return (
     <div
       className={cn(
@@ -85,7 +91,12 @@ export const AllocationInput: FC<AllocationInputProps> = ({
       </Paragraph>
       {editing && !allocationTxPending && (
         <div data-testid="allocationInputSlider">
-          <StickySlider value={[allocationPercentage]} step={1} onValueChange={handleSliderChange} />
+          <StickySlider
+            value={[allocationPercentage]}
+            step={1}
+            onValueChange={handleSliderChange}
+            onMouseLeave={onMouseLeave}
+          />
           <Paragraph className="text-[12px] text-v3-text-60 mt-2" data-testid="allocationInputPercentage">
             {allocationPercentage.toFixed(0)}% of total backing power
           </Paragraph>

--- a/src/app/backing/components/AllocationInput/AllocationInput.tsx
+++ b/src/app/backing/components/AllocationInput/AllocationInput.tsx
@@ -1,12 +1,13 @@
 import { getFiatAmount } from '@/app/collective-rewards/rewards'
 import { InputNumber } from '@/components/Input/InputNumber'
 import { Paragraph } from '@/components/TypographyNew'
-import { cn } from '@/lib/utils'
+import { cn, formatCurrency } from '@/lib/utils'
 import { Dispatch, FC, SetStateAction, useState } from 'react'
 import { PendingAllocation } from '../PendingAllocation/PendingAllocation'
 import { StickySlider } from '../StickySlider/StickySlider'
 import { RIFToken } from '../RIFToken/RIFToken'
 import { formatSymbol } from '@/app/collective-rewards/rewards/utils/formatter'
+import { USD } from '@/lib/constants'
 
 interface AllocationInputProps {
   allocation: bigint
@@ -34,7 +35,10 @@ export const AllocationInput: FC<AllocationInputProps> = ({
   setEditing,
 }) => {
   const allocationPercentage = maxAllocation === 0n ? 0 : Number((allocation * 100n) / maxAllocation)
-  const amountUsd = Number(getFiatAmount(allocation, rifPriceUsd).toFixed(2))
+  const amountUsd = formatCurrency(getFiatAmount(allocation, rifPriceUsd), {
+    currency: USD,
+    showCurrency: true,
+  })
 
   const handleSliderChange = (value: number[]) => {
     const percent = value[0]
@@ -77,7 +81,7 @@ export const AllocationInput: FC<AllocationInputProps> = ({
         </div>
       </div>
       <Paragraph className="text-[14px] text-v3-text-60" data-testid="allocationInputUsd">
-        {amountUsd} USD
+        {amountUsd}
       </Paragraph>
       {editing && !allocationTxPending && (
         <div data-testid="allocationInputSlider">

--- a/src/app/backing/components/BuilderAllocationBar/BuilderAllocationBar.tsx
+++ b/src/app/backing/components/BuilderAllocationBar/BuilderAllocationBar.tsx
@@ -102,8 +102,9 @@ const BuilderAllocationBar = () => {
         // Update allocations except for 'unallocated'
         const changedItems = [itemsData[increasedIndex], itemsData[decreasedIndex]]
         changedItems.forEach(item => {
+          const newValue = newValues[itemsData.indexOf(item)]
           if (item.key !== UNALLOCATED_KEY) {
-            updateAllocation(item.key as Address, parseEther(newValues[itemsData.indexOf(item)].toString()))
+            updateAllocation(item.key as Address, newValue > 0 ? parseEther(newValue.toString()) : 0n)
           }
         })
       } else if (change.type === 'reorder') {

--- a/src/app/backing/components/CurrentBacking/CurrentBacking.tsx
+++ b/src/app/backing/components/CurrentBacking/CurrentBacking.tsx
@@ -10,7 +10,6 @@ interface CurrentBackingProps {
 export const CurrentBacking: FC<CurrentBackingProps> = ({ existentAllocation }) => {
   return (
     <div className="border-t border-v3-bg-accent-40 p-3" data-testid="currentBackingContainer">
-      {/* FIXME: variables to moved in the variables file */}
       <Label className="text-xs text-v3-text-60" data-testid="currentBackingLabel">
         Current backing
       </Label>

--- a/src/app/backing/components/Spotlight/Spotlight.tsx
+++ b/src/app/backing/components/Spotlight/Spotlight.tsx
@@ -36,7 +36,15 @@ export const Spotlight = () => {
 
   useEffect(() => {
     if (userSelections) {
+      // include the new user selections into the selections object
       userSelections.forEach(builder => !selections[builder] && toggleSelectedBuilder(builder))
+      // remove the old user selections if they are not in the new user selections
+      Object.keys(selections).forEach(
+        builder =>
+          !userSelections.includes(builder as Address) &&
+          selections[builder as Address] &&
+          toggleSelectedBuilder(builder as Address),
+      )
     }
   }, [userSelections, toggleSelectedBuilder, selections])
 

--- a/src/app/backing/components/Spotlight/Spotlight.tsx
+++ b/src/app/backing/components/Spotlight/Spotlight.tsx
@@ -54,14 +54,28 @@ export const Spotlight = () => {
     console.warn('😈 ~ BuildersSpotlight.tsx ~ selections:', selections)
   }, [userSelections, selections])
 
-  const hasAllocations = totalOnchainAllocation > 0n
+  const hasAllocations = useMemo(() => totalOnchainAllocation > 0n, [totalOnchainAllocation])
 
-  const allocatedBuilders = hasAllocations
-    ? Object.keys(allocations).map(key => getBuilder(key as Address)!)
-    : randomBuilders
-  const spotlightBuilders = estimatedBuilders.filter(builder =>
-    allocatedBuilders.map(b => b.address).includes(builder.address),
-  )
+  const spotlightBuilders = useMemo(() => {
+    // Get builders based on allocation or selection state
+    let builderKeys: Address[] = []
+
+    if (hasAllocations) {
+      builderKeys = Object.keys(allocations) as Address[]
+    } else if (userSelections?.length) {
+      builderKeys = userSelections
+    }
+
+    // Resolve builder objects from keys or fallback to random builders
+    const resolvedBuilders = builderKeys.length
+      ? builderKeys.map(key => getBuilder(key)).filter(builder => !!builder)
+      : randomBuilders
+
+    const resolvedAddresses = resolvedBuilders.map(({ address }) => address)
+
+    // Return only estimated builders that match resolved addresses
+    return estimatedBuilders.filter(({ address }) => resolvedAddresses.includes(address))
+  }, [estimatedBuilders, hasAllocations, allocations, getBuilder, randomBuilders, userSelections])
 
   if (isLoading) {
     return (

--- a/src/app/backing/components/StickySlider/StickySlider.tsx
+++ b/src/app/backing/components/StickySlider/StickySlider.tsx
@@ -12,6 +12,8 @@ export interface StickySliderProps {
   thumbSize?: string
   ticksEdgesSize?: number
   stickyThreshold?: number
+  // TODO: we should refactor this to directly expose its component to improve flexibility and composability
+  onMouseLeave?: () => void
 }
 
 export const StickySlider: React.FC<StickySliderProps> = ({
@@ -24,6 +26,7 @@ export const StickySlider: React.FC<StickySliderProps> = ({
   thumbSize = '1rem',
   ticksEdgesSize = 8,
   stickyThreshold = 2,
+  onMouseLeave,
 }) => {
   // Snap to nearest tick during drag to have a magnetic effect
   const handleValueChange = (val: number[]) => {
@@ -95,6 +98,7 @@ export const StickySlider: React.FC<StickySliderProps> = ({
             height: thumbSize,
           }}
           data-testid="sliderThumb"
+          onMouseLeave={onMouseLeave}
         />
       </div>
     </SliderPrimitive.Root>

--- a/src/app/builders/components/Table/BuildersTable.tsx
+++ b/src/app/builders/components/Table/BuildersTable.tsx
@@ -39,7 +39,7 @@ const filterMap: Record<BuilderFilterOptionId, (builder: Builder) => boolean> = 
   all: () => true,
 }
 
-// FIXME: this is a temporary solution to filter builders by state.
+// TODO: this is a temporary solution to filter builders by state.
 type PagedFilter = {
   filterOption: BuilderFilterOptionId
   pageOptions: { start: number; end: number }
@@ -139,14 +139,14 @@ export const BuildersTable = ({ filterOption }: { filterOption: BuilderFilterOpt
     }
   }, [error, allocationsError, dispatch])
 
-  // FIXME: I don't think we should be using this context anymore
+  // TODO: I don't think we should be using this context anymore
   const {
     actions: { toggleSelectedBuilder },
     state: { selections },
   } = useContext(AllocationsContext)
 
   useEffect(() => {
-    // FIXME: this is a very hacky way to sync the selected rows with the allocations context.
+    // TODO: this is a very hacky way to sync the selected rows with the allocations context.
     // One reason to remove the allocs context (it loads (pre)selections on mount) is to avoid cleaning this up.
     const selectedBuilderIds = Object.keys(selectedRows)
     const selectionValues = Object.values(selectedRows)
@@ -161,8 +161,8 @@ export const BuildersTable = ({ filterOption }: { filterOption: BuilderFilterOpt
 
   /**
    * Set the action column header to show if the allocations column is hidden.
-   * FIXME: see if we can do this better to avoid re-rendering the table.
-  //  */
+   * TODO: see if we can do this better to avoid re-rendering the table.
+   */
   useEffect(() => {
     const isAllocationsHidden = columns.find(col => col.id == 'allocations')?.hidden ?? true
     const isActionsHidden = columns.find(col => col.id == 'actions')?.hidden ?? true

--- a/src/app/shared/components/BuilderCard/BuilderCard.tsx
+++ b/src/app/shared/components/BuilderCard/BuilderCard.tsx
@@ -1,6 +1,6 @@
 import { ConnectPopover } from '@/app/backing/components/Popovers/ConnectPopover'
 import { cn } from '@/lib/utils'
-import { FC, useState } from 'react'
+import { FC, useEffect, useState } from 'react'
 import { AllocationInput } from '@/app/backing/components/AllocationInput/AllocationInput'
 import { BuilderHeader } from '@/app/backing/components/BuilderHeader/BuilderHeader'
 import { CurrentBacking } from '@/app/backing/components/CurrentBacking/CurrentBacking'
@@ -57,6 +57,14 @@ export const BuilderCard: FC<BuilderCardProps> = ({
   const [editing, setEditing] = useState(false)
 
   const builderPageLink = `/proposals/${proposal.id}`
+
+  useEffect(() => {
+    if (allocation !== existentAllocation) {
+      setEditing(true)
+    } else {
+      setEditing(false)
+    }
+  }, [allocation, existentAllocation, setEditing])
 
   return (
     <div

--- a/src/app/shared/components/BuilderCard/BuilderCard.tsx
+++ b/src/app/shared/components/BuilderCard/BuilderCard.tsx
@@ -11,6 +11,7 @@ import { Paragraph } from '@/components/TypographyNew'
 import { isBuilderRewardable } from '@/app/collective-rewards/utils/isBuilderOperational'
 import { StylableComponentProps } from '@/components/commonProps'
 import { BuilderCardControlProps } from './BuilderCardControl'
+import { AnimatePresence, motion } from 'motion/react'
 
 const Warning = ({ className }: StylableComponentProps<HTMLDivElement>) => {
   return (
@@ -59,11 +60,7 @@ export const BuilderCard: FC<BuilderCardProps> = ({
   const builderPageLink = `/proposals/${proposal.id}`
 
   useEffect(() => {
-    if (allocation !== existentAllocation) {
-      setEditing(true)
-    } else {
-      setEditing(false)
-    }
+    allocation !== existentAllocation && setEditing(true)
   }, [allocation, existentAllocation, setEditing])
 
   return (
@@ -111,7 +108,18 @@ export const BuilderCard: FC<BuilderCardProps> = ({
               />
             </div>
           )}
-          {editing && <CurrentBacking existentAllocation={existentAllocation} />}
+          <AnimatePresence>
+            {editing && (
+              <motion.div
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: 'auto' }}
+                exit={{ opacity: 0, height: 0 }}
+                transition={{ duration: 0.3, ease: 'easeInOut' }}
+              >
+                <CurrentBacking existentAllocation={existentAllocation} />
+              </motion.div>
+            )}
+          </AnimatePresence>
         </div>
       </div>
       <div>

--- a/src/app/shared/components/BuilderCard/BuilderCard.tsx
+++ b/src/app/shared/components/BuilderCard/BuilderCard.tsx
@@ -81,6 +81,7 @@ export const BuilderCard: FC<BuilderCardProps> = ({
         name={builderName}
         builderPageLink={builderPageLink}
         className="mt-8"
+        showFullName={false}
       />
       {!isRewardable && <Warning className="pt-3" />}
       <div className="my-6 w-full">

--- a/src/app/shared/components/BuilderCard/BuilderCard.tsx
+++ b/src/app/shared/components/BuilderCard/BuilderCard.tsx
@@ -37,6 +37,7 @@ export interface BuilderCardProps extends BuilderCardControlProps {
 export const BuilderCard: FC<BuilderCardProps> = ({
   address,
   builderName,
+  proposal,
   stateFlags,
   existentAllocation,
   maxAllocation,
@@ -55,6 +56,8 @@ export const BuilderCard: FC<BuilderCardProps> = ({
   const isRewardable = isBuilderRewardable(stateFlags)
   const [editing, setEditing] = useState(false)
 
+  const builderPageLink = `/proposals/${proposal.id}`
+
   return (
     <div
       className={cn(
@@ -68,8 +71,12 @@ export const BuilderCard: FC<BuilderCardProps> = ({
         style={{ backgroundColor: topBarColor }}
         data-testid="builderCardTopBar"
       />
-      {/* FIXME: replace the builder page link */}
-      <BuilderHeader address={address} name={builderName} builderPageLink="#" className="mt-8" />
+      <BuilderHeader
+        address={address}
+        name={builderName}
+        builderPageLink={builderPageLink}
+        className="mt-8"
+      />
       {!isRewardable && <Warning className="pt-3" />}
       <div className="my-6 w-full">
         <div

--- a/src/app/shared/components/BuilderCard/BuilderCardControl.tsx
+++ b/src/app/shared/components/BuilderCard/BuilderCardControl.tsx
@@ -106,6 +106,7 @@ export const BuilderCardControl: FC<BuilderCardControlProps> = ({
     } else {
       closeDrawer()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialAllocations, allocations])
 
   return (

--- a/src/app/shared/components/BuilderCard/BuilderCardControl.tsx
+++ b/src/app/shared/components/BuilderCard/BuilderCardControl.tsx
@@ -8,7 +8,7 @@ import { ActionsContainer } from '@/components/containers/ActionsContainer'
 import { RIF } from '@/lib/constants'
 import { usePricesContext } from '@/shared/context/PricesContext'
 import { FC, useContext, useEffect } from 'react'
-import { parseEther } from 'viem'
+import { Address, parseEther } from 'viem'
 import { useAccount } from 'wagmi'
 import { floorToUnit, getBuilderColor } from '../utils'
 import { BuilderCard } from './BuilderCard'
@@ -67,7 +67,7 @@ export const BuilderCardControl: FC<BuilderCardControlProps> = ({
 }) => {
   const { isConnected } = useAccount()
   const { prices } = usePricesContext()
-  const { openDrawer } = useLayoutContext()
+  const { openDrawer, closeDrawer } = useLayoutContext()
   const {
     actions: { updateAllocation },
     state: {
@@ -87,8 +87,26 @@ export const BuilderCardControl: FC<BuilderCardControlProps> = ({
   const handleAllocationChange = (value: number) => {
     if (allocationTxPending) return
     updateAllocation(builderAddress, parseEther(value.toString()))
-    openDrawer(<AllocationDrawerContent />, true)
   }
+
+  useEffect(() => {
+    // Compare initialAllocations and allocations
+    // Find differences between initial and current allocations for this builder
+    if (Object.keys(allocations).length === 0) return
+    const initialAllocationsKeys = Object.keys(initialAllocations)
+    let hasChanged = false
+    for (const builderAddress of initialAllocationsKeys) {
+      if (initialAllocations[builderAddress as Address] !== allocations[builderAddress as Address]) {
+        hasChanged = true
+        break
+      }
+    }
+    if (hasChanged) {
+      openDrawer(<AllocationDrawerContent />, true)
+    } else {
+      closeDrawer()
+    }
+  }, [initialAllocations, allocations])
 
   return (
     <BuilderCard

--- a/src/app/shared/components/BuilderCard/BuilderCardControl.tsx
+++ b/src/app/shared/components/BuilderCard/BuilderCardControl.tsx
@@ -93,14 +93,13 @@ export const BuilderCardControl: FC<BuilderCardControlProps> = ({
     // Compare initialAllocations and allocations
     // Find differences between initial and current allocations for this builder
     if (Object.keys(allocations).length === 0) return
-    const initialAllocationsKeys = Object.keys(initialAllocations)
-    let hasChanged = false
-    for (const builderAddress of initialAllocationsKeys) {
-      if (initialAllocations[builderAddress as Address] !== allocations[builderAddress as Address]) {
-        hasChanged = true
-        break
-      }
-    }
+    const uniqueAddresses = [...new Set([...Object.keys(initialAllocations), ...Object.keys(allocations)])]
+    const hasChanged = uniqueAddresses.some(
+      builderAddress =>
+        (initialAllocations[builderAddress as Address] || 0n) !==
+        (allocations[builderAddress as Address] || 0n),
+    )
+
     if (hasChanged) {
       openDrawer(<AllocationDrawerContent />, true)
     } else {


### PR DESCRIPTION
## What

- add builder proposal link to Builder card
- show the selected builders
- add animation on editing
- manage drawer according to the allocation change
- add stake redirection
- show the spotlight without title if user is not connect or they already allocated
- change the usd formatting in the allocation input
- truncate builder name