### PR TITLE
DAO-1424: Fix missing src attribute in <img> tag causing render warning

### DIFF
--- a/src/app/communities/CommunityItem.tsx
+++ b/src/app/communities/CommunityItem.tsx
@@ -48,17 +48,19 @@ export const CommunityItem = ({
         data-testid={`${title}Card`}
       >
         {/* image */}
-        <div className={cn('relative w-full h-auto', variant === 'portrait' ? 'aspect-square' : 'flex-1 aspect-[3/4] max-w-1/2')}>
-          <Image
-            crossOrigin={isExternalImage ? 'anonymous' : undefined}
-            unoptimized={isExternalImage}
-            src={image}
-            alt={title}
-            fill
-            objectFit={variant === 'portrait' ? 'contain' : 'cover'}
-          />
-          {enableDebris && <ImageDebris image={image} />}
-        </div>
+        {image && (
+          <div className={cn('relative w-full h-auto', variant === 'portrait' ? 'aspect-square' : 'flex-1 aspect-[3/4] max-w-1/2')}>
+            <Image
+              crossOrigin={isExternalImage ? 'anonymous' : undefined}
+              unoptimized={isExternalImage}
+              src={image}
+              alt={title}
+              fill
+              className={variant === 'portrait' ? 'object-contain' : 'object-cover'}
+            />
+            {enableDebris && <ImageDebris image={image} />}
+          </div>
+        )}
         <div className="flex gap-[20px] flex-col flex-1">
           {/* Title */}
           <div className={cn(variant === 'landscape' ? 'mt-[32px]' : 'mt-[16px]')}>


### PR DESCRIPTION
Remove console errors related to empty or missing src atrribute.

<img width="966" height="226" alt="image" src="https://github.com/user-attachments/assets/672038d8-d14e-4e63-93dd-90bc77cd550f" />
