### PR TITLE
feat: add Next.js Turbopack support with webpack fallback

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -46,7 +46,7 @@ const nextConfig = {
 
     return config
   },
-  // TODO: temporary patch. investigate
+  turbopack: {},
   images: {
     remotePatterns: [
       {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "dao-frontend",
   "version": "1.11.0",
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbo",
+    "dev:webpack": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
@@ -10,8 +11,8 @@
     "lint-tsc": "tsc --noEmit",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "e2e-open": "start-server-and-test dev http://localhost:3000 \"cypress open --e2e\"",
-    "e2e-test": "start-server-and-test dev http://localhost:3000 \"cypress run --e2e\"",
+    "e2e-open": "start-server-and-test dev:webpack http://localhost:3000 \"cypress open --e2e\"",
+    "e2e-test": "start-server-and-test dev:webpack http://localhost:3000 \"cypress run --e2e\"",
     "test": "vitest",
     "build:start": "next build && next start"
   },


### PR DESCRIPTION
## What
- Added Turbopack support for development mode
- Created separate webpack development script for stability
- Updated Cypress E2E tests to use webpack mode

## Why
- Turbopack provides significantly faster development experience with faster hot reloads and compilation
- Webpack fallback ensures compatibility with custom webpack configurations and stable testing environment
- Separate scripts allow developers to choose between speed (Turbopack) and stability (webpack) based on their needs

## Changes
- Modified `dev` script to use `--turbo` flag for Turbopack
- Added `dev:webpack` script for traditional webpack development
- Updated Cypress test scripts to use `dev:webpack` for reliable E2E testing
- Removed experimental Turbopack configuration (not needed in Next.js 15)