### PR TITLE
Prevent stacking banner flickering on home screenre rendering before initial data load

### DIFF
--- a/src/app/user/StackingNotifications/StackingNotifications.tsx
+++ b/src/app/user/StackingNotifications/StackingNotifications.tsx
@@ -4,7 +4,7 @@ import { useRequiredTokens } from '@/app/user/IntroModal/hooks/useRequiredTokens
 import { BannerContent } from '@/components/StackableBanner/BannerContent'
 import { StackableBanner } from '@/components/StackableBanner/StackableBanner'
 import { useRouter } from 'next/navigation'
-import { useMemo } from 'react'
+import { useMemo, useEffect, useState } from 'react'
 import { zeroAddress } from 'viem'
 import { useAccount } from 'wagmi'
 import {
@@ -214,8 +214,17 @@ const StackingNotificationsContent = () => {
   // Wait for all dependencies to load before proceeding
   const areDependenciesLoaded = dependencies.every(dependency => dependency)
 
-  if (!areDependenciesLoaded) {
-    return null
+  // Only block rendering on FIRST load, not on subsequent polling updates
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false)
+
+  useEffect(() => {
+    if (areDependenciesLoaded && !hasLoadedOnce) {
+      setHasLoadedOnce(true)
+    }
+  }, [areDependenciesLoaded, hasLoadedOnce])
+
+  if (!hasLoadedOnce) {
+    return null // Only return null before first successful load
   }
 
   // Early return if no banners should be shown


### PR DESCRIPTION
# Fix: Prevent stacking banner flickering on home screen

## What
Fixed flickering issue with stacking banners on the home screen that occurred approximately every minute after user connection.

## Why
The banner component was returning `null` during dependency loading checks on every polling cycle (every ~60 seconds), causing the DOM element to unmount and remount, resulting in visible flickering.

The root cause was the `areDependenciesLoaded` check that blocked rendering not just on initial load, but also during subsequent data polling updates.

## Changes
- Added `hasLoadedOnce` state to track initial load completion
- Modified loading logic to only return `null` before the first successful render
- After initial load, component continues rendering even during polling updates
- Maintains live data updates while preventing visual flickering

## Ticket
[Resolves: Stacking Banner HomeScreen - Flickers](https://rsklabs.atlassian.net/browse/DAO-1448)

**AC**: ✅ Do not render anymore when it's rendered once (banner stays visible after initial load)