### PR TITLE
DAO-1469, DAO-1470, DAO-1475

### DIFF
--- a/src/app/user/latest-collective/components/CreatorRowComponent.tsx
+++ b/src/app/user/latest-collective/components/CreatorRowComponent.tsx
@@ -17,12 +17,12 @@ interface CreatorRowComponentProps {
 }
 
 export const CreatorRowComponent = ({ proposer, Starts, category, className }: CreatorRowComponentProps) => (
-  <div className={cn('flex flex-row mt-2 items-center', className)}>
+  <div className={cn('flex flex-row mt-2 items-center whitespace-nowrap flex-shrink-0', className)}>
     <Tooltip text="Copy address">
       <Span>
         <CopyButton icon={null} className="inline" copyText={proposer}>
-          <Span className="text-primary">by</Span>&nbsp;
-          <Span>{shortAddress(proposer)}</Span>
+          <Span>by</Span>&nbsp;
+          <Span className="text-primary">{shortAddress(proposer)}</Span>
         </CopyButton>
       </Span>
     </Tooltip>

--- a/src/app/user/latest-collective/components/LatestProposalCard.tsx
+++ b/src/app/user/latest-collective/components/LatestProposalCard.tsx
@@ -12,13 +12,18 @@ export const LatestProposalCard = ({
   proposal: { proposalId, name, category, Starts, proposer },
   'data-testid': dataTestId,
 }: LatestProposalCardProps) => (
-  <div className="p-6 w-1/3 bg-bg-60" data-testid={dataTestId}>
+  <div className="p-6 flex-1 bg-bg-60 flex flex-col" data-testid={dataTestId}>
     <Link
-      className="text-primary group-hover:underline group-hover:text-bg-100 group-hover:decoration-bg-40"
+      className="text-primary group-hover:underline group-hover:text-bg-100 group-hover:decoration-bg-40 flex-grow"
       href={`/proposals/${proposalId}`}
     >
-      <Paragraph className="w-full line-clamp-3 h-[72px]">{name}</Paragraph>
+      <Paragraph className="w-full line-clamp-3">{name}</Paragraph>
     </Link>
-    <CreatorRowComponent className={'mt-3'} category={category} Starts={Starts} proposer={proposer} />
+    <CreatorRowComponent
+      className={'mt-3 flex-shrink-0'}
+      category={category}
+      Starts={Starts}
+      proposer={proposer}
+    />
   </div>
 )


### PR DESCRIPTION
## WHY:
- The design wants the cards to be as tall as the longest title with spacing

## What:
- adjust the styling to make sure of that
- Now the address is orange not "by"
- the by {address} and date is no longer spanning 2 lines
- closes 3 tickets: https://rsklabs.atlassian.net/jira/software/projects/DAO/boards/88/backlog?assignee=633bffbd07a27ebeff18158c&selectedIssue=DAO-1469, https://rsklabs.atlassian.net/jira/software/projects/DAO/boards/88/backlog?assignee=633bffbd07a27ebeff18158c&selectedIssue=DAO-1470 and https://rsklabs.atlassian.net/jira/software/projects/DAO/boards/88/backlog?assignee=633bffbd07a27ebeff18158c&selectedIssue=DAO-1475

<img width="1118" height="220" alt="Screenshot 2025-08-21 at 11 35 14" src="https://github.com/user-attachments/assets/8639e9b7-ec05-4723-b603-1fd1942bcd17" />

<img width="1119" height="209" alt="Screenshot 2025-08-21 at 11 40 25" src="https://github.com/user-attachments/assets/7ce05155-d262-4822-a635-8fe6ae82946a" />
<img width="1131" height="194" alt="Screenshot 2025-08-21 at 11 46 52" src="https://github.com/user-attachments/assets/a6868fd1-9e9c-4c9e-993b-9eecada8443f" />
