### PR TITLE
TOK-908: removes tables sticky selection

### DIFF
--- a/src/app/builders/components/Table/BuilderDataRow.tsx
+++ b/src/app/builders/components/Table/BuilderDataRow.tsx
@@ -327,8 +327,15 @@ export const BuilderDataRow: FC<BuilderDataRowProps> = ({ row, ...props }) => {
           <RewardsPastCycleCell {...rewards_past_cycle} />
           <RewardsUpcomingCell {...rewards_upcoming} />
           <BuilderBackingCell {...backing} />
-          {!(isHovered && isConnected) && <BuilderBackingShareCell backingPercentage={backingPercentage} />}
-          <ActionsCell {...actions} forceShow={isHovered && isConnected} />
+          <BuilderBackingShareCell
+            backingPercentage={backingPercentage}
+            className={isHovered ? 'hidden' : 'visible'}
+          />
+          <ActionsCell
+            {...actions}
+            forceShow={isHovered && isConnected}
+            className={isHovered ? 'visible' : 'hidden'}
+          />
           <td className="w-[24px]"></td>
         </tr>
       </ConditionalTooltip>

--- a/src/app/my-rewards/backers/components/Table/BackerRewardsDataRow.tsx
+++ b/src/app/my-rewards/backers/components/Table/BackerRewardsDataRow.tsx
@@ -199,8 +199,8 @@ export const BackerRewardsDataRow: FC<BackerRewardsDataRowProps> = ({ row, ...pr
         <UnclaimedCell {...unclaimed} />
         <EstimatedCell {...estimated} />
         <TotalCell {...total} />
-        {!isHovered && isConnected && <BuilderBackingCell {...backing} />}
-        <ActionsCell {...actions} forceShow={isHovered} />
+        <BuilderBackingCell {...backing} className={isHovered ? 'hidden' : 'visible'} />
+        <ActionsCell {...actions} forceShow={isHovered} className={isHovered ? 'visible' : 'hidden'} />
         <td className="w-[24px]"></td>
       </tr>
     </ConditionalTooltip>


### PR DESCRIPTION
Instead of rendering different components on hover, we change tailwinds classes to show/hide the cell