### PR TITLE
Rename to BaseTypography

### DIFF
--- a/src/app/backing/components/AvailableBackingMetric/AvailableBackingMetric.tsx
+++ b/src/app/backing/components/AvailableBackingMetric/AvailableBackingMetric.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { Tooltip } from '@/components/Tooltip'
 import { STRIF } from '@/lib/constants'
 import { KotoQuestionMarkIcon } from '@/components/Icons/KotoQuestionMarkIcon'
@@ -15,9 +15,9 @@ interface AvailableBackingMetricProps {
 const StakeButton = ({ onStakeClick }: { onStakeClick?: () => void }) => (
   <>
     <Button variant="primary" className="flex h-7 px-4 py-3 items-center gap-2" onClick={onStakeClick}>
-      <Typography variant="tag-s" className="text-v3-bg-accent-100">
+      <BaseTypography variant="tag-s" className="text-v3-bg-accent-100">
         Stake RIF
-      </Typography>
+      </BaseTypography>
     </Button>
   </>
 )
@@ -29,20 +29,20 @@ const DistributeButton = ({ onDistributeClick }: { onDistributeClick?: () => voi
       className="flex h-7 px-2 py-1 items-center gap-2"
       onClick={onDistributeClick}
     >
-      <Typography
+      <BaseTypography
         variant="tag-s"
         className="text-white font-rootstock-sans text-sm font-normal leading-[145%]"
       >
         Distribute equally
-      </Typography>
+      </BaseTypography>
     </Button>
     <div className="flex w-4 py-[6px] flex-col justify-center items-center self-stretch aspect-square">
       <Tooltip
         text={
           <div className="flex w-[269px] p-6 flex-col items-start gap-2">
-            <Typography className="self-stretch text-v3-bg-accent-100 font-rootstock-sans text-[14px] font-normal leading-[145%]">
+            <BaseTypography className="self-stretch text-v3-bg-accent-100 font-rootstock-sans text-[14px] font-normal leading-[145%]">
               You&apos;ll be distributing equally to each of the Builders below
-            </Typography>
+            </BaseTypography>
           </div>
         }
         side="top"

--- a/src/app/backing/components/BackingBanner/BackingBanner.tsx
+++ b/src/app/backing/components/BackingBanner/BackingBanner.tsx
@@ -1,6 +1,6 @@
 import { DecorativeSquares } from '@/app/backing/components/DecorativeSquares'
 import { Header, Span } from '@/components/Typography'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { cn } from '@/lib/utils'
 import { FC } from 'react'
 import { CommonComponentProps } from '@/components/commonProps'
@@ -19,13 +19,13 @@ export const BackingBanner: FC<CommonComponentProps> = ({ className = '' }) => {
       <Header variant="h3">WHAT&apos;S IN IT FOR ME?</Header>
       <ul className="list-[circle] pl-6">
         <li>
-          <Typography>Earn a share of the rewards from Builders you back</Typography>
+          <BaseTypography>Earn a share of the rewards from Builders you back</BaseTypography>
         </li>
         <li>
-          <Typography>Influence how rewards are distributed to Builders</Typography>
+          <BaseTypography>Influence how rewards are distributed to Builders</BaseTypography>
         </li>
         <li>
-          <Typography>Retain full ownership and access to your stRIF</Typography>
+          <BaseTypography>Retain full ownership and access to your stRIF</BaseTypography>
         </li>
       </ul>
       <Span>

--- a/src/app/backing/components/BackingInfoTitle/BackingInfoTitle.tsx
+++ b/src/app/backing/components/BackingInfoTitle/BackingInfoTitle.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/Button'
 import { Span } from '@/components/Typography'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { CommonComponentProps } from '@/components/commonProps'
 import { cn } from '@/lib/utils'
 import { FC } from 'react'
@@ -17,10 +17,10 @@ export const BackingInfoTitle: FC<BackingInfoTitleProps> = ({
 }) => {
   return (
     <div className={cn('flex flex-row gap-3', className)}>
-      <Typography className="text-v3-text-100">
+      <BaseTypography className="text-v3-text-100">
         {isConnected && <Span className="font-bold">You are not backing any Builders yet. </Span>}
         <Span>Use your stRIF backing power to support the Builders you believe in.</Span>
-      </Typography>
+      </BaseTypography>
 
       {isConnected && hasAllocations && (
         <Button variant="primary" className="shrink-0 ml-auto">

--- a/src/app/backing/components/Metrics/BackerAnnualBackersIncentives.tsx
+++ b/src/app/backing/components/Metrics/BackerAnnualBackersIncentives.tsx
@@ -5,7 +5,7 @@ import { useAccount } from 'wagmi'
 import { LoadingSpinner } from '@/components/LoadingSpinner'
 import { Metric, MetricTitle } from '@/components/Metric'
 import { Header } from '@/components/Typography'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { ABIFormula } from '../ABIFormula'
 
 export const BackerAnnualBackersIncentives = () => {
@@ -20,18 +20,18 @@ export const BackerAnnualBackersIncentives = () => {
       title={
         <MetricTitle
           title={
-            <Typography
+            <BaseTypography
               variant="tag"
               className="text-v3-bg-accent-0 text-base font-medium font-rootstock-sans leading-[150%]"
             >
               Annual Backers Incentives
-            </Typography>
+            </BaseTypography>
           }
           infoIconProps={{
             tooltipClassName: 'max-w-sm text-sm',
           }}
           info={
-            <Typography>
+            <BaseTypography>
               Your Annual Backers Incentives (%) represents an estimate of the annualized percentage of
               rewards that you could receive based on your backing allocations.
               <br />
@@ -44,13 +44,13 @@ export const BackerAnnualBackersIncentives = () => {
               <br />
               This estimation is dynamic and may vary based on total rewards and user activity. This data is
               for informational purposes only.
-            </Typography>
+            </BaseTypography>
           }
         />
       }
     >
       <Header variant="h1">
-        {abiPct.toFixed(0)} <Typography variant="body-l">% (estimated)</Typography>
+        {abiPct.toFixed(0)} <BaseTypography variant="body-l">% (estimated)</BaseTypography>
       </Header>
     </Metric>
   )

--- a/src/app/backing/components/RIFToken/RIFToken.tsx
+++ b/src/app/backing/components/RIFToken/RIFToken.tsx
@@ -2,7 +2,7 @@ import { TokenImage } from '@/components/TokenImage'
 import { RIF } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 import { FC } from 'react'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 
 export const RIFToken: FC<{ size?: number; className?: string; textClassName?: string }> = ({
   className,
@@ -15,7 +15,7 @@ export const RIFToken: FC<{ size?: number; className?: string; textClassName?: s
       data-testid="currentBackingToken"
     >
       <TokenImage symbol={RIF} size={size} />
-      <Typography className={cn('text-xs text-v3-text-100', textClassName)}>stRIF</Typography>
+      <BaseTypography className={cn('text-xs text-v3-text-100', textClassName)}>stRIF</BaseTypography>
     </div>
   )
 }

--- a/src/app/builders/components/BecomeBuilderBanner/BecomeBuilderBanner.tsx
+++ b/src/app/builders/components/BecomeBuilderBanner/BecomeBuilderBanner.tsx
@@ -1,5 +1,5 @@
 import { Paragraph } from '@/components/Typography'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { Button } from '@/components/Button'
 import Image from 'next/image'
 import CollapsibleWithPreview from '@/components/CollapsibleWithPreview/CollapsibleWithPreview'
@@ -23,15 +23,15 @@ const ExpandedContent = () => {
       {/* Center: Main Content */}
       <div className="flex flex-col text-base justify-center gap-4 basis-1/2 md:basis-1/2 mt-16">
         <div>
-          <Typography variant="h1" className="text-v3-text-0">
+          <BaseTypography variant="h1" className="text-v3-text-0">
             BECOME A COLLECTIVE BUILDER.
-          </Typography>
+          </BaseTypography>
           <br />
-          <Typography variant="h1" className="text-v3-bg-accent-20 mt-2">
+          <BaseTypography variant="h1" className="text-v3-bg-accent-20 mt-2">
             SECURE FUNDING. EARN
             <br />
             CONTINUOUSLY.
-          </Typography>
+          </BaseTypography>
         </div>
         <Paragraph className="text-v3-text-0">
           Join a growing network of innovators building the future of decentralised infrastructure. Get
@@ -52,9 +52,9 @@ const ExpandedContent = () => {
       </div>
       {/* Right: Why Become a Builder */}
       <div className="flex flex-col justify-center bg-transparent basis-1/4 md:basis-1/4 w-full md:pl-8 mt-16">
-        <Typography variant="h3" className="text-v3-text-0 mb-4">
+        <BaseTypography variant="h3" className="text-v3-text-0 mb-4">
           WHY BECOME A BUILDER?
-        </Typography>
+        </BaseTypography>
         <ul className="list-[circle] pl-4 text-v3-text-0">
           <li>
             <Paragraph>join a mission-aligned network</Paragraph>

--- a/src/app/builders/components/Table/Cell/BackingCell/BackingCell.tsx
+++ b/src/app/builders/components/Table/Cell/BackingCell/BackingCell.tsx
@@ -1,6 +1,6 @@
 import { CommonComponentProps } from '@/components/commonProps'
 import { TokenImage } from '@/components/TokenImage'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { RIF } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 import { ReactNode } from 'react'
@@ -24,29 +24,29 @@ export const BackingCell = ({
   return (
     <div className={cn('flex justify-end items-end gap-2', className)} data-testid="BackingCell">
       <div className="flex flex-col items-end">
-        <Typography
+        <BaseTypography
           variant="body"
           className={cn('font-rootstock-sans text-base font-normal leading-6 text-right')}
         >
           {formattedAmount}
-        </Typography>
-        <Typography
+        </BaseTypography>
+        <BaseTypography
           variant="body"
           className="font-rootstock-sans text-xs font-normal leading-[18px] text-right text-v3-bg-accent-40"
         >
           {formattedUsdAmount}
-        </Typography>
+        </BaseTypography>
       </div>
       <div className="flex flex-col items-start gap-1">
         <div className="flex justify-center items-center aspect-square">
           <TokenImage symbol={RIF} />
         </div>
-        <Typography
+        <BaseTypography
           variant="body"
           className="font-rootstock-sans text-xs font-normal leading-[18px] text-v3-bg-accent-40"
         >
           USD
-        </Typography>
+        </BaseTypography>
       </div>
     </div>
   )

--- a/src/app/collective-rewards/components/CallToActionCard/CallToActionCard.stories.tsx
+++ b/src/app/collective-rewards/components/CallToActionCard/CallToActionCard.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs'
 import { CallToActionCard } from './CallToActionCard'
 import { BackingBanner } from '@/app/backing/components/BackingBanner/BackingBanner'
 import { Header, Paragraph } from '@/components/Typography'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { MetricsContainer } from '@/components/containers/MetricsContainer'
 
 const meta: Meta<typeof CallToActionCard> = {
@@ -38,7 +38,7 @@ export const Default: Story = {
     ),
     children: (
       <MetricsContainer className="px-6 pb-10 pt-0">
-        <Typography className="text-v3-text-0">Default container content</Typography>
+        <BaseTypography className="text-v3-text-0">Default container content</BaseTypography>
       </MetricsContainer>
     ),
   },
@@ -55,7 +55,7 @@ export const CustomStyles: Story = {
     ),
     children: (
       <MetricsContainer className="mx-4 ">
-        <Typography>Customized container content</Typography>
+        <BaseTypography>Customized container content</BaseTypography>
       </MetricsContainer>
     ),
   },

--- a/src/app/collective-rewards/components/ClaimRewardModal/ClaimRewardRadioOption.tsx
+++ b/src/app/collective-rewards/components/ClaimRewardModal/ClaimRewardRadioOption.tsx
@@ -1,5 +1,5 @@
 import { LoadingSpinner } from '@/components/LoadingSpinner'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import * as RadioGroup from '@radix-ui/react-radio-group'
 import { FC, ReactNode } from 'react'
 import { ClaimRewardType } from './types'
@@ -32,10 +32,10 @@ export const ClaimRewardRadioOption: FC<ClaimRewardRadioOptionProps> = ({
             <RadioGroup.Indicator className="w-full h-full rounded-full border-4 border-white" />
           </span>
           <div className="flex flex-col items-start gap-2 justify-start text-left w-full">
-            <Typography variant="h3">{label}</Typography>
-            <Typography variant="body" className="text-v3-bg-accent-0">
+            <BaseTypography variant="h3">{label}</BaseTypography>
+            <BaseTypography variant="body" className="text-v3-bg-accent-0">
               {subLabel}
-            </Typography>
+            </BaseTypography>
           </div>
         </div>
       )}

--- a/src/app/collective-rewards/components/ClaimRewardModal/ClaimRewardsModalView.tsx
+++ b/src/app/collective-rewards/components/ClaimRewardModal/ClaimRewardsModalView.tsx
@@ -4,7 +4,7 @@ import { TransactionInProgressButton } from '@/app/user/Stake/components/Transac
 import { Button } from '@/components/Button'
 import { Modal } from '@/components/Modal/Modal'
 import { TokenImage } from '@/components/TokenImage'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { RBTC } from '@/lib/constants'
 import { cn, formatCurrencyWithLabel } from '@/lib/utils'
 import { FC, ReactNode } from 'react'
@@ -72,20 +72,20 @@ export const ClaimRewardsModalView: FC<ClaimRewardsModalViewProps> = ({
       className={cn('font-rootstock-sans shadow-[0px_0px_40px_0px_rgba(255,255,255,0.10)]', className)}
     >
       <div className="p-8 flex flex-col gap-8">
-        <Typography variant="h1">CLAIM REWARDS</Typography>
-        <Typography>
+        <BaseTypography variant="h1">CLAIM REWARDS</BaseTypography>
+        <BaseTypography>
           Select the rewards that you want to claim, then confirm the transaction in your wallet.
-        </Typography>
+        </BaseTypography>
         <ClaimRewardRadioGroup
           value={selectedRewardType}
           onValueChange={onRewardTypeChange}
           options={radioOptions}
           isLoading={isLoading}
         />
-        <Typography variant="body">
+        <BaseTypography variant="body">
           Claim your rewards directly to your wallet. Claimed rewards are transferred immediately, and your
           unclaimed balance resets.
-        </Typography>
+        </BaseTypography>
         <div className="flex justify-end gap-4 mt-8">
           <Button variant="secondary-outline" onClick={onClose}>
             Cancel

--- a/src/app/collective-rewards/components/CountMetric/CountMetric.tsx
+++ b/src/app/collective-rewards/components/CountMetric/CountMetric.tsx
@@ -1,5 +1,5 @@
 import { Metric } from '@/components/Metric'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { Header } from '@/components/Typography'
 import { FC } from 'react'
 import { LoadingSpinner } from '@/components/LoadingSpinner'
@@ -11,7 +11,7 @@ interface CountMetricProps extends CommonComponentProps {
 }
 export const CountMetric: FC<CountMetricProps> = ({ title, children, isLoading }) => {
   return (
-    <Metric className="text-v3-text-0" title={<Typography variant="body">{title}</Typography>}>
+    <Metric className="text-v3-text-0" title={<BaseTypography variant="body">{title}</BaseTypography>}>
       {isLoading ? <LoadingSpinner size="small" /> : <Header>{children}</Header>}
     </Metric>
   )

--- a/src/app/collective-rewards/components/RewardsMetrics/RewardsMetrics.tsx
+++ b/src/app/collective-rewards/components/RewardsMetrics/RewardsMetrics.tsx
@@ -1,6 +1,6 @@
 import { RifRbtcTooltip } from '@/components/RifRbtcTooltip/RifRbtcTooltip'
 import { DottedUnderlineLabel } from '@/components/DottedUnderlineLabel/DottedUnderlineLabel'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { Header } from '@/components/Typography'
 import { Metric } from '@/components/Metric'
 import { FC } from 'react'
@@ -24,7 +24,7 @@ export const RewardsMetrics: FC<RewardsMetricsProps> = ({ title, rbtcRewards, ri
     .toString()
 
   return (
-    <Metric className="text-v3-text-0" title={<Typography variant="body">{title}</Typography>}>
+    <Metric className="text-v3-text-0" title={<BaseTypography variant="body">{title}</BaseTypography>}>
       <div className="flex flex-row items-baseline gap-2 font-rootstock-sans">
         <Header>{formatCurrency(estimatedRewards)}</Header>
         <RifRbtcTooltip rbtcValue={rbtcRewards} rifValue={rifRewards}>

--- a/src/app/my-rewards/backers/components/BackerRewardsMetrics.tsx
+++ b/src/app/my-rewards/backers/components/BackerRewardsMetrics.tsx
@@ -7,7 +7,7 @@ import { BackerABI } from './BackerABI'
 import { TotalEarned } from './TotalEarned'
 import { RBI } from './RBI'
 import { Switch, SwitchThumb } from '@/components/Switch'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { Address } from 'viem'
 import { TOKENS } from '@/lib/tokens'
 import { useHandleErrors } from '@/app/collective-rewards/utils'
@@ -44,7 +44,7 @@ export const BackerRewardsMetrics = ({ backer }: { backer: Address }) => {
             <Switch checked={isDetailedView} onCheckedChange={() => setIsDetailedView(!isDetailedView)}>
               <SwitchThumb />
             </Switch>
-            <Typography variant="body-s">Detailed View</Typography>
+            <BaseTypography variant="body-s">Detailed View</BaseTypography>
           </div>
         )}
       </div>

--- a/src/app/my-rewards/builder/components/UpdateBackerRewardModal/UpdateBackerRewardViewModal.tsx
+++ b/src/app/my-rewards/builder/components/UpdateBackerRewardModal/UpdateBackerRewardViewModal.tsx
@@ -6,7 +6,7 @@ import { InputNumber } from '@/components/Input/InputNumber'
 import { LoadingSpinner } from '@/components/LoadingSpinner'
 import { Modal } from '@/components/Modal/Modal'
 import { Tooltip } from '@/components/Tooltip'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { cn, durationToLabel } from '@/lib/utils'
 import { Duration } from 'luxon'
 
@@ -55,28 +55,28 @@ const UpdateBackerRewardViewModal = ({
       className={cn('font-rootstock-sans shadow-[0px_0px_40px_0px_rgba(255,255,255,0.10)]', className)}
     >
       <div className="relative flex flex-col gap-8 min-w-[500px] p-6">
-        <Typography variant="h1">MY BACKERS&apos; REWARDS</Typography>
+        <BaseTypography variant="h1">MY BACKERS&apos; REWARDS</BaseTypography>
         {isLoading ? (
           <LoadingSpinner />
         ) : (
           <>
-            <Typography variant="body">
+            <BaseTypography variant="body">
               Any updates to the Rewards % will take effect after the {cooldownDuration?.days} days cooling
               period.
-            </Typography>
+            </BaseTypography>
             <div className="flex gap-6 justify-between">
               <div className="flex flex-col items-start gap-2">
-                <Typography variant="body" className="text-bg-0">
+                <BaseTypography variant="body" className="text-bg-0">
                   Current Rewards %
-                </Typography>
-                <Typography variant="h1">{currentReward}%</Typography>
+                </BaseTypography>
+                <BaseTypography variant="h1">{currentReward}%</BaseTypography>
               </div>
               <div className="flex flex-col items-center gap-2 w-[60%]">
                 <div className="flex flex-row items-center justify-between px-4 py-3 bg-input-bg w-full">
                   <div className="flex flex-col">
-                    <Typography variant="body-xs" className="text-bg-0">
+                    <BaseTypography variant="body-xs" className="text-bg-0">
                       Updated Rewards %
-                    </Typography>
+                    </BaseTypography>
                     <InputNumber
                       name="updatedReward"
                       value={updatedReward}
@@ -87,9 +87,9 @@ const UpdateBackerRewardViewModal = ({
                     />
                   </div>
                   {timeRemaining && (
-                    <Typography variant="body" className="text-brand-rootstock-lime text-sm self-end">
+                    <BaseTypography variant="body" className="text-brand-rootstock-lime text-sm self-end">
                       Effective in {timeRemaining}
-                    </Typography>
+                    </BaseTypography>
                   )}
                 </div>
                 <div className="flex items-center gap-2 w-full justify-end">

--- a/src/app/my-rewards/components/RewardCard.tsx
+++ b/src/app/my-rewards/components/RewardCard.tsx
@@ -1,7 +1,7 @@
 import { LoadingSpinner } from '@/components/LoadingSpinner'
 import { Metric, MetricTitle } from '@/components/Metric'
 import { Paragraph } from '@/components/Typography'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { ReactNode } from 'react'
 
 export const RewardCard = ({
@@ -23,9 +23,9 @@ export const RewardCard = ({
       title={
         <MetricTitle
           title={
-            <Typography variant="body" className="text-v3-bg-accent-0 text-sm">
+            <BaseTypography variant="body" className="text-v3-bg-accent-0 text-sm">
               {title}
-            </Typography>
+            </BaseTypography>
           }
           info={<Paragraph className="text-[14px] font-normal text-left">{info}</Paragraph>}
           infoIconProps={{

--- a/src/app/proposals/new/review/components/PreviewLabel.tsx
+++ b/src/app/proposals/new/review/components/PreviewLabel.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import InfoIcon from './InfoIcon'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 
 export function PreviewLabel() {
   return (
     <div className="flex gap-1 items-center justify-end flex-nowrap">
       <InfoIcon />
-      <Typography className="text-sm md:text-base leading-tight text-text-40 whitespace-nowrap">
+      <BaseTypography className="text-sm md:text-base leading-tight text-text-40 whitespace-nowrap">
         This is a preview of how the proposal will look
-      </Typography>
+      </BaseTypography>
     </div>
   )
 }

--- a/src/app/shared/components/AnnualBackersIncentives/AnnualBackersIncentives.tsx
+++ b/src/app/shared/components/AnnualBackersIncentives/AnnualBackersIncentives.tsx
@@ -1,6 +1,6 @@
 import { CommonComponentProps } from '@/components/commonProps'
 import { LoadingSpinner } from '@/components/LoadingSpinner/LoadingSpinner'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { AnnualBackerIncentivesLoader } from '@/app/shared/components/AnnualBackersIncentivesLoader/AnnualBackerIncentivesLoader'
 import { Metric, MetricTitle } from '@/components/Metric'
 import { Paragraph } from '@/components/Typography'
@@ -40,13 +40,13 @@ export const AnnualBackersIncentives = ({ className }: AnnualBackersIncentivesPr
           className={className}
         >
           <div className="flex flex-row gap-10 items-center">
-            <Typography variant="e1" className="text-center">
+            <BaseTypography variant="e1" className="text-center">
               {isLoading ? <LoadingSpinner size="small" /> : `${abiPct.toFixed(0)}%`}
-            </Typography>
-            <Typography>
+            </BaseTypography>
+            <BaseTypography>
               Collective Rewards is a shared incentive system that lets Backers earn by supporting Builders,
               and Builders earn by delivering impact — all powered by stRIF.
-            </Typography>
+            </BaseTypography>
           </div>
         </Metric>
       )}

--- a/src/app/shared/components/BuilderCard/BackMoreBuildersCard.tsx
+++ b/src/app/shared/components/BuilderCard/BackMoreBuildersCard.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/components/Button'
 import { BuildingBrick, CloseIconKoto } from '@/components/Icons'
 import { Paragraph } from '@/components/Typography'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { cn } from '@/lib/utils'
 import { useRouter } from 'next/navigation'
 import { FC, useState } from 'react'
@@ -45,9 +45,9 @@ export const BackMoreBuildersCard: FC<BackMoreBuildersCardProps> = ({
         <div className="">
           <BuildingBrick color="none" />
         </div>
-        <Typography variant="h3" className="text-v3-text-100">
+        <BaseTypography variant="h3" className="text-v3-text-100">
           Grow your impact
-        </Typography>
+        </BaseTypography>
         <Paragraph className="pb-2 text-center">
           Backing more Builders helps diversify your support across the ecosystem.
         </Paragraph>

--- a/src/app/user/StackingNotifications/configs.tsx
+++ b/src/app/user/StackingNotifications/configs.tsx
@@ -1,7 +1,7 @@
 import { Cycle } from '@/app/collective-rewards/metrics'
 import { BANNER_CONFIGS, CYCLE_ENDED, CYCLE_ENDING, KYC_ONLY, NOT_BACKING, START_BUILDING } from './constants'
 import { BannerConfig } from './types'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { DateTime } from 'luxon'
 
 /**
@@ -62,10 +62,10 @@ export const getBannerConfigForCycleEnding = (cycle: Cycle): BannerConfig | null
   return {
     ...staticConfig,
     rightContent: (
-      <Typography variant="h1" className="text-white">
+      <BaseTypography variant="h1" className="text-white">
         {/* eslint-disable-next-line quotes */}
         {`${diff.toFormat("d'd' hh'h' mm'm'")}`}
-      </Typography>
+      </BaseTypography>
     ),
   }
 }

--- a/src/components/Header/BuilderStatus/BuilderStatusView.tsx
+++ b/src/components/Header/BuilderStatus/BuilderStatusView.tsx
@@ -1,6 +1,6 @@
 import SeparatorBar from '@/components/SeparatorBar/SeparatorBar'
 import { HourglassIcon } from '../../Icons/HourglassIcon'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { HtmlHTMLAttributes } from 'react'
 import { cn } from '@/lib/utils'
 import { ExtendedBuilderState } from './types'
@@ -42,9 +42,9 @@ export function BuilderStatusView({ builderState }: BuilderStatusProps) {
     <div className={cn('flex items-center font-rootstock-sans', config.className)}>
       <SeparatorBar className="mr-2" />
       {IconComponent && <IconComponent />}
-      <Typography variant="body-xs" className="ml-[2px]">
+      <BaseTypography variant="body-xs" className="ml-[2px]">
         BUILDER
-      </Typography>
+      </BaseTypography>
     </div>
   )
 }

--- a/src/components/Metric/Metric.stories.tsx
+++ b/src/components/Metric/Metric.stories.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { TooltipProvider } from '@radix-ui/react-tooltip'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { expect, within } from 'storybook/test'
@@ -36,8 +36,8 @@ export const Default: Story = {
     ),
     children: (
       <div className="flex items-baseline gap-2">
-        <Typography className="text-2xl font-bold">123,456.78</Typography>
-        <Typography className="text-sm font-bold">USD</Typography>
+        <BaseTypography className="text-2xl font-bold">123,456.78</BaseTypography>
+        <BaseTypography className="text-sm font-bold">USD</BaseTypography>
       </div>
     ),
     className: 'bg-v3-bg-accent-80',
@@ -113,9 +113,9 @@ export const WithMultipleIcons: Story = {
     title: (
       <div className="flex items-center gap-2">
         <UsersIcon className="w-5 h-5" />
-        <Typography variant="body" className="grow not-italic leading-6 text-v3-bg-accent-0">
+        <BaseTypography variant="body" className="grow not-italic leading-6 text-v3-bg-accent-0">
           Community Stats
-        </Typography>
+        </BaseTypography>
       </div>
     ),
     children: (

--- a/src/components/Metric/Metric.tsx
+++ b/src/components/Metric/Metric.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { cn } from '@/lib/utils'
 import { FC, ReactNode } from 'react'
 import { CommonComponentProps } from '../../components/commonProps'
@@ -25,9 +25,9 @@ export const Metric: FC<MetricProps> = ({
     <div data-testid={dataTestId} className={cn('flex items-center gap-4 w-full', className)}>
       <div className={cn('w-full flex flex-col gap-2', containerClassName)}>
         {isTitleTextual ? (
-          <Typography variant="body" className="text-v3-bg-accent-0">
+          <BaseTypography variant="body" className="text-v3-bg-accent-0">
             {title}
-          </Typography>
+          </BaseTypography>
         ) : (
           title
         )}

--- a/src/components/Metric/MetricTitle.tsx
+++ b/src/components/Metric/MetricTitle.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { cn } from '@/lib/utils'
 import { FC, ReactNode } from 'react'
 import { CommonComponentProps } from '../../components/commonProps'
@@ -16,9 +16,9 @@ export const MetricTitle: FC<MetricTitleProps> = ({ title, info, className = '',
   return (
     <div data-testid="MetricTitle" className={cn('flex w-full items-start gap-2', className)}>
       {isTitleTextual ? (
-        <Typography variant="body" className="text-v3-bg-accent-0">
+        <BaseTypography variant="body" className="text-v3-bg-accent-0">
           {title}
-        </Typography>
+        </BaseTypography>
       ) : (
         title
       )}

--- a/src/components/RifRbtcTooltip/RifRbtcTooltip.tsx
+++ b/src/components/RifRbtcTooltip/RifRbtcTooltip.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { TokenImage } from '@/components/TokenImage'
 import { RBTC, RIF } from '@/lib/constants'
 import { formatSymbol } from '@/app/collective-rewards/rewards/utils/formatter'
@@ -30,13 +30,13 @@ const TokenDisplay = ({
   return (
     <div className="flex flex-row items-start w-14">
       <TokenImage symbol={symbol} size={size} className={className} />
-      <Typography className="text-sm">{displayText}</Typography>
+      <BaseTypography className="text-sm">{displayText}</BaseTypography>
     </div>
   )
 }
 
 const FormattedValue = ({ value, symbol }: { value: bigint; symbol: string }) => {
-  return <Typography className="text-lg">{formatSymbol(value, symbol)}</Typography>
+  return <BaseTypography className="text-lg">{formatSymbol(value, symbol)}</BaseTypography>
 }
 
 export const RifRbtcTooltip = ({ children, rbtcValue, rifValue, className }: RifRbtcTooltipProps) => (

--- a/src/components/StackableBanner/BannerContent.tsx
+++ b/src/components/StackableBanner/BannerContent.tsx
@@ -1,7 +1,7 @@
 import { FC, ReactNode } from 'react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/Button'
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 
 export interface BannerContentProps {
   title: ReactNode
@@ -23,8 +23,8 @@ export const BannerContent: FC<BannerContentProps> = ({
   return (
     <div className={cn('text-v3-text-0 w-full flex flex-row gap-2 items-center justify-between', className)}>
       <div className="flex flex-col gap-2 w-1/2">
-        <Typography variant="h3">{title}</Typography>
-        <Typography>{description}</Typography>
+        <BaseTypography variant="h3">{title}</BaseTypography>
+        <BaseTypography>{description}</BaseTypography>
         {buttonText && (
           <Button variant="primary" onClick={buttonOnClick} className="w-fit">
             {buttonText}

--- a/src/components/StackableBanner/story-utils.tsx
+++ b/src/components/StackableBanner/story-utils.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@/components/Typography/Typography'
+import { BaseTypography } from '@/components/Typography/Typography'
 import { TokenImage } from '@/components/TokenImage'
 import { RBTC, RIF } from '@/lib/constants'
 import { ArrowRight } from 'lucide-react'
@@ -59,15 +59,15 @@ export const startBuildingArgs = {
 export const currentCycleEndingSoonArgs = {
   title: 'CURRENT CYCLE ENDING SOON',
   description: (
-    <Typography size="sm" className="flex items-center gap-1">
+    <BaseTypography size="sm" className="flex items-center gap-1">
       Learn how cycles work <ArrowRight />
-    </Typography>
+    </BaseTypography>
   ),
   buttonOnClick: () => console.log('Learn more clicked!'),
   rightContent: (
-    <Typography variant="h1" className="text-white">
+    <BaseTypography variant="h1" className="text-white">
       23h 59m
-    </Typography>
+    </BaseTypography>
   ),
 }
 
@@ -82,20 +82,22 @@ export const stepsListArgs = {
   title: 'TITLE ONLY IF NEEDED',
   description: (
     <div>
-      <Typography size="sm" className="mb-3">
+      <BaseTypography size="sm" className="mb-3">
         Lorem ipsum dolor sit amet consectetur adipiscing elit
-      </Typography>
+      </BaseTypography>
       <ul className="space-y-2 list-disc list-inside">
         <li>
-          <Typography size="sm">step 1... lorem ipsum dolor sit amet, consectetur adipiscing elit</Typography>
+          <BaseTypography size="sm">
+            step 1... lorem ipsum dolor sit amet, consectetur adipiscing elit
+          </BaseTypography>
         </li>
         <li>
-          <Typography size="sm">
+          <BaseTypography size="sm">
             step 2... proin suscipit scelerisque ipsum placerat velit sed quam
-          </Typography>
+          </BaseTypography>
         </li>
         <li>
-          <Typography size="sm">step 3... venenatis, non commodo risus fringilla</Typography>
+          <BaseTypography size="sm">step 3... venenatis, non commodo risus fringilla</BaseTypography>
         </li>
       </ul>
     </div>

--- a/src/components/Typography/Header.tsx
+++ b/src/components/Typography/Header.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import { EmphaseVariants, HeaderVariants, TypographyElement } from './types'
-import { Typography, TypographyProps } from './Typography'
+import { BaseTypography, BaseTypographyProps } from './Typography'
 
 type HeaderVariant = EmphaseVariants | HeaderVariants
 
@@ -17,7 +17,7 @@ const elementByVariant: Record<HeaderVariant, TypographyElement> = {
   h5: 'h5',
 }
 
-export interface HeaderProps extends Omit<TypographyProps<TypographyElement>, 'as'> {
+export interface HeaderProps extends Omit<BaseTypographyProps<TypographyElement>, 'as'> {
   variant?: HeaderVariant
 }
 
@@ -38,7 +38,7 @@ export interface HeaderProps extends Omit<TypographyProps<TypographyElement>, 'a
  * - h5: font-size: 12px; font-family: font-rootstock-sans
  */
 export const Header: FC<HeaderProps> = ({ variant = 'h1', children, 'data-testid': dataTestId, ...rest }) => (
-  <Typography as={elementByVariant[variant]} variant={variant} data-testid={dataTestId} {...rest}>
+  <BaseTypography as={elementByVariant[variant]} variant={variant} data-testid={dataTestId} {...rest}>
     {children}
-  </Typography>
+  </BaseTypography>
 )

--- a/src/components/Typography/Label.tsx
+++ b/src/components/Typography/Label.tsx
@@ -1,10 +1,10 @@
 import { FC } from 'react'
 import { BodyVariants, TagVariants } from './types'
-import { Typography, TypographyProps } from './Typography'
+import { BaseTypography, BaseTypographyProps } from './Typography'
 
 type LabelVariant = BodyVariants | TagVariants
 
-interface Props extends Omit<TypographyProps<'label'>, 'as'> {
+interface Props extends Omit<BaseTypographyProps<'label'>, 'as'> {
   variant?: LabelVariant
 }
 
@@ -22,7 +22,7 @@ interface Props extends Omit<TypographyProps<'label'>, 'as'> {
  * - body-xs: font-size: 12px; font-weight: 400; font-family: font-rootstock-sans
  */
 export const Label: FC<Props> = ({ children, variant = 'body', 'data-testid': dataTestId = '', ...rest }) => (
-  <Typography as="label" variant={variant} data-testid={dataTestId} {...rest}>
+  <BaseTypography as="label" variant={variant} data-testid={dataTestId} {...rest}>
     {children}
-  </Typography>
+  </BaseTypography>
 )

--- a/src/components/Typography/Paragraph.tsx
+++ b/src/components/Typography/Paragraph.tsx
@@ -1,8 +1,8 @@
 import { FC } from 'react'
 import { BodyVariants } from './types'
-import { Typography, TypographyProps } from './Typography'
+import { BaseTypography, BaseTypographyProps } from './Typography'
 
-interface Props extends Omit<TypographyProps<'p'>, 'as'> {
+interface Props extends Omit<BaseTypographyProps<'p'>, 'as'> {
   variant?: BodyVariants
 }
 
@@ -22,7 +22,7 @@ export const Paragraph: FC<Props> = ({
   'data-testid': dataTestId = '',
   ...rest
 }) => (
-  <Typography as="p" variant={variant} data-testid={`Paragraph${dataTestId}`} {...rest}>
+  <BaseTypography as="p" variant={variant} data-testid={`Paragraph${dataTestId}`} {...rest}>
     {children}
-  </Typography>
+  </BaseTypography>
 )

--- a/src/components/Typography/Span.tsx
+++ b/src/components/Typography/Span.tsx
@@ -1,10 +1,10 @@
 import { FC } from 'react'
 import { BodyVariants, EmphaseVariants, TagVariants } from './types'
-import { Typography, TypographyProps } from './Typography'
+import { BaseTypography, BaseTypographyProps } from './Typography'
 
 type SpanVariant = BodyVariants | TagVariants | EmphaseVariants
 
-interface Props extends Omit<TypographyProps<'span'>, 'as'> {
+interface Props extends Omit<BaseTypographyProps<'span'>, 'as'> {
   variant?: SpanVariant
 }
 
@@ -26,7 +26,7 @@ interface Props extends Omit<TypographyProps<'span'>, 'as'> {
  * - e3: font-size: 16px; font-family: font-kk-topo
  */
 export const Span: FC<Props> = ({ variant = 'body', children, ...rest }) => (
-  <Typography as="span" variant={variant} {...rest}>
+  <BaseTypography as="span" variant={variant} {...rest}>
     {children}
-  </Typography>
+  </BaseTypography>
 )

--- a/src/components/Typography/Typography.stories.tsx
+++ b/src/components/Typography/Typography.stories.tsx
@@ -1,12 +1,12 @@
 import { Header } from './Header'
 import { Label } from './Label'
 import { Paragraph } from './Paragraph'
-import { Typography } from './Typography'
+import { BaseTypography } from './Typography'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 
 const meta = {
   title: 'Components/TypographyNew',
-  component: Typography,
+  component: BaseTypography,
   parameters: {
     layout: 'padded',
   },
@@ -24,7 +24,7 @@ const meta = {
       </div>
     ),
   ],
-} satisfies Meta<typeof Typography>
+} satisfies Meta<typeof BaseTypography>
 
 export default meta
 

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -11,7 +11,7 @@ import type { BodyVariants, EmphaseVariants, HeaderVariants, TagVariants } from 
 type TypographyVariant = EmphaseVariants | HeaderVariants | BodyVariants | TagVariants
 
 /**
- * Props for the Typography component.
+ * Props for the BaseTypography component.
  * @template T - The HTML element type to render (defaults to 'span')
  * @property {T} [as] - The HTML element to render (e.g., 'div', 'p', 'span')
  * @property {TypographyVariant} [variant='body'] - The typography style variant to apply
@@ -21,7 +21,7 @@ type TypographyVariant = EmphaseVariants | HeaderVariants | BodyVariants | TagVa
  * @property {string} [data-testid] - Test ID for testing purposes
  * @extends {ComponentPropsWithoutRef<T>} - Inherits all props from the underlying HTML element
  */
-export type TypographyProps<T extends ElementType> = {
+export type BaseTypographyProps<T extends ElementType> = {
   as?: T
   variant?: TypographyVariant
   html?: boolean
@@ -55,7 +55,7 @@ export const variantClasses: Record<TypographyVariant, string> = {
 }
 
 /**
- * Typography Component
+ * BaseTypography Component
  *
  * A flexible typography component that provides consistent text styling across the application.
  * This is an abstract base component that should not be used directly. Instead, use one of the following
@@ -83,7 +83,7 @@ export const variantClasses: Record<TypographyVariant, string> = {
  * - html: Allows rendering sanitized HTML content
  *
  * @template T - The HTML element type to render
- * @param {TypographyProps<T>} props - Component props
+ * @param {BaseTypographyProps<T>} props - Component props
  * @returns {JSX.Element} Rendered typography component
  *
  * @internal
@@ -91,7 +91,7 @@ export const variantClasses: Record<TypographyVariant, string> = {
  * Direct usage is discouraged in favor of the specific variant components.
  * Please DO NOT use this component directly, use the specific variant components instead.
  */
-export function Typography<T extends ElementType>({
+export function BaseTypography<T extends ElementType>({
   children,
   as = 'span' as T,
   variant = 'body',
@@ -102,7 +102,7 @@ export function Typography<T extends ElementType>({
   'data-testid': dataTestId,
   onClick,
   ...props
-}: TypographyProps<T>) {
+}: BaseTypographyProps<T>) {
   const Component: ElementType = as
   const isHtml = html && typeof children === 'string'
   const cleanHtml = isHtml


### PR DESCRIPTION
Renaming `Typography` to `BaseTypography` to reinforce that this component is not intended to be used directly.