### PR TITLE
TOK-881: remove hardcoded size to adjust to screen size

### DIFF
--- a/src/app/collective-rewards/components/BackersCallToAction/BackersCallToAction.tsx
+++ b/src/app/collective-rewards/components/BackersCallToAction/BackersCallToAction.tsx
@@ -11,6 +11,7 @@ import { ActiveBackers } from '../ActiveBackers'
 import { FC } from 'react'
 import { RewardsMetrics } from '../RewardsMetrics'
 import { useRouter } from 'next/navigation'
+import { cn } from '@/lib/utils'
 
 const BackersBanner = () => (
   <Banner
@@ -68,13 +69,14 @@ const BackerCTAButton = () => {
 interface BackersCallToActionProps {
   rifRewards: bigint
   rbtcRewards: bigint
+  className?: string
 }
-export const BackersCallToAction: FC<BackersCallToActionProps> = ({ rifRewards, rbtcRewards }) => {
+export const BackersCallToAction: FC<BackersCallToActionProps> = ({ rifRewards, rbtcRewards, className }) => {
   return (
     <CallToActionCard
       title={<BackersTitle />}
       banner={<BackersBanner />}
-      className="bg-v3-text-80 rounded-sm"
+      className={cn('bg-v3-text-80 rounded-sm w-full', className)}
     >
       <MetricsContainer className="px-6 pb-10 pt-0 bg-v3-text-80 items-start divide-y-0">
         <BackerCTAButton />

--- a/src/app/collective-rewards/components/Banner/Banner.tsx
+++ b/src/app/collective-rewards/components/Banner/Banner.tsx
@@ -10,7 +10,7 @@ interface BannerProps {
 export const Banner = ({ imageSrc, altText, DecorativeComponent }: BannerProps) => {
   return (
     <div className="relative p-4">
-      <div className="min-w-[536px] h-[240px] overflow-hidden relative">
+      <div className="w-full h-[240px] overflow-hidden relative">
         <Image src={imageSrc} alt={altText} fill />
       </div>
       <DecorativeComponent

--- a/src/app/collective-rewards/components/BuildersCallToAction/BuildersCallToAction.tsx
+++ b/src/app/collective-rewards/components/BuildersCallToAction/BuildersCallToAction.tsx
@@ -11,6 +11,7 @@ import { ActiveBuilders } from '../ActiveBuilders'
 import { FC } from 'react'
 import { RewardsMetrics } from '../RewardsMetrics'
 import { useRouter } from 'next/navigation'
+import { cn } from '@/lib/utils'
 
 const BuildersBanner = () => (
   <Banner
@@ -64,11 +65,20 @@ const BuilderCTAButton = () => {
 interface BuildersCallToActionProps {
   rifRewards: bigint
   rbtcRewards: bigint
+  className?: string
 }
 
-export const BuildersCallToAction: FC<BuildersCallToActionProps> = ({ rifRewards, rbtcRewards }) => {
+export const BuildersCallToAction: FC<BuildersCallToActionProps> = ({
+  rifRewards,
+  rbtcRewards,
+  className,
+}) => {
   return (
-    <CallToActionCard title={<BuildersTitle />} banner={<BuildersBanner />} className="bg-v3-text-80">
+    <CallToActionCard
+      title={<BuildersTitle />}
+      banner={<BuildersBanner />}
+      className={cn('bg-v3-text-80 w-full', className)}
+    >
       <MetricsContainer className="px-6 pb-10 pt-0 bg-v3-text-80 items-start divide-y-0">
         <BuilderCTAButton />
         <Paragraph className="text-v3-text-0">

--- a/src/app/collective-rewards/components/CallToActionSection/CallToActionSection.tsx
+++ b/src/app/collective-rewards/components/CallToActionSection/CallToActionSection.tsx
@@ -33,8 +33,12 @@ export const CallToActionSection = () => {
 
   return (
     <InfoContainer className="flex-row p-0 pt-1">
-      <BackersCallToAction rifRewards={rifBackerRewards} rbtcRewards={rbtcBackerRewards} />
-      <BuildersCallToAction rifRewards={rifBuilderRewards} rbtcRewards={rbtcBuilderRewards} />
+      <BackersCallToAction rifRewards={rifBackerRewards} rbtcRewards={rbtcBackerRewards} className="w-1/2" />
+      <BuildersCallToAction
+        rifRewards={rifBuilderRewards}
+        rbtcRewards={rbtcBuilderRewards}
+        className="w-1/2"
+      />
     </InfoContainer>
   )
 }

--- a/src/app/user/latest-collective/components/LatestProposalCard.tsx
+++ b/src/app/user/latest-collective/components/LatestProposalCard.tsx
@@ -12,7 +12,7 @@ export const LatestProposalCard = ({
   proposal: { proposalId, name, category, Starts, proposer },
   'data-testid': dataTestId,
 }: LatestProposalCardProps) => (
-  <div className="p-6 w-[360px] h-[156px] bg-bg-60" data-testid={dataTestId}>
+  <div className="p-6 w-1/3 bg-bg-60 bg-bg-60" data-testid={dataTestId}>
     <Link
       className="text-primary group-hover:underline group-hover:text-bg-100 group-hover:decoration-bg-40"
       href={`/proposals/${proposalId}`}


### PR DESCRIPTION
Due to a pixel-fixed width + gap, the `LatestProposalCard` were expanding the backing page width gap value, making that page not consistent in width. I added dynamic dimensions to the card to avoid this.

[TOK-881](https://rsklabs.atlassian.net/jira/software/projects/TOK/boards/267?selectedIssue=TOK-881)