### PR TITLE
DAO-1473: The "Learn more" link for Hacktivator should have an “external link” icon instead

### DIFF
--- a/src/app/communities/CommunityItem.tsx
+++ b/src/app/communities/CommunityItem.tsx
@@ -19,6 +19,7 @@ interface CommunityItemProps {
   enableDebris?: boolean
   specialPower?: string
   boostedPercentage?: string
+  isExternal?: boolean
 }
 
 /**
@@ -36,6 +37,7 @@ export const CommunityItem = ({
   enableDebris = false,
   specialPower,
   boostedPercentage,
+  isExternal,
 }: CommunityItemProps) => {
   const isExternalImage = leftImageSrc.startsWith('http')
   const image = isExternalImage
@@ -80,7 +82,12 @@ export const CommunityItem = ({
           {/* Description */}
           <Paragraph>{description}</Paragraph>
           {/* Learn more */}
-          <CommunityItemButtonHandler nftAddress={nftAddress} readMoreLink={readMoreLink} data-testid={`LearnMoreLink-${title}`} />
+          <CommunityItemButtonHandler
+            nftAddress={nftAddress}
+            readMoreLink={readMoreLink}
+            data-testid={`LearnMoreLink-${title}`}
+            isExternal={isExternal}
+          />
         </div>
       </div>
     </BoostedBox>

--- a/src/app/communities/communityUtils.tsx
+++ b/src/app/communities/communityUtils.tsx
@@ -22,6 +22,7 @@ export interface CommunityItem {
   readMoreLink?: string
   discussionLink?: string
   campaignDetails?: FC<{ activation?: ReactNode }>
+  isExternal?: boolean
 }
 
 interface RowProps {
@@ -212,6 +213,7 @@ export const rootstockHacktivator: CommunityItem = {
   specialPower: '',
   activation: '',
   requirement: '',
+  isExternal: true,
 }
 
 export const communitiesToRender = [

--- a/src/app/communities/components/CommunityItemButtonHandler.tsx
+++ b/src/app/communities/components/CommunityItemButtonHandler.tsx
@@ -1,11 +1,12 @@
 import { Paragraph } from '@/components/Typography'
 import Link from 'next/link'
-import { ArrowRightIconKoto } from '@/components/Icons'
+import { ArrowRightIconKoto, ArrowUpRightLightIcon } from '@/components/Icons'
 
 interface CommunityItemButtonHandlerProps {
   nftAddress?: string
   readMoreLink?: string
   color?: string
+  isExternal?: boolean
   'data-testid'?: string
 }
 
@@ -21,6 +22,7 @@ export const CommunityItemButtonHandler = ({
   nftAddress,
   readMoreLink,
   color = 'white',
+  isExternal = false,
   'data-testid': dataTestId,
 }: CommunityItemButtonHandlerProps) => {
   let href = nftAddress ? `/communities/nft/${nftAddress}` : '/communities'
@@ -33,7 +35,7 @@ export const CommunityItemButtonHandler = ({
     <Link href={href} target={target} data-testid={dataTestId}>
       <div className={'flex flex-row gap-1 items-center'} style={{ color }}>
         <Paragraph>Learn more</Paragraph>
-        <ArrowRightIconKoto color={color} />
+        {isExternal ? <ArrowUpRightLightIcon color={color} /> : <ArrowRightIconKoto color={color} />}
       </div>
     </Link>
   )


### PR DESCRIPTION
<img width="1132" height="431" alt="image" src="https://github.com/user-attachments/assets/5ca3703c-9bd7-4b1c-b6f0-8469459211c9" />
