### PR TITLE
feat: add Helm chart for Kubernetes deployment

### DIFF
--- a/.github/workflows/cr.qa.eks.deploy.yaml
+++ b/.github/workflows/cr.qa.eks.deploy.yaml
@@ -1,0 +1,106 @@
+name: Deploy to Amazon EKS (cr-qa)
+# Deploys to: https://qa-eks.cr.rootstockcollective.xyz/
+# Triggers when a branch is merged into cr-qa
+# Uses the `.env.cr.qa` env file
+
+on:
+  push:
+    branches:
+      - feat/add-helm-chart-k8s-deployment
+
+# Declare default permissions as read only.
+permissions: read-all
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REPOSITORY: rscoll-dev-bim-qa
+  EKS_CLUSTER: rscoll-dev
+  HELM_RELEASE: dao-frontend-cr-qa
+  NAMESPACE: cr-qa
+
+  # The .env file that is used to build the docker image
+  # is retrieved using PROFILE, so be sure there is a `.env.<PROFILE>` file
+  # that matches with the profile set
+  PROFILE: cr.qa
+
+jobs:
+  build:
+    name: Build and Push Image
+    runs-on: ubuntu-latest
+    environment:
+      name: CR-QA
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a #v4.3.1
+        with:
+          role-to-assume: ${{ secrets.AWS_LOGIN_QA_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 #v2.0.1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg PROFILE="$PROFILE" --build-arg NEXT_PUBLIC_BUILD_ID=${{ github.sha }} --no-cache .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+  deploy:
+    name: Deploy to EKS
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: CR-QA
+      url: https://qa-eks.cr.rootstockcollective.xyz
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a #v4.3.1
+        with:
+          role-to-assume: ${{ secrets.AWS_LOGIN_QA_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Update kubeconfig for EKS
+        run: |
+          aws eks update-kubeconfig --name ${{ env.EKS_CLUSTER }} --region ${{ env.AWS_REGION }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 #v4.3.1
+        with:
+          version: 'v3.14.0'
+
+      - name: Deploy to EKS using Helm
+        env:
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          helm upgrade --install ${{ env.HELM_RELEASE }} ./helm \
+            --namespace ${{ env.NAMESPACE }} \
+            --values ./helm/values-cr-qa.yaml \
+            --set image.tag=$IMAGE_TAG \
+            --wait \
+            --timeout 10m
+
+      - name: Verify deployment
+        run: |
+          kubectl rollout status deployment/dao-frontend -n ${{ env.NAMESPACE }}
+          kubectl get pods -n ${{ env.NAMESPACE }}

--- a/.github/workflows/dao.qa.eks.deploy.yaml
+++ b/.github/workflows/dao.qa.eks.deploy.yaml
@@ -1,0 +1,106 @@
+name: Deploy to Amazon EKS (dao-qa)
+# Deploys to: https://qa-eks.dao.rootstockcollective.xyz/
+# Triggers when a branch is merged into dao-qa
+# Uses the `.env.dao.qa` env file
+
+on:
+  push:
+    branches:
+      - feat/add-helm-chart-k8s-deployment
+
+# Declare default permissions as read only.
+permissions: read-all
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REPOSITORY: rscoll-dev-dao-qa
+  EKS_CLUSTER: rscoll-dev
+  HELM_RELEASE: dao-frontend-qa
+  NAMESPACE: dao-qa
+
+  # The .env file that is used to build the docker image
+  # is retrieved using PROFILE, so be sure there is a `.env.<PROFILE>` file
+  # that matches with the profile set
+  PROFILE: dao.qa
+
+jobs:
+  build:
+    name: Build and Push Image
+    runs-on: ubuntu-latest
+    environment:
+      name: DAO-QA
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a #v4.3.1
+        with:
+          role-to-assume: ${{ secrets.AWS_LOGIN_QA_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 #v2.0.1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg PROFILE="$PROFILE" --build-arg NEXT_PUBLIC_BUILD_ID=${{ github.sha }} --no-cache .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+  deploy:
+    name: Deploy to EKS
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: DAO-QA
+      url: https://qa-eks.dao.rootstockcollective.xyz
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a #v4.3.1
+        with:
+          role-to-assume: ${{ secrets.AWS_LOGIN_QA_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Update kubeconfig for EKS
+        run: |
+          aws eks update-kubeconfig --name ${{ env.EKS_CLUSTER }} --region ${{ env.AWS_REGION }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 #v4.3.1
+        with:
+          version: 'v3.14.0'
+
+      - name: Deploy to EKS using Helm
+        env:
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          helm upgrade --install ${{ env.HELM_RELEASE }} ./helm \
+            --namespace ${{ env.NAMESPACE }} \
+            --values ./helm/values-qa.yaml \
+            --set image.tag=$IMAGE_TAG \
+            --wait \
+            --timeout 10m
+
+      - name: Verify deployment
+        run: |
+          kubectl rollout status deployment/dao-frontend -n ${{ env.NAMESPACE }}
+          kubectl get pods -n ${{ env.NAMESPACE }}

--- a/.github/workflows/dev.eks.deploy.yaml
+++ b/.github/workflows/dev.eks.deploy.yaml
@@ -1,0 +1,107 @@
+name: Deploy to Amazon EKS (dev)
+# Deploys to: https://dev-eks.app.rootstockcollective.xyz/
+# Triggers when a branch is merged into main
+# Uses the `.env.dev` env file
+
+on:
+  push:
+    branches:
+      - feat/add-helm-chart-k8s-deployment
+
+# Declare default permissions as read only.
+permissions: read-all
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REPOSITORY: rscoll-dev-dao-dev
+  EKS_CLUSTER: rscoll-dev
+  HELM_RELEASE: dao-frontend-dev
+  NAMESPACE: dev
+
+  # The .env file that is used to build the docker image
+  # is retrieved using PROFILE, so be sure there is a `.env.<PROFILE>` file
+  # that matches with the profile set
+  # Example: PROFILE=testnet => .env.testnet
+  PROFILE: dev
+
+jobs:
+  build:
+    name: Build and Push Image
+    runs-on: ubuntu-latest
+    environment:
+      name: dev
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a #v4.3.1
+        with:
+          role-to-assume: ${{ secrets.AWS_LOGIN_DEV_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 #v2.0.1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg PROFILE="$PROFILE" --build-arg NEXT_PUBLIC_BUILD_ID=${{ github.sha }} --no-cache .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+  deploy:
+    name: Deploy to EKS
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: dev
+      url: https://dev-eks.app.rootstockcollective.xyz
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a #v4.3.1
+        with:
+          role-to-assume: ${{ secrets.AWS_LOGIN_DEV_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Update kubeconfig for EKS
+        run: |
+          aws eks update-kubeconfig --name ${{ env.EKS_CLUSTER }} --region ${{ env.AWS_REGION }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 #v4.3.1
+        with:
+          version: 'v3.14.0'
+
+      - name: Deploy to EKS using Helm
+        env:
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          helm upgrade --install ${{ env.HELM_RELEASE }} ./helm \
+            --namespace ${{ env.NAMESPACE }} \
+            --values ./helm/values-dev.yaml \
+            --set image.tag=$IMAGE_TAG \
+            --wait \
+            --timeout 10m
+
+      - name: Verify deployment
+        run: |
+          kubectl rollout status deployment/dao-frontend -n ${{ env.NAMESPACE }}
+          kubectl get pods -n ${{ env.NAMESPACE }}

--- a/.github/workflows/release-candidate-mainnet.eks.deploy.yaml
+++ b/.github/workflows/release-candidate-mainnet.eks.deploy.yaml
@@ -1,0 +1,107 @@
+name: Deploy to Amazon EKS (rc-mainnet)
+# Deploys to: https://rc-mainnet-eks.app.rootstockcollective.xyz/
+# Triggers when a branch is merged into main
+# Uses the `.env.rc-mainnet` env file
+
+on:
+  push:
+    branches:
+      - feat/add-helm-chart-k8s-deployment
+
+# Declare default permissions as read only.
+permissions: read-all
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REPOSITORY: rscoll-dev-dao-rc-mainnet
+  EKS_CLUSTER: rscoll-dev
+  HELM_RELEASE: dao-frontend-rc-mainnet
+  NAMESPACE: rc-mainnet
+
+  # The .env file that is used to build the docker image
+  # is retrieved using PROFILE, so be sure there is a `.env.<PROFILE>` file
+  # that matches with the profile set
+  # Example: PROFILE=testnet => .env.testnet
+  PROFILE: release-candidate-mainnet
+
+jobs:
+  build:
+    name: Build and Push Image
+    runs-on: ubuntu-latest
+    environment:
+      name: release-candidate-mainnet
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a #v4.3.1
+        with:
+          role-to-assume: ${{ secrets.AWS_LOGIN_STAGING_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 #v2.0.1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg PROFILE="$PROFILE" --build-arg NEXT_PUBLIC_BUILD_ID=${{ github.sha }} --no-cache .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+  deploy:
+    name: Deploy to EKS
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: release-candidate-mainnet
+      url: https://rc-mainnet-eks.app.rootstockcollective.xyz
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a #v4.3.1
+        with:
+          role-to-assume: ${{ secrets.AWS_LOGIN_STAGING_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Update kubeconfig for EKS
+        run: |
+          aws eks update-kubeconfig --name ${{ env.EKS_CLUSTER }} --region ${{ env.AWS_REGION }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 #v4.3.1
+        with:
+          version: 'v3.14.0'
+
+      - name: Deploy to EKS using Helm
+        env:
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          helm upgrade --install ${{ env.HELM_RELEASE }} ./helm \
+            --namespace ${{ env.NAMESPACE }} \
+            --values ./helm/values-rc-mainnet.yaml \
+            --set image.tag=$IMAGE_TAG \
+            --wait \
+            --timeout 10m
+
+      - name: Verify deployment
+        run: |
+          kubectl rollout status deployment/dao-frontend -n ${{ env.NAMESPACE }}
+          kubectl get pods -n ${{ env.NAMESPACE }}

--- a/.github/workflows/release-candidate-testnet.eks.deploy.yaml
+++ b/.github/workflows/release-candidate-testnet.eks.deploy.yaml
@@ -1,0 +1,107 @@
+name: Deploy to Amazon EKS (release candidate staging - testnet)
+# Deploys to: https://release-candidate-testnet-eks.app.rootstockcollective.xyz/
+# Triggers on when a tag is pushed to the repo in the format of vX.X.X-rc.X
+# where X are numbers. An example: v1.5.0-rc.1
+# Uses the `.env.release-candidate-testnet` env file
+
+on:
+  push:
+    branches:
+      - feat/add-helm-chart-k8s-deployment
+
+# Declare default permissions as read only.
+permissions: read-all
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REPOSITORY: rscoll-dev-dao-staging
+  EKS_CLUSTER: rscoll-dev
+  HELM_RELEASE: dao-frontend-rc-testnet
+  NAMESPACE: rc-testnet
+
+  # The .env file that is used to build the docker image
+  # is retrieved using PROFILE, so be sure there is a `.env.<PROFILE>` file
+  # that matches with the profile set
+  PROFILE: release-candidate-testnet
+
+jobs:
+  build:
+    name: Build and Push Image
+    runs-on: ubuntu-latest
+    environment:
+      name: release-candidate-testnet
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a #v4.3.1
+        with:
+          role-to-assume: ${{ secrets.AWS_LOGIN_STAGING_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 #v2.0.1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg PROFILE="$PROFILE" --build-arg NEXT_PUBLIC_BUILD_ID=${{ github.sha }} --no-cache .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+  deploy:
+    name: Deploy to EKS
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: release-candidate-testnet
+      url: https://release-candidate-testnet-eks.app.rootstockcollective.xyz
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a #v4.3.1
+        with:
+          role-to-assume: ${{ secrets.AWS_LOGIN_STAGING_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Update kubeconfig for EKS
+        run: |
+          aws eks update-kubeconfig --name ${{ env.EKS_CLUSTER }} --region ${{ env.AWS_REGION }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 #v4.3.1
+        with:
+          version: 'v3.14.0'
+
+      - name: Deploy to EKS using Helm
+        env:
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          helm upgrade --install ${{ env.HELM_RELEASE }} ./helm \
+            --namespace ${{ env.NAMESPACE }} \
+            --values ./helm/values-rc-testnet.yaml \
+            --set image.tag=$IMAGE_TAG \
+            --wait \
+            --timeout 10m
+
+      - name: Verify deployment
+        run: |
+          kubectl rollout status deployment/dao-frontend -n ${{ env.NAMESPACE }}
+          kubectl get pods -n ${{ env.NAMESPACE }}

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,8 @@ CLAUDE.md
 
 # Local git worktrees
 .worktrees/
+
+# Helm values overrides with secrets (allow committed environment files)
+helm/secrets.yaml
+helm/values-local.yaml
+helm/values-override.yaml

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+/helm/                                          @RootstockCollective/devops
+/.github/workflows/*.eks.deploy.yaml            @RootstockCollective/devops

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: dao-frontend
+description: DAO Frontend application for RootstockCollective
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,186 @@
+# DAO Frontend Helm Chart
+
+Simple Helm chart for deploying dao-frontend to Kubernetes.
+
+## Prerequisites
+
+1. Kubernetes cluster (rscoll-dev) with External Secrets Operator installed
+2. AWS Systems Manager Parameter Store parameters (already exist for all environments)
+3. ECR images available in respective repositories
+
+## Quick Deploy
+
+### 1. Deploy with Helm
+
+Deploy to specific environments using environment-specific values files.
+
+**Note:** Each environment deploys to its own namespace:
+- `dao-frontend-dev` for development
+- `dao-frontend-qa` for QA
+- `dao-frontend-cr-qa` for CR QA
+- `dao-frontend-rc-testnet` for RC Testnet
+- `dao-frontend-rc-mainnet` for RC Mainnet
+
+```bash
+# Deploy to dev
+helm upgrade --install dao-frontend-dev ./helm -f helm/values-dev.yaml
+
+# Deploy to DAO QA
+helm upgrade --install dao-frontend-qa ./helm -f helm/values-qa.yaml
+
+# Deploy to CR QA
+helm upgrade --install dao-frontend-cr-qa ./helm -f helm/values-cr-qa.yaml
+
+# Deploy to RC Testnet
+helm upgrade --install dao-frontend-rc-testnet ./helm -f helm/values-rc-testnet.yaml
+
+# Deploy to RC Mainnet
+helm upgrade --install dao-frontend-rc-mainnet ./helm -f helm/values-rc-mainnet.yaml
+
+# Override image tag for any environment
+helm upgrade --install dao-frontend-dev ./helm \
+  -f helm/values-dev.yaml \
+  --set image.tag=<GIT_SHA>
+```
+
+## Environment Files
+
+| File | Environment | ECR Repository | Latest Image (as of Jan 21, 2026) |
+|------|-------------|----------------|-----------------------------------|
+| `values-dev.yaml` | Development | `rscoll-dev-dao-dev` | `930eac4...` |
+| `values-qa.yaml` | DAO QA | `rscoll-dev-dao-qa` | `14231be...` |
+| `values-cr-qa.yaml` | CR QA | `rscoll-dev-bim-qa` | `615a41a...` |
+| `values-rc-testnet.yaml` | RC Testnet | `rscoll-dev-dao-staging` | `639c687...` |
+| `values-rc-mainnet.yaml` | RC Mainnet | `rscoll-dev-dao-rc-mainnet` | `639c687...` |
+
+**Parameters are automatically pulled from AWS Systems Manager Parameter Store based on the environment.**
+
+## Configuration
+
+Key values in `values.yaml`:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `image.repository` | ECR repository | `886436934082.dkr.ecr.us-east-1.amazonaws.com/rscoll-dev-dao-dev` |
+| `image.tag` | Image tag | `930eac49828502453196eb19cb032ae441c4b8a5` |
+| `replicaCount` | Number of replicas | `2` |
+| `namespace` | Kubernetes namespace | `dao-frontend` |
+| `externalSecrets.parameterPaths` | Parameter Store paths | See environment-specific values files |
+| `ingress.enabled` | Enable ingress | `false` |
+
+## Common Commands
+
+```bash
+# Install (replace 'dev' with your environment)
+ENVIRONMENT=dev
+helm install dao-frontend-${ENVIRONMENT} ./helm -f helm/values-${ENVIRONMENT}.yaml
+
+# Install with custom image tag
+helm install dao-frontend-${ENVIRONMENT} ./helm -f helm/values-${ENVIRONMENT}.yaml --set image.tag=v1.2.3
+
+# Upgrade
+helm upgrade dao-frontend-${ENVIRONMENT} ./helm -f helm/values-${ENVIRONMENT}.yaml --set image.tag=v1.2.4
+
+# Uninstall
+helm uninstall dao-frontend-${ENVIRONMENT}
+
+# View values
+helm get values dao-frontend-${ENVIRONMENT}
+
+# View manifest (for testing)
+helm template dao-frontend-${ENVIRONMENT} ./helm -f helm/values-${ENVIRONMENT}.yaml
+
+# Dry run
+helm install dao-frontend-${ENVIRONMENT} ./helm -f helm/values-${ENVIRONMENT}.yaml --dry-run --debug
+```
+
+## CI/CD Usage
+
+In your CI/CD pipeline:
+
+```bash
+# Build and push image (update ECR_REPO based on environment)
+ECR_REPO=886436934082.dkr.ecr.us-east-1.amazonaws.com/rscoll-dev-dao-dev
+docker build -t ${ECR_REPO}:${GITHUB_SHA} .
+docker push ${ECR_REPO}:${GITHUB_SHA}
+
+# Deploy to cluster
+helm upgrade --install dao-frontend-dev ./helm \
+  -f helm/values-dev.yaml \
+  --set image.tag=${GITHUB_SHA} \
+  --wait
+```
+
+## Verify Deployment
+
+Each environment deploys to its own namespace:
+
+```bash
+# Check all dao-frontend environments
+kubectl get namespaces | grep dao-frontend
+kubectl get pods --all-namespaces | grep dao-frontend
+
+# Check specific environment (replace 'dev' with qa, cr-qa, rc-testnet, or rc-mainnet)
+ENVIRONMENT=dev
+
+# Check release status
+helm status dao-frontend-${ENVIRONMENT}
+
+# Check pods
+kubectl get pods -n dao-frontend-${ENVIRONMENT}
+
+# Check service
+kubectl get svc -n dao-frontend-${ENVIRONMENT}
+
+# Check ingress
+kubectl get ingress -n dao-frontend-${ENVIRONMENT}
+
+# View logs
+kubectl logs -n dao-frontend-${ENVIRONMENT} -l app.kubernetes.io/name=dao-frontend -f
+
+# Check External Secret sync
+kubectl get externalsecret -n dao-frontend-${ENVIRONMENT}
+kubectl describe externalsecret dao-frontend-secrets -n dao-frontend-${ENVIRONMENT}
+```
+
+### Quick Commands by Environment:
+
+```bash
+# Dev
+kubectl get pods -n dao-frontend-dev
+kubectl logs -n dao-frontend-dev -l app.kubernetes.io/name=dao-frontend -f
+
+# QA
+kubectl get pods -n dao-frontend-qa
+kubectl logs -n dao-frontend-qa -l app.kubernetes.io/name=dao-frontend -f
+
+# CR QA
+kubectl get pods -n dao-frontend-cr-qa
+kubectl logs -n dao-frontend-cr-qa -l app.kubernetes.io/name=dao-frontend -f
+
+# RC Testnet
+kubectl get pods -n dao-frontend-rc-testnet
+kubectl logs -n dao-frontend-rc-testnet -l app.kubernetes.io/name=dao-frontend -f
+
+# RC Mainnet
+kubectl get pods -n dao-frontend-rc-mainnet
+kubectl logs -n dao-frontend-rc-mainnet -l app.kubernetes.io/name=dao-frontend -f
+```
+
+## Rollback
+
+```bash
+# View history (replace 'dev' with your environment)
+ENVIRONMENT=dev
+helm history dao-frontend-${ENVIRONMENT}
+
+# Rollback to previous version
+helm rollback dao-frontend-${ENVIRONMENT}
+
+# Rollback to specific revision
+helm rollback dao-frontend-${ENVIRONMENT} 2
+
+# Examples for specific environments:
+helm rollback dao-frontend-dev        # Rollback dev to previous
+helm rollback dao-frontend-qa 3       # Rollback qa to revision 3
+```

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dao-frontend.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "dao-frontend.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "dao-frontend.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "dao-frontend.labels" -}}
+helm.sh/chart: {{ include "dao-frontend.chart" . }}
+{{ include "dao-frontend.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "dao-frontend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "dao-frontend.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dao-frontend.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "dao-frontend.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "dao-frontend.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "dao-frontend.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.service.targetPort }}
+          protocol: TCP
+        env:
+        - name: THE_GRAPH_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "dao-frontend.fullname" . }}-secrets
+              key: the-graph-api-key
+        - name: DB_CONNECTION_STRING
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "dao-frontend.fullname" . }}-secrets
+              key: db-connection-string
+        - name: DAO_GRAPH_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "dao-frontend.fullname" . }}-secrets
+              key: dao-graph-api-key
+        - name: DAO_DATA_DB_CONNECTION_STRING
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "dao-frontend.fullname" . }}-secrets
+              key: dao-data-db-connection-string
+        - name: BTC_VAULT_GRAPH_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "dao-frontend.fullname" . }}-secrets
+              key: btc-vault-graph-api-key
+        - name: COIN_MARKET_CAP_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "dao-frontend.fullname" . }}-secrets
+              key: coin-market-cap-key
+        {{- if .Values.externalSecrets.parameterPaths.jwtSecret }}
+        - name: JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "dao-frontend.fullname" . }}-secrets
+              key: jwt-secret
+        {{- end }}
+        livenessProbe:
+          {{- toYaml .Values.livenessProbe | nindent 10 }}
+        readinessProbe:
+          {{- toYaml .Values.readinessProbe | nindent 10 }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}

--- a/helm/templates/externalsecret.yaml
+++ b/helm/templates/externalsecret.yaml
@@ -1,0 +1,39 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "dao-frontend.fullname" . }}-secrets
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "dao-frontend.labels" . | nindent 4 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-parameter-store
+    kind: ClusterSecretStore
+  target:
+    name: {{ include "dao-frontend.fullname" . }}-secrets
+    creationPolicy: Owner
+  data:
+  - secretKey: the-graph-api-key
+    remoteRef:
+      key: {{ .Values.externalSecrets.parameterPaths.theGraphApiKey }}
+  - secretKey: db-connection-string
+    remoteRef:
+      key: {{ .Values.externalSecrets.parameterPaths.dbConnectionString }}
+  - secretKey: dao-graph-api-key
+    remoteRef:
+      key: {{ .Values.externalSecrets.parameterPaths.daoGraphApiKey }}
+  - secretKey: dao-data-db-connection-string
+    remoteRef:
+      key: {{ .Values.externalSecrets.parameterPaths.daoDataDbConnectionString }}
+  - secretKey: btc-vault-graph-api-key
+    remoteRef:
+      key: {{ .Values.externalSecrets.parameterPaths.btcVaultGraphApiKey }}
+  - secretKey: coin-market-cap-key
+    remoteRef:
+      key: {{ .Values.externalSecrets.parameterPaths.coinMarketCapKey }}
+  {{- if .Values.externalSecrets.parameterPaths.jwtSecret }}
+  - secretKey: jwt-secret
+    remoteRef:
+      key: {{ .Values.externalSecrets.parameterPaths.jwtSecret }}
+  {{- end }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "dao-frontend.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "dao-frontend.labels" . | nindent 4 }}
+  annotations:
+    # AWS Load Balancer Controller annotations
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: '443'
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificateArn }}
+    alb.ingress.kubernetes.io/healthcheck-path: /health
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: '10'
+    alb.ingress.kubernetes.io/success-codes: '200'
+    # External DNS annotation for automatic DNS record creation
+    external-dns.alpha.kubernetes.io/hostname: {{ (index .Values.ingress.hosts 0).host }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+  - host: {{ .host | quote }}
+    http:
+      paths:
+      {{- range .paths }}
+      - path: {{ .path }}
+        pathType: {{ .pathType }}
+        backend:
+          service:
+            name: {{ include "dao-frontend.fullname" $ }}
+            port:
+              number: {{ $.Values.service.port }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/ssl-redirect: '443'
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificateArn }}
+    {{- if .Values.ingress.wafAclArn }}
+    alb.ingress.kubernetes.io/wafv2-acl-arn: {{ .Values.ingress.wafAclArn }}
+    {{- end }}
     alb.ingress.kubernetes.io/healthcheck-path: /health
     alb.ingress.kubernetes.io/healthcheck-interval-seconds: '10'
     alb.ingress.kubernetes.io/success-codes: '200'

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -12,6 +12,8 @@ metadata:
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/ssl-redirect: '443'
+    # All dao-frontend envs share one ALB via this group; saves 4× ALB cost.
+    alb.ingress.kubernetes.io/group.name: dao-frontend-rscoll-dev
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificateArn }}
     {{- if .Values.ingress.wafAclArn }}
     alb.ingress.kubernetes.io/wafv2-acl-arn: {{ .Values.ingress.wafAclArn }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dao-frontend.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "dao-frontend.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: {{ .Values.service.targetPort }}
+    protocol: TCP
+    name: http
+  selector:
+    {{- include "dao-frontend.selectorLabels" . | nindent 4 }}

--- a/helm/values-cr-qa.yaml
+++ b/helm/values-cr-qa.yaml
@@ -1,0 +1,26 @@
+# CR QA environment
+image:
+  repository: 886436934082.dkr.ecr.us-east-1.amazonaws.com/rscoll-dev-bim-qa
+  tag: 615a41a35d6e1d01b365a5fe8909a448469f3edc
+
+namespace: cr-qa
+
+ingress:
+  enabled: true
+  className: alb
+  certificateArn: "arn:aws:acm:us-east-1:886436934082:certificate/079f3575-cd79-4435-9154-c14d8a034d39"
+  hosts:
+    - host: qa-eks.cr.rootstockcollective.xyz
+      paths:
+        - path: /
+          pathType: Prefix
+  annotations: {}
+
+externalSecrets:
+  parameterPaths:
+    theGraphApiKey: /rscoll-dev/cr-qa/the-graph-api-key
+    dbConnectionString: /rscoll-dev/bim-qa/database-uri
+    daoGraphApiKey: /rscoll-dev/cr-qa/dao-graph-api-key
+    daoDataDbConnectionString: /rscoll-dev/bim-qa/dao-data-database-uri
+    btcVaultGraphApiKey: /rscoll-dev/cr-qa/btc-vault-graph-api-key
+    coinMarketCapKey: /rscoll-dev-coinmarketcap-key

--- a/helm/values-cr-qa.yaml
+++ b/helm/values-cr-qa.yaml
@@ -19,8 +19,8 @@ ingress:
 externalSecrets:
   parameterPaths:
     theGraphApiKey: /rscoll-dev/cr-qa/the-graph-api-key
-    dbConnectionString: /rscoll-dev/bim-qa/database-uri
+    dbConnectionString: /rscoll-dev-eks/cr-qa/database-uri
     daoGraphApiKey: /rscoll-dev/cr-qa/dao-graph-api-key
-    daoDataDbConnectionString: /rscoll-dev/bim-qa/dao-data-database-uri
+    daoDataDbConnectionString: /rscoll-dev-eks/cr-qa/dao-data-database-uri
     btcVaultGraphApiKey: /rscoll-dev/cr-qa/btc-vault-graph-api-key
     coinMarketCapKey: /rscoll-dev-coinmarketcap-key

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -1,0 +1,26 @@
+# Development environment
+image:
+  repository: 886436934082.dkr.ecr.us-east-1.amazonaws.com/rscoll-dev-dao-dev
+  tag: 930eac49828502453196eb19cb032ae441c4b8a5
+
+namespace: dev
+
+ingress:
+  enabled: true
+  className: alb
+  certificateArn: "arn:aws:acm:us-east-1:886436934082:certificate/079f3575-cd79-4435-9154-c14d8a034d39"
+  hosts:
+    - host: dev-eks.app.rootstockcollective.xyz
+      paths:
+        - path: /
+          pathType: Prefix
+  annotations: {}
+
+externalSecrets:
+  parameterPaths:
+    theGraphApiKey: /rscoll-dev/dev/the-graph-api-key
+    dbConnectionString: /rscoll-dev/dao-dev/database-uri
+    daoGraphApiKey: /rscoll-dev/dev/dao-graph-api-key
+    daoDataDbConnectionString: /rscoll-dev/dao-dev/dao-data-database-uri
+    btcVaultGraphApiKey: /rscoll-dev/dev/btc-vault-graph-api-key
+    coinMarketCapKey: /rscoll-dev-coinmarketcap-key

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -19,8 +19,8 @@ ingress:
 externalSecrets:
   parameterPaths:
     theGraphApiKey: /rscoll-dev/dev/the-graph-api-key
-    dbConnectionString: /rscoll-dev/dao-dev/database-uri
+    dbConnectionString: /rscoll-dev-eks/dev/database-uri
     daoGraphApiKey: /rscoll-dev/dev/dao-graph-api-key
-    daoDataDbConnectionString: /rscoll-dev/dao-dev/dao-data-database-uri
+    daoDataDbConnectionString: /rscoll-dev-eks/dev/dao-data-database-uri
     btcVaultGraphApiKey: /rscoll-dev/dev/btc-vault-graph-api-key
     coinMarketCapKey: /rscoll-dev-coinmarketcap-key

--- a/helm/values-qa.yaml
+++ b/helm/values-qa.yaml
@@ -1,0 +1,26 @@
+# DAO QA environment
+image:
+  repository: 886436934082.dkr.ecr.us-east-1.amazonaws.com/rscoll-dev-dao-qa
+  tag: 14231be7f0a0b4588e946909049402a285ffec19
+
+namespace: dao-qa
+
+ingress:
+  enabled: true
+  className: alb
+  certificateArn: "arn:aws:acm:us-east-1:886436934082:certificate/079f3575-cd79-4435-9154-c14d8a034d39"
+  hosts:
+    - host: qa-eks.dao.rootstockcollective.xyz
+      paths:
+        - path: /
+          pathType: Prefix
+  annotations: {}
+
+externalSecrets:
+  parameterPaths:
+    theGraphApiKey: /rscoll-dev/dao-qa/the-graph-api-key
+    dbConnectionString: /rscoll-dev/dao-qa/database-uri
+    daoGraphApiKey: /rscoll-dev/dao-qa/dao-graph-api-key
+    daoDataDbConnectionString: /rscoll-dev/dao-qa/dao-data-database-uri
+    btcVaultGraphApiKey: /rscoll-dev/dao-qa/btc-vault-graph-api-key
+    coinMarketCapKey: /rscoll-dev-coinmarketcap-key

--- a/helm/values-qa.yaml
+++ b/helm/values-qa.yaml
@@ -19,8 +19,8 @@ ingress:
 externalSecrets:
   parameterPaths:
     theGraphApiKey: /rscoll-dev/dao-qa/the-graph-api-key
-    dbConnectionString: /rscoll-dev/dao-qa/database-uri
+    dbConnectionString: /rscoll-dev-eks/dao-qa/database-uri
     daoGraphApiKey: /rscoll-dev/dao-qa/dao-graph-api-key
-    daoDataDbConnectionString: /rscoll-dev/dao-qa/dao-data-database-uri
+    daoDataDbConnectionString: /rscoll-dev-eks/dao-qa/dao-data-database-uri
     btcVaultGraphApiKey: /rscoll-dev/dao-qa/btc-vault-graph-api-key
     coinMarketCapKey: /rscoll-dev-coinmarketcap-key

--- a/helm/values-rc-mainnet.yaml
+++ b/helm/values-rc-mainnet.yaml
@@ -1,0 +1,27 @@
+# Release Candidate Mainnet environment
+image:
+  repository: 886436934082.dkr.ecr.us-east-1.amazonaws.com/rscoll-dev-dao-rc-mainnet
+  tag: 639c6872f43776d4befd5ddd8fd39825e99d6b39
+
+namespace: rc-mainnet
+
+ingress:
+  enabled: true
+  className: alb
+  certificateArn: "arn:aws:acm:us-east-1:886436934082:certificate/079f3575-cd79-4435-9154-c14d8a034d39"
+  hosts:
+    - host: release-candidate-eks.app.rootstockcollective.xyz
+      paths:
+        - path: /
+          pathType: Prefix
+  annotations: {}
+
+externalSecrets:
+  parameterPaths:
+    theGraphApiKey: /rscoll-dev/rc-mainnet/the-graph-api-key
+    dbConnectionString: /rscoll-dev/dao-rc-mainnet/database-uri
+    daoGraphApiKey: /rscoll-dev/rc-mainnet/dao-graph-api-key
+    daoDataDbConnectionString: /rscoll-dev/dao-rc-mainnet/dao-data-database-uri
+    btcVaultGraphApiKey: /rscoll-dev/rc-mainnet/btc-vault-graph-api-key
+    coinMarketCapKey: /rscoll-dev-coinmarketcap-key
+    jwtSecret: /rscoll-dev/rc-mainnet/jwt-secret

--- a/helm/values-rc-mainnet.yaml
+++ b/helm/values-rc-mainnet.yaml
@@ -19,9 +19,9 @@ ingress:
 externalSecrets:
   parameterPaths:
     theGraphApiKey: /rscoll-dev/rc-mainnet/the-graph-api-key
-    dbConnectionString: /rscoll-dev/dao-rc-mainnet/database-uri
+    dbConnectionString: /rscoll-dev-eks/rc-mainnet/database-uri
     daoGraphApiKey: /rscoll-dev/rc-mainnet/dao-graph-api-key
-    daoDataDbConnectionString: /rscoll-dev/dao-rc-mainnet/dao-data-database-uri
+    daoDataDbConnectionString: /rscoll-dev-eks/rc-mainnet/dao-data-database-uri
     btcVaultGraphApiKey: /rscoll-dev/rc-mainnet/btc-vault-graph-api-key
     coinMarketCapKey: /rscoll-dev-coinmarketcap-key
     jwtSecret: /rscoll-dev/rc-mainnet/jwt-secret

--- a/helm/values-rc-testnet.yaml
+++ b/helm/values-rc-testnet.yaml
@@ -1,0 +1,27 @@
+# Release Candidate Testnet environment
+image:
+  repository: 886436934082.dkr.ecr.us-east-1.amazonaws.com/rscoll-dev-dao-staging
+  tag: 639c6872f43776d4befd5ddd8fd39825e99d6b39
+
+namespace: rc-testnet
+
+ingress:
+  enabled: true
+  className: alb
+  certificateArn: "arn:aws:acm:us-east-1:886436934082:certificate/079f3575-cd79-4435-9154-c14d8a034d39"
+  hosts:
+    - host: release-candidate-testnet-eks.app.rootstockcollective.xyz
+      paths:
+        - path: /
+          pathType: Prefix
+  annotations: {}
+
+externalSecrets:
+  parameterPaths:
+    theGraphApiKey: /rscoll-dev/rc-testnet/the-graph-api-key
+    dbConnectionString: /rscoll-dev/dao-staging/database-uri
+    daoGraphApiKey: /rscoll-dev/rc-testnet/dao-graph-api-key
+    daoDataDbConnectionString: /rscoll-dev/dao-staging/dao-data-database-uri
+    btcVaultGraphApiKey: /rscoll-dev/rc-testnet/btc-vault-graph-api-key
+    coinMarketCapKey: /rscoll-dev-coinmarketcap-key
+    jwtSecret: /rscoll-dev/rc-testnet/jwt-secret

--- a/helm/values-rc-testnet.yaml
+++ b/helm/values-rc-testnet.yaml
@@ -19,9 +19,9 @@ ingress:
 externalSecrets:
   parameterPaths:
     theGraphApiKey: /rscoll-dev/rc-testnet/the-graph-api-key
-    dbConnectionString: /rscoll-dev/dao-staging/database-uri
+    dbConnectionString: /rscoll-dev-eks/rc-testnet/database-uri
     daoGraphApiKey: /rscoll-dev/rc-testnet/dao-graph-api-key
-    daoDataDbConnectionString: /rscoll-dev/dao-staging/dao-data-database-uri
+    daoDataDbConnectionString: /rscoll-dev-eks/rc-testnet/dao-data-database-uri
     btcVaultGraphApiKey: /rscoll-dev/rc-testnet/btc-vault-graph-api-key
     coinMarketCapKey: /rscoll-dev-coinmarketcap-key
     jwtSecret: /rscoll-dev/rc-testnet/jwt-secret

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,58 @@
+replicaCount: 2
+
+image:
+  repository: 886436934082.dkr.ecr.us-east-1.amazonaws.com/rscoll-dev-dao-dev
+  pullPolicy: Always
+  tag: 930eac49828502453196eb19cb032ae441c4b8a5
+
+namespace: dao-frontend
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 3000
+
+ingress:
+  enabled: false
+  className: alb
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: '443'
+    # alb.ingress.kubernetes.io/certificate-arn: ""  # Add your ACM certificate ARN
+  hosts:
+    - host: dao-frontend.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: 3000
+  initialDelaySeconds: 30
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: 3000
+  initialDelaySeconds: 10
+  periodSeconds: 5
+
+externalSecrets:
+  enabled: true
+  serviceAccount: external-secrets
+  parameterPaths:
+    theGraphApiKey: /rscoll-dev/dev/the-graph-api-key
+    dbConnectionString: /rscoll-dev/dao-dev/database-uri
+    daoGraphApiKey: /rscoll-dev/dev/dao-graph-api-key

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -15,6 +15,7 @@ service:
 ingress:
   enabled: false
   className: alb
+  wafAclArn: arn:aws:wafv2:us-east-1:886436934082:regional/webacl/rscoll-dev-blocking/e6c95241-f808-4052-8d84-fac7e401048f
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,4 +1,4 @@
-replicaCount: 2
+replicaCount: 1
 
 image:
   repository: 886436934082.dkr.ecr.us-east-1.amazonaws.com/rscoll-dev-dao-dev
@@ -30,8 +30,8 @@ ingress:
 
 resources:
   requests:
-    cpu: 100m
-    memory: 256Mi
+    cpu: 50m
+    memory: 128Mi
   limits:
     cpu: 500m
     memory: 512Mi


### PR DESCRIPTION
Add Helm chart for deploying dao-frontend to Kubernetes with:
- Multi-environment support (dev, qa, cr-qa, rc-testnet, rc-mainnet)
- ClusterSecretStore integration for AWS Parameter Store
- Environment-specific values files with correct ECR repos and parameter paths
- Separate namespace per environment for isolation
- 2 replicas per environment with resource limits
- ClusterIP service configuration
- Optional ALB ingress support