### PR TITLE
Tok 875/allocation bar overlaps and style

### DIFF
--- a/src/app/backing/components/AllocationBar/AllocationBarDragHandle.tsx
+++ b/src/app/backing/components/AllocationBar/AllocationBarDragHandle.tsx
@@ -1,5 +1,4 @@
 import { DraggableAttributes } from '@dnd-kit/core/dist/hooks/useDraggable'
-import { FourDotsIcon } from '@/components/Icons/FourDotsIcon'
 import { SyntheticListenerMap } from '@dnd-kit/core/dist/hooks/utilities/useSyntheticListeners'
 
 export const AllocationBarDragHandle = ({
@@ -13,11 +12,9 @@ export const AllocationBarDragHandle = ({
     <div
       {...attributes}
       {...listeners}
-      className="cursor-grab flex items-center px-1 select-none user-select-none h-full align-self-stretch bg-[rgba(255,255,255,0.06)]"
+      className="cursor-grab flex items-center px-1 select-none user-select-none h-full w-full"
       aria-label="Drag to reorder"
       tabIndex={0}
-    >
-      <FourDotsIcon />
-    </div>
+    />
   )
 }

--- a/src/app/backing/components/AllocationBar/AllocationBarResizeHandle.tsx
+++ b/src/app/backing/components/AllocationBar/AllocationBarResizeHandle.tsx
@@ -9,7 +9,7 @@ export const AllocationBarResizeHandle = ({
 }) => {
   return (
     <div
-      className="w-2 cursor-ew-resize h-full flex items-center justify-center z-10 ml-1 mr-1 bg-transparent absolute right-[-12px] top-0 bottom-0"
+      className="w-2 cursor-ew-resize h-full flex items-center justify-center z-10 ml-1 mr-1 bg-transparent absolute -right-3 top-0 bottom-0"
       onMouseDown={onHandleMouseDown(index)}
     >
       <div

--- a/src/app/backing/components/AllocationBar/AllocationBarResizeHandle.tsx
+++ b/src/app/backing/components/AllocationBar/AllocationBarResizeHandle.tsx
@@ -9,7 +9,7 @@ export const AllocationBarResizeHandle = ({
 }) => {
   return (
     <div
-      className="w-2 cursor-ew-resize h-full flex items-center justify-center z-10 ml-1 mr-1 bg-transparent absolute -right-0.5 top-0 bottom-0"
+      className="w-2 cursor-ew-resize h-full flex items-center justify-center z-10 ml-1 mr-1 bg-transparent absolute right-[-12px] top-0 bottom-0"
       onMouseDown={onHandleMouseDown(index)}
     >
       <div

--- a/src/app/backing/components/AllocationBar/AllocationBarSegment.tsx
+++ b/src/app/backing/components/AllocationBar/AllocationBarSegment.tsx
@@ -5,7 +5,7 @@ import { AllocationBarResizeHandle } from './AllocationBarResizeHandle'
 import { AllocationBarValueDisplay, AllocationItem } from './types'
 import { checkerboardStyle, valueToPercentage } from './utils'
 import { Tooltip } from '@/components/Tooltip'
-import MoreIcon from '@/components/Icons/MoreIcon'
+import { MoreIcon } from '@/components/Icons/MoreIcon'
 
 const AllocationBarSegmentPercent = ({
   value,

--- a/src/app/backing/components/AllocationBar/AllocationBarSegment.tsx
+++ b/src/app/backing/components/AllocationBar/AllocationBarSegment.tsx
@@ -83,6 +83,7 @@ export const AllocationBarSegment = ({
     dragIndex !== null ? 'transition-none' : 'transition-transform duration-200 ease-out'
   const dragStateClasses = isDragging ? 'opacity-60 z-[99]' : 'opacity-100 z-1'
   const borderClasses = `${index === 0 ? 'rounded-l-sm' : ''} ${isLast ? 'rounded-r-sm' : ''}`
+  const positionClasses = !isLast ? 'mr-2' : ''
 
   return (
     <div
@@ -93,6 +94,7 @@ export const AllocationBarSegment = ({
         ${transitionClasses}
         ${dragStateClasses}
         ${borderClasses}
+        ${positionClasses}
       `.trim()}
     >
       {/* DRAG HANDLE (always far left) */}

--- a/src/app/backing/components/AllocationBar/AllocationBarSegment.tsx
+++ b/src/app/backing/components/AllocationBar/AllocationBarSegment.tsx
@@ -4,7 +4,6 @@ import { AllocationBarDragHandle } from './AllocationBarDragHandle'
 import { AllocationBarResizeHandle } from './AllocationBarResizeHandle'
 import { AllocationBarValueDisplay, AllocationItem } from './types'
 import { checkerboardStyle, valueToPercentage } from './utils'
-import { DotsOverlayVert } from '../../../proposals/new/images/DotsOverlayVert'
 import { Tooltip } from '../../../../components/Tooltip'
 import MoreIcon from '@/components/Icons/MoreIcon'
 
@@ -37,8 +36,8 @@ const AllocationBarSegmentPercent = ({
 
   if (showDots) {
     return (
-      <Tooltip text={displayValue} side="top" align="center" className="p-4 z-50">
-        <MoreIcon size={16} className="absolute -top-7 left-1/2 -translate-x-1/2 cursor-pointer z-10" />
+      <Tooltip text={displayValue} side="top" align="center" className="p-4 z-10 text-lg">
+        <MoreIcon size={16} className="absolute -top-7 left-1/2 -translate-x-1/2  cursor-pointer z-10" />
       </Tooltip>
     )
   }
@@ -112,19 +111,17 @@ export const AllocationBarSegment = ({
         ${positionClasses}
       `.trim()}
     >
-      {/* DRAG HANDLE (always far left) */}
+      {/* DRAG HANDLE of the size of the segment */}
       {isDraggable && <AllocationBarDragHandle attributes={attributes} listeners={listeners} />}
 
-      <div className="flex-1 flex items-center justify-center relative">
-        {
-          <AllocationBarSegmentPercent
-            value={value}
-            totalValue={totalValue}
-            valueDisplay={valueDisplay}
-            showDots={showDots}
-          />
-        }
-      </div>
+      {
+        <AllocationBarSegmentPercent
+          value={value}
+          totalValue={totalValue}
+          valueDisplay={valueDisplay}
+          showDots={showDots}
+        />
+      }
 
       {/* RESIZE HANDLE (far right, not overlapping drag handle) */}
       {!isLast && isResizable && (

--- a/src/app/backing/components/AllocationBar/AllocationBarSegment.tsx
+++ b/src/app/backing/components/AllocationBar/AllocationBarSegment.tsx
@@ -4,15 +4,20 @@ import { AllocationBarDragHandle } from './AllocationBarDragHandle'
 import { AllocationBarResizeHandle } from './AllocationBarResizeHandle'
 import { AllocationBarValueDisplay, AllocationItem } from './types'
 import { checkerboardStyle, valueToPercentage } from './utils'
+import { DotsOverlayVert } from '../../../proposals/new/images/DotsOverlayVert'
+import { Tooltip } from '../../../../components/Tooltip'
+import MoreIcon from '@/components/Icons/MoreIcon'
 
 const AllocationBarSegmentPercent = ({
   value,
   totalValue,
   valueDisplay,
+  showDots = false,
 }: {
   value: number
   totalValue: number
   valueDisplay: AllocationBarValueDisplay
+  showDots?: boolean
 }) => {
   const { percentDecimals, valueDecimals } = valueDisplay.format ?? {}
 
@@ -29,6 +34,14 @@ const AllocationBarSegmentPercent = ({
   let displayValue = ''
   if (showValue) displayValue += formattedValue
   if (showPercent) displayValue += showValue ? ` (${percent}%)` : `${percent}%`
+
+  if (showDots) {
+    return (
+      <Tooltip text={displayValue} side="top" align="center" className="p-4 z-50">
+        <MoreIcon size={16} className="absolute -top-7 left-1/2 -translate-x-1/2 cursor-pointer z-10" />
+      </Tooltip>
+    )
+  }
 
   return (
     <span className="absolute -top-7 left-1/2 -translate-x-1/2 pointer-events-none whitespace-nowrap font-normal leading-5 text-v3-bg-accent-0 font-rootstock-sans">
@@ -48,6 +61,7 @@ interface AllocationBarSegmentProps {
   dragIndex: number | null
   isDraggable: boolean
   isResizable: boolean
+  showDots?: boolean
 }
 
 export const AllocationBarSegment = ({
@@ -61,6 +75,7 @@ export const AllocationBarSegment = ({
   dragIndex,
   isDraggable,
   isResizable,
+  showDots,
 }: AllocationBarSegmentProps) => {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useSortable({ id: item.key })
 
@@ -101,7 +116,14 @@ export const AllocationBarSegment = ({
       {isDraggable && <AllocationBarDragHandle attributes={attributes} listeners={listeners} />}
 
       <div className="flex-1 flex items-center justify-center relative">
-        {<AllocationBarSegmentPercent value={value} totalValue={totalValue} valueDisplay={valueDisplay} />}
+        {
+          <AllocationBarSegmentPercent
+            value={value}
+            totalValue={totalValue}
+            valueDisplay={valueDisplay}
+            showDots={showDots}
+          />
+        }
       </div>
 
       {/* RESIZE HANDLE (far right, not overlapping drag handle) */}

--- a/src/app/backing/components/AllocationBar/AllocationBarSegment.tsx
+++ b/src/app/backing/components/AllocationBar/AllocationBarSegment.tsx
@@ -4,7 +4,7 @@ import { AllocationBarDragHandle } from './AllocationBarDragHandle'
 import { AllocationBarResizeHandle } from './AllocationBarResizeHandle'
 import { AllocationBarValueDisplay, AllocationItem } from './types'
 import { checkerboardStyle, valueToPercentage } from './utils'
-import { Tooltip } from '../../../../components/Tooltip'
+import { Tooltip } from '@/components/Tooltip'
 import MoreIcon from '@/components/Icons/MoreIcon'
 
 const AllocationBarSegmentPercent = ({


### PR DESCRIPTION
[TOK-875](https://rsklabs.atlassian.net/jira/software/projects/TOK/boards/267?selectedIssue=TOK-875)

- show tooltip with percentages for small segments 
      - more exactly, when 2 neighbor's sum is small
- move separator between bar segments, according to the design
- remove 3 dots, and allow the whole bar to drag segment

Still awaiting Vlad confirmation on the changes