### PR TITLE
DAO-1433 - Hardcode activation date rather than use the boostData

### DIFF
--- a/src/app/communities/communityUtils.tsx
+++ b/src/app/communities/communityUtils.tsx
@@ -15,6 +15,7 @@ export interface CommunityItem {
   cover: string
   detailedDescription: ReactNode
   specialPower: string
+  activation: string
   requirement: string
   isMintable?: boolean
   additionalChecks?: { name: string; check: (data: any) => boolean; alertMessage: string }[]
@@ -57,6 +58,7 @@ export const earlyAdoptersCommunity: CommunityItem = {
     </>
   ),
   specialPower: 'Voting Booster',
+  activation: 'July 2025',
   requirement: 'First 150 stakers with 1 stRIF, Self-Claim',
 }
 
@@ -77,6 +79,7 @@ export const ogFounders: CommunityItem = {
     </>
   ),
   specialPower: 'Voting Booster',
+  activation: 'H2 2025',
   requirement: '1 stRIF on 23rd Sept 2024, Self-Claim',
 }
 
@@ -98,6 +101,7 @@ export const ogFoundersEcosystemPartners: CommunityItem = {
     </>
   ),
   specialPower: 'Voting Booster',
+  activation: 'H2 2025',
   requirement: 'Recognized Community contributions, 25k stRIF, Air-Drop',
 }
 
@@ -119,6 +123,7 @@ export const ogFoundersExternalContributors: CommunityItem = {
     </>
   ),
   specialPower: 'Delegation Kickstarter OR Voting Booster',
+  activation: 'March 2025',
   requirement: 'Recognized Community contributions, Air-Drop',
 }
 
@@ -139,6 +144,7 @@ export const vanguardCommunity: CommunityItem = {
     </>
   ),
   specialPower: 'Voting Booster',
+  activation: 'April 2025',
   requirement: 'Voted on 1 of the last 3 proposals, Self-Claim',
   additionalChecks: [
     {
@@ -187,6 +193,7 @@ export const betaBuilders: CommunityItem = {
     </>
   ),
   specialPower: 'Voting Booster',
+  activation: 'H2 2025',
   requirement: 'First 50 CollectiveRewards Builders, Air-Drop',
   discussionLink: 'https://discord.com/channels/842021106956238848/1284160805671272458',
 }
@@ -203,6 +210,7 @@ export const rootstockHacktivator: CommunityItem = {
   cover: '',
   detailedDescription: <></>,
   specialPower: '',
+  activation: '',
   requirement: '',
 }
 

--- a/src/app/communities/nft/[address]/_sections/CommunityInfoHeader.tsx
+++ b/src/app/communities/nft/[address]/_sections/CommunityInfoHeader.tsx
@@ -23,7 +23,7 @@ export function CommunityInfoHeader({ address: nftAddress }: { address: Address 
   const { isConnected } = useAccount()
   const { image, tokenId = 0, isMember, isMintable, tokensAvailable } = useCommunityNFT()
 
-  const { title, specialPower, requirement, detailedDescription, discussionLink } = useMemo(
+  const { title, specialPower, activation, requirement, detailedDescription, discussionLink } = useMemo(
     () => communitiesMapByContract[nftAddress.toLowerCase()],
     [nftAddress],
   )
@@ -69,9 +69,7 @@ export function CommunityInfoHeader({ address: nftAddress }: { address: Address 
           {/* Activation time column */}
           <div className="flex flex-col gap-2">
             <Paragraph className="text-text-60 font-medium">Activation</Paragraph>
-            <Paragraph className="font-kk-topo">
-              {DateTime.fromSeconds(Number(boostData?.timestamp) ?? 0).toFormat('MMMM yyyy')}
-            </Paragraph>
+            <Paragraph className="font-kk-topo">{activation}</Paragraph>
           </div>
           {/* NFT ID column - showing only to member */}
           {isMember && (


### PR DESCRIPTION
Hardcoding this data instead of using boostData. 

<img width="485" height="425" alt="Screenshot 2025-07-29 at 2 15 10 PM" src="https://github.com/user-attachments/assets/7ed95fb8-a984-4cc6-9831-479050ec4504" />
