### PR TITLE
Fix: separate viewport configuration from metadata in layout.tsx

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,7 +18,11 @@ const openSans = Open_Sans({
 export const metadata: Metadata = {
   title: 'RootstockCollective',
   description: 'RootstockCollective DAO dApp',
-  viewport: 'width=device-width, initial-scale=1',
+}
+
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
 }
 
 interface Props {


### PR DESCRIPTION
Fix the following warning in console:
```
 ⚠ Unsupported metadata viewport is configured in metadata export in /proposals. Please move it to viewport export instead.
Read more: https://nextjs.org/docs/app/api-reference/functions/generate-viewport
```