### PR TITLE
DAO-1536 [Mobile] Delegation Page - Modal should be mobile friendly

### DIFF
--- a/src/app/delegate/components/DelegateModal/DelegateModal.tsx
+++ b/src/app/delegate/components/DelegateModal/DelegateModal.tsx
@@ -4,6 +4,7 @@ import { Modal } from '@/components/Modal'
 import { Header, Paragraph, Span } from '@/components/Typography'
 import { shortAddress } from '@/lib/utils'
 import { Address } from 'viem'
+import { useIsDesktop } from '@/shared/hooks/useIsDesktop'
 
 interface Props {
   onClose: () => void
@@ -30,6 +31,7 @@ export const DelegateModal = ({
   actionButtonText,
   'data-testid': dataTestId = '',
 }: Props) => {
+  const isDesktop = useIsDesktop()
   return (
     <Modal
       onClose={onClose}
@@ -37,12 +39,13 @@ export const DelegateModal = ({
       className="bg-text-80"
       closeButtonColor="black"
       data-testid={dataTestId}
+      fullscreen={!isDesktop}
     >
       <div className="flex flex-col gap-2 items-center py-4 px-8">
-        <Paragraph className="pr-8 text-bg-100">{title}</Paragraph>
+        <Paragraph className="pr-8 text-bg-100 md:mt-4 mt-16">{title}</Paragraph>
         {name ? (
           <>
-            <div className="rounded-full bg-text-100">
+            <div className="rounded-full bg-text-100 md:mt-4 mt-10">
               <IpfsAvatar imageIpfs={imageIpfs} address={address} name={name} size={88} />
             </div>
             <div className="flex flex-col items-center">
@@ -62,17 +65,22 @@ export const DelegateModal = ({
             </Paragraph>
           </>
         )}
-        <div className="flex flex-row gap-2 justify-end w-full mt-6">
-          <Button variant="secondary-outline" onClick={onClose} data-testid="CancelButton">
-            <Span className="text-bg-100" bold>
-              Cancel
-            </Span>
+        <div
+          className={`flex flex-row gap-3 justify-end md:w-full mt-6 ${!isDesktop ? 'fixed bottom-4 inset-x-4' : ''}`}
+        >
+          <Button
+            variant="secondary-outline"
+            onClick={onClose}
+            data-testid="CancelButton"
+            className="w-auto text-bg-100 py-3 px-4"
+          >
+            Cancel
           </Button>
           <Button
             variant="primary"
             onClick={() => onDelegate(address)}
             disabled={isLoading}
-            className="disabled:bg-disabled-border"
+            className="disabled:bg-disabled-border md:flex-none flex-1"
             data-testid={`${actionButtonText}Button`}
           >
             {actionButtonText}


### PR DESCRIPTION
# WHY:
- Mobile design did not fully implement with Figma
- Desktop one was also missing some paddings

# WHAT:
- Adjusted mobile design 
- Added necessary paddings for desktop

# PROOF: 

## Before:
<img width="462" height="767" alt="Screenshot 2025-09-29 at 11 55 09" src="https://github.com/user-attachments/assets/7b4c96de-1a54-4343-a518-69eca9cb3282" />
<img width="698" height="367" alt="Screenshot 2025-09-29 at 11 55 23" src="https://github.com/user-attachments/assets/56565823-5ab6-4090-97f2-afae7065f797" />


## After:
<img width="435" height="766" alt="Screenshot 2025-09-29 at 11 48 21" src="https://github.com/user-attachments/assets/47e6470d-0caa-4e24-9070-6547522b231e" />
<img width="424" height="778" alt="Screenshot 2025-09-29 at 11 49 03" src="https://github.com/user-attachments/assets/a3017c50-f6f4-4746-a8df-91e9ef80149e" />
<img width="699" height="404" alt="Screenshot 2025-09-29 at 11 48 04" src="https://github.com/user-attachments/assets/20cf7a07-ab15-4e7f-bc63-63586ea3009a" />
