### PR TITLE
Make Sidebar and Header Bars Sticky (Non-Scrollable)

### DIFF
--- a/src/components/MainContainer/sidebars/SidebarDesktop.tsx
+++ b/src/components/MainContainer/sidebars/SidebarDesktop.tsx
@@ -55,7 +55,7 @@ export const SidebarDesktop = () => {
           {/* Menu */}
           <ul className="px-3">
             {menuDataToUse.map(data => (
-              <Fragment key={data.text}>
+              <Fragment key={data.buttonProps.id}>
                 {'type' in data && data.type === 'category' ? (
                   <li
                     {...data.buttonProps}

--- a/src/components/MainContainer/sidebars/SidebarMobile.tsx
+++ b/src/components/MainContainer/sidebars/SidebarMobile.tsx
@@ -39,11 +39,11 @@ export function SidebarMobile() {
       <div className="h-full flex flex-col justify-between gap-4 ">
         <ul className="w-fit">
           {menuDataToUse.map(data => (
-            <Fragment key={data.href}>
+            <Fragment key={data.buttonProps.id}>
               {'type' in data && data.type === 'category' ? (
                 <div className="m-3" />
               ) : (
-                <MenuItem key={data.href} {...data} />
+                <MenuItem key={data.buttonProps.id} {...data} />
               )}
             </Fragment>
           ))}

--- a/src/components/MainContainer/sidebars/menuData.ts
+++ b/src/components/MainContainer/sidebars/menuData.ts
@@ -91,7 +91,7 @@ export const menuDataNotConnected = [
   {
     href: '',
     text: 'Holdings',
-    buttonProps: { id: 'Button_User', name: 'user' },
+    buttonProps: { id: 'Button_Holdings_Not_Connected', name: 'holdings' },
     iconUrl: '/images/sidemenukoto/Holdings.svg',
   },
   {


### PR DESCRIPTION
# Make Sidebar and Header Bars Sticky (Non-Scrollable)

## What
- Made desktop sidebar sticky positioned to remain in place during scroll
- Changed mobile sidebar to fixed positioning for consistent behavior
- Adjusted useful links positioning within the sticky sidebar layout

## Why
Per designs and ticket DAO-1428, the sidebar should remain static when users scroll the page content. Previously, the sidebar would scroll with the page, creating poor UX and not matching the intended design.

## Ticket
[DAO-1428](https://rsklabs.atlassian.net/browse/DAO-1428)