### PR TITLE
DAO-1466: Useful Links - the spacing between Get RIF/rBTC and icons needs to be larger

### DIFF
--- a/src/components/MainContainer/sidebars/usefulLinksData.tsx
+++ b/src/components/MainContainer/sidebars/usefulLinksData.tsx
@@ -24,7 +24,7 @@ export const usefulLinksData: UsefulLink[] = [
     content: (
       <div className="inline-flex">
         Get RIF
-        <TokenImage className="ml-1" symbol="RIF" size={16} />
+        <TokenImage className="ml-2" symbol="RIF" size={16} />
       </div>
     ),
   },
@@ -34,7 +34,7 @@ export const usefulLinksData: UsefulLink[] = [
     content: (
       <div className="inline-flex">
         Get rBTC
-        <TokenImage className="ml-1" symbol="RBTC" size={16} />
+        <TokenImage className="ml-2" symbol="RBTC" size={16} />
       </div>
     ),
   },


### PR DESCRIPTION
<img width="168" height="209" alt="image" src="https://github.com/user-attachments/assets/07244e64-f3b3-4820-acd6-d7e15e5dff19" />
