### PR TITLE
TOK-874: show proper title for builder and backer

### DIFF
--- a/src/app/communities/components/SectionContainer.tsx
+++ b/src/app/communities/components/SectionContainer.tsx
@@ -1,5 +1,6 @@
 import { ComponentProps, ReactNode } from 'react'
 import { Header } from '@/components/Typography'
+import { withSpinner } from '@/components/LoadingSpinner/withLoadingSpinner'
 
 interface SectionContainerProps {
   title: string
@@ -33,3 +34,5 @@ export const SectionContainer = ({
     <div data-testid="SectionContainerContent">{children}</div>
   </div>
 )
+
+export const SectionContainerWithSpinner = withSpinner(SectionContainer)

--- a/src/app/user/my-holdings/MyActivityAndBalances.tsx
+++ b/src/app/user/my-holdings/MyActivityAndBalances.tsx
@@ -1,11 +1,10 @@
 'use client'
 
 import { MyBacking } from './components/backing'
-import { SectionContainer, SectionContainerWithSpinner } from '@/app/communities/components/SectionContainer'
+import { SectionContainerWithSpinner } from '@/app/communities/components/SectionContainer'
 import { BalancesSection } from '../Balances/BalancesSection'
 import { useIsBuilder } from './hooks/useIsBuilder'
 import { useHandleErrors } from '@/app/collective-rewards/utils'
-import { LoadingSpinner } from '@/components/LoadingSpinner'
 
 const Separator = () => <hr className="w-full bg-bg-60 border-none h-px my-10" />
 

--- a/src/app/user/my-holdings/MyActivityAndBalances.tsx
+++ b/src/app/user/my-holdings/MyActivityAndBalances.tsx
@@ -3,21 +3,29 @@
 import { MyBacking } from './components/backing'
 import { SectionContainer } from '@/app/communities/components/SectionContainer'
 import { BalancesSection } from '../Balances/BalancesSection'
+import { useReadBuilderRegistry } from '@/shared/hooks/contracts'
+import { useAccount } from 'wagmi'
+import { zeroAddress } from 'viem'
 
 const Separator = () => <hr className="w-full bg-bg-60 border-none h-px my-10" />
 
 export const MyActivityAndBalances = () => {
-  const isUserBuilder = true // @TODO
+  const { address } = useAccount()
+  const { data: gauge } = useReadBuilderRegistry(
+    {
+      functionName: 'builderToGauge',
+      args: [address ?? zeroAddress],
+    },
+    { enabled: !!address },
+  )
+
+  const isUserBuilder = Boolean(gauge && gauge !== zeroAddress)
   const sectionTitle = isUserBuilder ? 'MY ACTIVITY & BALANCES' : 'MY BALANCES'
 
   return (
     <SectionContainer title={sectionTitle} headerVariant="h3">
-      {isUserBuilder && (
-        <>
-          <MyBacking />
-          <Separator />
-        </>
-      )}
+      <MyBacking />
+      <Separator />
       <BalancesSection />
     </SectionContainer>
   )

--- a/src/app/user/my-holdings/MyActivityAndBalances.tsx
+++ b/src/app/user/my-holdings/MyActivityAndBalances.tsx
@@ -3,23 +3,12 @@
 import { MyBacking } from './components/backing'
 import { SectionContainer } from '@/app/communities/components/SectionContainer'
 import { BalancesSection } from '../Balances/BalancesSection'
-import { useReadBuilderRegistry } from '@/shared/hooks/contracts'
-import { useAccount } from 'wagmi'
-import { zeroAddress } from 'viem'
+import { useIsBuilder } from './hooks/useIsBuilder'
 
 const Separator = () => <hr className="w-full bg-bg-60 border-none h-px my-10" />
 
 export const MyActivityAndBalances = () => {
-  const { address } = useAccount()
-  const { data: gauge } = useReadBuilderRegistry(
-    {
-      functionName: 'builderToGauge',
-      args: [address ?? zeroAddress],
-    },
-    { enabled: !!address },
-  )
-
-  const isUserBuilder = Boolean(gauge && gauge !== zeroAddress)
+  const { isUserBuilder } = useIsBuilder()
   const sectionTitle = isUserBuilder ? 'MY ACTIVITY & BALANCES' : 'MY BALANCES'
 
   return (

--- a/src/app/user/my-holdings/MyActivityAndBalances.tsx
+++ b/src/app/user/my-holdings/MyActivityAndBalances.tsx
@@ -1,21 +1,25 @@
 'use client'
 
 import { MyBacking } from './components/backing'
-import { SectionContainer } from '@/app/communities/components/SectionContainer'
+import { SectionContainer, SectionContainerWithSpinner } from '@/app/communities/components/SectionContainer'
 import { BalancesSection } from '../Balances/BalancesSection'
 import { useIsBuilder } from './hooks/useIsBuilder'
+import { useHandleErrors } from '@/app/collective-rewards/utils'
+import { LoadingSpinner } from '@/components/LoadingSpinner'
 
 const Separator = () => <hr className="w-full bg-bg-60 border-none h-px my-10" />
 
 export const MyActivityAndBalances = () => {
-  const { isUserBuilder } = useIsBuilder()
+  const { isUserBuilder, isLoading, error } = useIsBuilder()
   const sectionTitle = isUserBuilder ? 'MY ACTIVITY & BALANCES' : 'MY BALANCES'
 
+  useHandleErrors({ error, title: 'Error fetching builder status' })
+
   return (
-    <SectionContainer title={sectionTitle} headerVariant="h3">
+    <SectionContainerWithSpinner title={sectionTitle} headerVariant="h3" isLoading={isLoading}>
       <MyBacking />
       <Separator />
       <BalancesSection />
-    </SectionContainer>
+    </SectionContainerWithSpinner>
   )
 }

--- a/src/app/user/my-holdings/hooks/useIsBuilder.ts
+++ b/src/app/user/my-holdings/hooks/useIsBuilder.ts
@@ -4,7 +4,11 @@ import { zeroAddress } from 'viem'
 
 export const useIsBuilder = () => {
   const { address } = useAccount()
-  const { data: gauge } = useReadBuilderRegistry(
+  const {
+    data: gauge,
+    isLoading,
+    error,
+  } = useReadBuilderRegistry(
     {
       functionName: 'builderToGauge',
       args: [address ?? zeroAddress],
@@ -18,5 +22,7 @@ export const useIsBuilder = () => {
     isUserBuilder,
     gauge,
     address,
+    isLoading,
+    error,
   }
 }

--- a/src/app/user/my-holdings/hooks/useIsBuilder.ts
+++ b/src/app/user/my-holdings/hooks/useIsBuilder.ts
@@ -1,0 +1,22 @@
+import { useReadBuilderRegistry } from '@/shared/hooks/contracts'
+import { useAccount } from 'wagmi'
+import { zeroAddress } from 'viem'
+
+export const useIsBuilder = () => {
+  const { address } = useAccount()
+  const { data: gauge } = useReadBuilderRegistry(
+    {
+      functionName: 'builderToGauge',
+      args: [address ?? zeroAddress],
+    },
+    { enabled: !!address },
+  )
+
+  const isUserBuilder = Boolean(gauge && gauge !== zeroAddress)
+
+  return {
+    isUserBuilder,
+    gauge,
+    address,
+  }
+}


### PR DESCRIPTION
[TOK-874](https://rsklabs.atlassian.net/jira/software/projects/TOK/boards/267?selectedIssue=TOK-874)

According to the US updates, content show always display as long as there is a connected user.
I just removed a TODO, and shows the title conditionally if the user is a backer, or a builder.