### PR TITLE
DAO - 1525 [Mobile] Proposal List Page - Latest Proposals Header should scroll with user (sticky)

### DIFF
--- a/src/app/proposals/components/LatestProposalsTable.tsx
+++ b/src/app/proposals/components/LatestProposalsTable.tsx
@@ -24,18 +24,27 @@ import { useClickOutside } from '@/shared/hooks/useClickOutside'
 import { Status } from '@/components/Status'
 import { SearchButton } from './SearchButton'
 import { Category } from '../components/category'
-import { Paragraph } from '@/components/Typography'
+import { Header, Paragraph } from '@/components/Typography'
 import { Proposal } from '@/app/proposals/shared/types'
 import { filterOptions } from './filter/filterOptions'
 import { Pagination } from '@/components/Pagination'
+import { useIsDesktop } from '@/shared/hooks/useIsDesktop'
+import { useStickyHeader } from '@/shared/hooks'
 
 interface LatestProposalsTableProps {
   proposals: Proposal[]
 }
 
 const LatestProposalsTable = ({ proposals }: LatestProposalsTableProps) => {
+  const isDesktop = useIsDesktop()
   // React-table sorting state
   const [sorting, setSorting] = useState<SortingState>([])
+
+  // Sticky header hook - only enabled on mobile/tablet
+  const { headerRef } = useStickyHeader({
+    isEnabled: !isDesktop,
+    backgroundColor: 'var(--color-bg-80)',
+  })
 
   const searchParams = useSearchParams()
 
@@ -250,8 +259,10 @@ const LatestProposalsTable = ({ proposals }: LatestProposalsTableProps) => {
 
   return (
     <div className="py-4 px-6 rounded-sm bg-bg-80">
-      <div className="mb-8 w-full flex items-center gap-4">
-        <h2 className="font-kk-topo text-xl leading-tight uppercase tracking-wide">Latest Proposals</h2>
+      <div ref={headerRef} className="mb-8 w-full flex items-center gap-4">
+        <Header variant={'h3'} className={'uppercase'}>
+          Latest Proposals
+        </Header>
         <div className="grow h-[50px] flex justify-end">
           <AnimatePresence>
             {searchVisible && (

--- a/src/components/MainContainer/ContainerMobile.tsx
+++ b/src/components/MainContainer/ContainerMobile.tsx
@@ -6,7 +6,6 @@ import { HeaderMobile } from './headers/HeaderMobile'
 import { FooterMobile } from './footers/FooterMobile'
 import { SidebarMobile } from './sidebars/SidebarMobile'
 import { useLayoutContext } from './LayoutProvider'
-import { AnimatePresence } from 'motion/react'
 import { BottomDrawer } from '@/components/MainContainer/drawers/BottomDrawer'
 
 export default function ContainerMobile({ className, children, ...props }: HTMLAttributes<HTMLDivElement>) {

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useStickyHeader } from './useStickyHeader'

--- a/src/shared/hooks/useStickyHeader.ts
+++ b/src/shared/hooks/useStickyHeader.ts
@@ -1,0 +1,89 @@
+import { useRef, useEffect } from 'react'
+
+interface UseStickyHeaderOptions {
+  isEnabled?: boolean
+  zIndex?: string
+  backgroundColor?: string
+  padding?: {
+    left?: string
+    right?: string
+    top?: string
+    bottom?: string
+  }
+}
+
+export const useStickyHeader = (options: UseStickyHeaderOptions = {}) => {
+  const {
+    isEnabled = true,
+    zIndex = '50',
+    backgroundColor = 'var(--color-bg-80)',
+    padding = {
+      left: '1.5rem',
+      right: '1.5rem',
+      top: '1rem',
+      bottom: '1rem',
+    },
+  } = options
+
+  const headerRef = useRef<HTMLDivElement>(null)
+  const originalHeaderTop = useRef<number>(0)
+
+  // Sticky header styles
+  const stickyStyles = {
+    position: 'fixed',
+    top: '0',
+    zIndex,
+    backgroundColor,
+    width: '100vw',
+    left: '0',
+    right: '0',
+    paddingLeft: padding.left,
+    paddingRight: padding.right,
+    paddingTop: padding.top,
+    paddingBottom: padding.bottom,
+  }
+
+  const clearStickyStyles = () => {
+    if (!headerRef.current) return
+    headerRef.current.style.position = ''
+    headerRef.current.style.top = ''
+    headerRef.current.style.zIndex = ''
+    headerRef.current.style.backgroundColor = ''
+    headerRef.current.style.width = ''
+    headerRef.current.style.left = ''
+    headerRef.current.style.right = ''
+    headerRef.current.style.paddingLeft = ''
+    headerRef.current.style.paddingRight = ''
+    headerRef.current.style.paddingTop = ''
+    headerRef.current.style.paddingBottom = ''
+  }
+
+  useEffect(() => {
+    if (!isEnabled) return
+
+    const handleScroll = () => {
+      if (!headerRef.current) return
+
+      const scrollY = window.scrollY
+
+      // If we haven't stored the original position yet, get it from the element's offsetTop
+      if (originalHeaderTop.current === 0) {
+        originalHeaderTop.current = headerRef.current.offsetTop
+      }
+
+      // When scrolling past the header's original position, make it fixed
+      if (scrollY >= originalHeaderTop.current) {
+        Object.assign(headerRef.current.style, stickyStyles)
+      }
+      // When scrolling back up to before the header's original position, return to normal layout
+      else if (scrollY < originalHeaderTop.current) {
+        clearStickyStyles()
+      }
+    }
+
+    window.addEventListener('scroll', handleScroll)
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [isEnabled, zIndex, backgroundColor, padding.left, padding.right, padding.top, padding.bottom])
+
+  return { headerRef }
+}


### PR DESCRIPTION
## WHY:
- Make Latest Proposals search and filter bar sticky when scrolled past on mobile
- Ticket: https://rsklabs.atlassian.net/jira/software/projects/DAO/boards/88/backlog?assignee=633bffbd07a27ebeff18158c&selectedIssue=DAO-1525

## WHAT:
- `useStickyHeader` hook to bypass issues with CSS layout and to apply to any Header we wish
- Applied to Latest Proposals bar

## PROOF:

https://github.com/user-attachments/assets/d7a26a6c-d67f-4693-b703-300b637890c7

