### PR TITLE
refactor: remove 'Home' entry from sidebar menu data

### DIFF
--- a/src/components/MainContainer/sidebars/menuData.tsx
+++ b/src/components/MainContainer/sidebars/menuData.tsx
@@ -50,11 +50,6 @@ export const menuData = [
     type: 'category',
   },
   {
-    href: 'home',
-    text: 'Home',
-    buttonProps: { id: 'Button_Home', name: 'home' },
-  },
-  {
     href: 'treasury',
     text: 'Treasury',
     buttonProps: { id: 'Button_Treasury', name: 'treasury' },


### PR DESCRIPTION
# What

Remove duplicate Home item in the menu

# Why

[Requested by Toby ](https://rootstocklabs.slack.com/archives/C0540E911PA/p1753431695286649)
