### PR TITLE
DAO-1498 [Mobile] Intro Modal - Close icon is different

### DIFF
--- a/src/app/user/IntroModal/IntroModalContent.tsx
+++ b/src/app/user/IntroModal/IntroModalContent.tsx
@@ -13,10 +13,10 @@ const GLASS_STYLE =
 interface Props {
   tokenStatus: IntroModalStatus
   isDesktop: boolean
-  rbtcBalance?: string
-  rifBalance?: string
   onClose: () => void
   onContinue: (url: string, external: boolean) => void
+  rbtcBalance?: string
+  rifBalance?: string
 }
 
 export const IntroModalContent = ({

--- a/src/components/Icons/CloseIconKoto.tsx
+++ b/src/components/Icons/CloseIconKoto.tsx
@@ -11,7 +11,7 @@ export function CloseIconKoto({
   return (
     <svg width={size} height={size} viewBox="0 0 20 20" fill="none" {...props}>
       <path
-        d="M15.8334 4.16669L4.16675 15.8334M4.16675 4.16669L15.8334 15.8334"
+        d="M19 5L5 19M5 5L19 19"
         stroke={stroke}
         strokeWidth={strokeWidth}
         strokeLinecap="round"

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -3,7 +3,7 @@
 import { cn } from '@/lib/utils'
 import { FC, ReactNode } from 'react'
 import { createPortal } from 'react-dom'
-import { CloseIcon } from '../Icons'
+import { CloseIconKoto } from '../Icons'
 
 export interface ModalProps {
   children: ReactNode
@@ -50,7 +50,7 @@ export const Modal: FC<ModalProps> = ({
       >
         {/* Close Button */}
         <button onClick={onClose} className="absolute top-4 right-4 z-10" data-testid="CloseButton">
-          <CloseIcon size={24} aria-label="Close" color={closeButtonColor} />
+          <CloseIconKoto size={24} aria-label="Close" color={closeButtonColor} />
         </button>
 
         {children}


### PR DESCRIPTION
## Why:
- Align with the design

# What:
- Use newly created close Icon in the Modal component
<img width="154" height="423" alt="Screenshot 2025-08-26 at 08 20 24" src="https://github.com/user-attachments/assets/a9683376-3ae2-4f81-8377-2e6849fbf41a" />
