### PR TITLE
DAO-1506 In the proposal table, the “by” string that appears next to the proposer’s address is not styled consistently with the design.

### DIFF
--- a/src/app/proposals/components/table-columns/ProposalNameColumn.tsx
+++ b/src/app/proposals/components/table-columns/ProposalNameColumn.tsx
@@ -22,11 +22,11 @@ export const ProposalNameColumn = ({ name, proposalId }: ProposalNameColumnProps
 export const ProposerColumn = ({ by: proposer }: { by: Address }) => (
   <Tooltip text="Copy address">
     <CopyButton icon={null} className="inline" copyText={proposer}>
-      <Span variant="body-s" className="text-primary">
-        by
-      </Span>
+      <Span variant="body-s">by</Span>
       &nbsp;
-      <Span variant="body-s">{shortAddress(proposer)}</Span>
+      <Span variant="body-s" className="text-primary">
+        {shortAddress(proposer)}
+      </Span>
     </CopyButton>
   </Tooltip>
 )


### PR DESCRIPTION
## WHY:
- by string was colored `primary` instead of address

## WHAT:
- Now address is colored `primary`

<img width="857" height="632" alt="Screenshot 2025-08-27 at 09 43 53" src="https://github.com/user-attachments/assets/538d7de2-1a3a-4e74-a9bb-65356f99991a" />
