### PR TITLE
Change Default NFT Holders View to Images

### DIFF
--- a/src/app/communities/nft/[address]/_sections/NftHoldersSection.tsx
+++ b/src/app/communities/nft/[address]/_sections/NftHoldersSection.tsx
@@ -28,7 +28,7 @@ export const NftHoldersSection = ({ address }: { address: Address }) => {
     pageIndex: 0,
     pageSize: 15,
   }))
-  const [view, setView] = useState<ViewState>('table')
+  const [view, setView] = useState<ViewState>('images')
   const { isLoading, isError, allItems } = useFetchNftHolders(address)
   // Define NFT holders table
   const { accessor } = createColumnHelper<(typeof allItems)[number]>()


### PR DESCRIPTION
# Change Default NFT Holders View to Images

## Ticket

[DAO-1474](https://rsklabs.atlassian.net/browse/DAO-1474)

## What

This PR changes the default view state for the NFT Holders section from table view to images view, providing a more visual-first experience for users browsing community NFT holders.

### Key Changes

- **Default View Update**: Modified `NftHoldersSection` component to initialize with `'images'` view instead of `'table'` view
- **User Experience**: Users will now see NFT holders displayed as image cards by default, with the option to switch to table view if needed

### Files Modified

- `src/app/communities/nft/[address]/_sections/NftHoldersSection.tsx` - Updated default view state initialization

### Summary

A simple but impactful UX improvement that makes the NFT holders section more visually appealing by defaulting to the images view, which better showcases the visual nature of NFTs.