### PR TITLE
fix: select builder text

### DIFF
--- a/src/app/builders/components/Table/BuilderDataRow.tsx
+++ b/src/app/builders/components/Table/BuilderDataRow.tsx
@@ -320,7 +320,7 @@ export const SelectBuildersTooltipContent = () => {
     <div className="flex justify-center">
       <div className="bg-v3-text-80 rounded-sm shadow-sm w-64 flex flex-col items-start p-6 gap-2">
         <Paragraph className="text-v3-bg-accent-100 text-sm w-full font-normal leading-5 rootstock-sans self-stretch">
-          Click table line to select the Builder(s) that you would like to back
+          Select Builders you want to back
         </Paragraph>
       </div>
     </div>


### PR DESCRIPTION
changes the wording of a tooltip