### PR TITLE
DAO-1576: [Mobile] Available amount text overlaps buttons in staking/unstaking modal with long decimals

### DIFF
--- a/src/app/user/Stake/Steps/StepOne.tsx
+++ b/src/app/user/Stake/Steps/StepOne.tsx
@@ -77,7 +77,7 @@ export const StepOne = ({ onGoNext }: StepProps) => {
         <Button
           variant="secondary"
           onClick={() => handleAmountChange(totalBalance)}
-          className="bg-transparent border border-bg-40 px-2 py-0"
+          className="bg-transparent border border-bg-40 px-2 py-0 w-fit"
           data-testid="maxButton"
         >
           <Span variant="body-s">Max</Span>


### PR DESCRIPTION
<img width="398" height="179" alt="image" src="https://github.com/user-attachments/assets/f77d50c4-8f84-4a0a-bda6-f35dbd984df7" />
