### PR TITLE
SPIKE: explore how to query average block time of Rootstock chain (mainnet and testnets)

### DIFF
--- a/src/app/collective-rewards/allocations/hooks/useGetVotingPower.ts
+++ b/src/app/collective-rewards/allocations/hooks/useGetVotingPower.ts
@@ -1,7 +1,8 @@
-import { StRIFTokenAbi } from '@/lib/abis/StRIFTokenAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-import { tokenContracts } from '@/lib/contracts'
 import { useAccount, useReadContract } from 'wagmi'
+
+import { StRIFTokenAbi } from '@/lib/abis/StRIFTokenAbi'
+import { tokenContracts } from '@/lib/contracts'
+
 export const useGetVotingPower = () => {
   const { address } = useAccount()
   const { data, isLoading, error } = useReadContract({
@@ -9,9 +10,6 @@ export const useGetVotingPower = () => {
     address: tokenContracts.stRIF,
     functionName: 'balanceOf',
     args: [address!],
-    query: {
-      refetchInterval: AVERAGE_BLOCKTIME,
-    },
   })
   return {
     data,

--- a/src/app/collective-rewards/components/ActiveBackers/ActiveBackers.tsx
+++ b/src/app/collective-rewards/components/ActiveBackers/ActiveBackers.tsx
@@ -1,5 +1,5 @@
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { useQuery } from '@tanstack/react-query'
+
 import { CountMetric } from '../CountMetric'
 import { useHandleErrors } from '../../utils'
 
@@ -13,7 +13,6 @@ export const ActiveBackers = () => {
       return response.json()
     },
     queryKey: ['activeBackers'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   useHandleErrors({ error, title: 'Error loading active backers' })

--- a/src/app/collective-rewards/metrics/hooks/useIntervalTimestamp.ts
+++ b/src/app/collective-rewards/metrics/hooks/useIntervalTimestamp.ts
@@ -1,17 +1,19 @@
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { DateTime } from 'luxon'
 import { useEffect, useState } from 'react'
 
+import { useBlockTime } from '@/shared/context/BlockTimeContext'
+
 export const useIntervalTimestamp = () => {
+  const { averageBlockTimeMs } = useBlockTime()
   const [timestamp, setTimestamp] = useState(BigInt(DateTime.now().toUnixInteger()))
 
   useEffect(() => {
     const interval = setInterval(() => {
       setTimestamp(BigInt(DateTime.now().toUnixInteger()))
-    }, AVERAGE_BLOCKTIME)
+    }, averageBlockTimeMs)
 
     return () => clearInterval(interval)
-  }, [])
+  }, [averageBlockTimeMs])
 
   return timestamp
 }

--- a/src/app/collective-rewards/rewards/backers/hooks/useGetBackerStakingHistory.ts
+++ b/src/app/collective-rewards/rewards/backers/hooks/useGetBackerStakingHistory.ts
@@ -1,6 +1,6 @@
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { useQuery } from '@tanstack/react-query'
 import { Address } from 'viem'
+
 import { fetchBackerStakingHistory } from '../actions/fetchBackerStakingHistory'
 
 export interface BackerStakingHistory {
@@ -30,7 +30,6 @@ export const useGetBackerStakingHistoryWithStateSync = (backer: Address) => {
       return response.json()
     },
     queryKey: ['backerStakingHistory', backer],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   return {
@@ -44,7 +43,6 @@ export const useGetBackerStakingHistoryWithGraph = (backer: Address) => {
   const { data, isLoading, error } = useQuery({
     queryFn: () => fetchBackerStakingHistory(backer),
     queryKey: ['backerStakingHistory', backer],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   return {

--- a/src/app/collective-rewards/rewards/builders/hooks/useGetBuilderRewardsClaimedLogs.ts
+++ b/src/app/collective-rewards/rewards/builders/hooks/useGetBuilderRewardsClaimedLogs.ts
@@ -1,8 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
-import { fetchBuilderRewardsClaimed } from '@/app/collective-rewards/actions'
 import { Address, getAddress, parseEventLogs } from 'viem'
+
+import { fetchBuilderRewardsClaimed } from '@/app/collective-rewards/actions'
 import { GaugeAbi } from '@/lib/abis/tok/GaugeAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 
 type BuilderRewardsClaimedEventLog = ReturnType<
   typeof parseEventLogs<typeof GaugeAbi, true, 'BuilderRewardsClaimed'>
@@ -29,7 +29,6 @@ export const useGetBuilderRewardsClaimedLogs = (gauge: Address) => {
       }, {})
     },
     queryKey: ['builderRewardsClaimedLogs', gauge],
-    refetchInterval: AVERAGE_BLOCKTIME,
     initialData: {},
   })
 

--- a/src/app/collective-rewards/rewards/hooks/useGetChartBackingData.tsx
+++ b/src/app/collective-rewards/rewards/hooks/useGetChartBackingData.tsx
@@ -1,5 +1,5 @@
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { useQuery } from '@tanstack/react-query'
+
 import { DailyAllocationItem } from '@/app/collective-rewards/types'
 
 export const useGetChartBackingData = () => {
@@ -22,7 +22,6 @@ export const useGetChartBackingData = () => {
       return result.data as DailyAllocationItem[]
     },
     queryKey: ['backingChartData'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   return {

--- a/src/app/collective-rewards/rewards/hooks/useGetChartRewardsData.tsx
+++ b/src/app/collective-rewards/rewards/hooks/useGetChartRewardsData.tsx
@@ -1,5 +1,5 @@
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { useQuery } from '@tanstack/react-query'
+
 import { CycleRewardsItem } from '@/app/collective-rewards/types'
 
 export const useGetChartRewardsData = () => {
@@ -22,7 +22,6 @@ export const useGetChartRewardsData = () => {
       return result.data as CycleRewardsItem[]
     },
     queryKey: ['rewardsChartData'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   return {

--- a/src/app/collective-rewards/rewards/hooks/useGetGaugesEvents.ts
+++ b/src/app/collective-rewards/rewards/hooks/useGetGaugesEvents.ts
@@ -5,7 +5,7 @@ import {
   fetchGaugeNotifyRewardLogs,
 } from '@/app/collective-rewards/actions'
 import { useQuery } from '@tanstack/react-query'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
+
 import { GaugeAbi } from '@/lib/abis/tok/GaugeAbi'
 
 type EventEntry = Extract<(typeof GaugeAbi)[number], AbiEvent>
@@ -37,7 +37,6 @@ export const useGetGaugesEvents = <T extends EventName>(gauges: Address[], event
       }, {})
     },
     queryKey: ['useGetGaugesEvents', eventName, gauges],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   return {

--- a/src/app/collective-rewards/rewards/hooks/useGetNotifyRewardLogs.ts
+++ b/src/app/collective-rewards/rewards/hooks/useGetNotifyRewardLogs.ts
@@ -1,9 +1,9 @@
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Address, getAddress, isAddressEqual, parseEventLogs } from 'viem'
+
 import { fetchGaugeNotifyRewardLogs } from '@/app/collective-rewards/actions'
 import { GaugeAbi } from '@/lib/abis/tok/GaugeAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-import { useQuery } from '@tanstack/react-query'
-import { useMemo } from 'react'
-import { Address, getAddress, isAddressEqual, parseEventLogs } from 'viem'
 
 export type GaugeNotifyRewardEventLog = ReturnType<
   typeof parseEventLogs<typeof GaugeAbi, true, 'NotifyReward'>
@@ -31,7 +31,6 @@ export const useGetGaugeNotifyRewardLogs = (
       })
     },
     queryKey: ['notifyRewardLogs', gauge],
-    refetchInterval: AVERAGE_BLOCKTIME,
     initialData: [],
   })
 

--- a/src/app/collective-rewards/rewards/hooks/useGetRewardDistributionFinishedLogs.ts
+++ b/src/app/collective-rewards/rewards/hooks/useGetRewardDistributionFinishedLogs.ts
@@ -1,9 +1,9 @@
-import { fetchRewardDistributionFinished } from '@/app/collective-rewards/actions'
-import { type BackersManagerAbi, getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-import { BackersManagerAddress } from '@/lib/contracts'
 import { useQuery } from '@tanstack/react-query'
 import { parseEventLogs } from 'viem'
+
+import { fetchRewardDistributionFinished } from '@/app/collective-rewards/actions'
+import { type BackersManagerAbi, getAbi } from '@/lib/abis/tok'
+import { BackersManagerAddress } from '@/lib/contracts'
 
 export type RewardDistributionFinishedEventLog = ReturnType<
   typeof parseEventLogs<BackersManagerAbi, true, 'RewardDistributionFinished'>
@@ -21,7 +21,6 @@ export const useGetRewardDistributionFinishedLogs = () => {
       })
     },
     queryKey: ['RewardDistributionFinished', BackersManagerAddress],
-    refetchInterval: AVERAGE_BLOCKTIME,
     initialData: [],
   })
 

--- a/src/app/collective-rewards/shared/hooks/useGetABIWithGraph.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetABIWithGraph.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
+
 import { getCachedABIData } from '../actions/fetchABIData'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { useGetABI } from './useGetABI'
 
 export const useGetMetricsAbiWithGraph = () => {
@@ -11,7 +11,6 @@ export const useGetMetricsAbiWithGraph = () => {
   } = useQuery({
     queryFn: () => getCachedABIData(),
     queryKey: ['abiData'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   const data = useGetABI(abiData)

--- a/src/app/collective-rewards/shared/hooks/useGetABIWithStateSync.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetABIWithStateSync.ts
@@ -1,6 +1,6 @@
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { useQuery } from '@tanstack/react-query'
 import Big from 'big.js'
+
 import { AbiData, useGetABI } from './useGetABI'
 import { useStateSyncHealthCheck } from './useStateSyncHealthCheck'
 
@@ -27,7 +27,6 @@ export const useGetMetricsAbiWithStateSync = () => {
       return response.json()
     },
     queryKey: ['abiData'],
-    refetchInterval: AVERAGE_BLOCKTIME,
     enabled: !healthCheckIsLoading && isStateSyncHealthy,
   })
 

--- a/src/app/collective-rewards/shared/hooks/useGetActiveBuildersCount.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetActiveBuildersCount.ts
@@ -1,4 +1,3 @@
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { useQuery } from '@tanstack/react-query'
 
 export const useGetActiveBuildersCount = () => {
@@ -11,7 +10,6 @@ export const useGetActiveBuildersCount = () => {
       return response.json()
     },
     queryKey: ['activeBuilders'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   return { data, isLoading, error }

--- a/src/app/collective-rewards/shared/hooks/useGetLastCycleRewardsWithStateSync.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetLastCycleRewardsWithStateSync.ts
@@ -1,5 +1,5 @@
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { useQuery } from '@tanstack/react-query'
+
 import { CycleData } from './useGetABI'
 import { useStateSyncHealthCheck } from './useStateSyncHealthCheck'
 
@@ -26,7 +26,6 @@ export const useGetLastCycleRewardsWithStateSync = () => {
       return result.data as CycleData[]
     },
     queryKey: ['lastCycleRewardsWithStateSync'],
-    refetchInterval: AVERAGE_BLOCKTIME,
     enabled: !healthCheckIsLoading && isStateSyncHealthy,
   })
 

--- a/src/app/collective-rewards/shared/hooks/useGetRewardsDistributionRewards.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetRewardsDistributionRewards.ts
@@ -1,9 +1,9 @@
-import { fetchRewardDistributionRewards } from '@/app/collective-rewards/actions'
-import { type BackersManagerAbi, getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-import { BackersManagerAddress } from '@/lib/contracts'
 import { useQuery } from '@tanstack/react-query'
 import { parseEventLogs } from 'viem'
+
+import { fetchRewardDistributionRewards } from '@/app/collective-rewards/actions'
+import { type BackersManagerAbi, getAbi } from '@/lib/abis/tok'
+import { BackersManagerAddress } from '@/lib/contracts'
 
 export type RewardDistributionRewardsEventLog = ReturnType<
   typeof parseEventLogs<BackersManagerAbi, true, 'RewardDistributionRewards'>
@@ -21,7 +21,6 @@ export const useGetRewardDistributionRewardsLogs = () => {
       }) as Log[]
     },
     queryKey: ['RewardDistributionRewards', BackersManagerAddress],
-    refetchInterval: AVERAGE_BLOCKTIME,
     initialData: [],
   })
 

--- a/src/app/collective-rewards/shared/hooks/useStateSyncHealthCheck.ts
+++ b/src/app/collective-rewards/shared/hooks/useStateSyncHealthCheck.ts
@@ -1,12 +1,12 @@
-import type { HealthCheckResult } from '@/app/api/health/healthCheck.utils'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+
+import type { HealthCheckResult } from '@/app/api/health/healthCheck.utils'
 import { sentryClient } from '@/lib/sentry/sentry-client'
 
 export const useStateSyncHealthCheck = (
   options?: Omit<UseQueryOptions<HealthCheckResult, Error>, 'queryKey' | 'queryFn'>,
-) =>
-  useQuery<HealthCheckResult, Error>({
+) => {
+  return useQuery<HealthCheckResult, Error>({
     queryFn: async (): Promise<HealthCheckResult> => {
       const response = await fetch('/api/health', {
         method: 'GET',
@@ -40,7 +40,7 @@ export const useStateSyncHealthCheck = (
         throw new Error('Invalid health check data')
       }
     },
-    refetchInterval: AVERAGE_BLOCKTIME,
     ...options,
     queryKey: ['healthCheck'],
   })
+}

--- a/src/app/collective-rewards/user/hooks/useGetGaugesArray.ts
+++ b/src/app/collective-rewards/user/hooks/useGetGaugesArray.ts
@@ -1,10 +1,10 @@
-import { BuilderRegistryAbi } from '@/lib/abis/tok/BuilderRegistryAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-import { BuilderRegistryAddress } from '@/lib/contracts'
-import { useReadBuilderRegistry } from '@/shared/hooks/contracts'
 import { useMemo } from 'react'
 import { AbiFunction, Address } from 'viem'
 import { useReadContracts } from 'wagmi'
+
+import { BuilderRegistryAbi } from '@/lib/abis/tok/BuilderRegistryAbi'
+import { BuilderRegistryAddress } from '@/lib/contracts'
+import { useReadBuilderRegistry } from '@/shared/hooks/contracts'
 
 const _gaugeTypeOptions = ['active', 'halted'] as const
 type GaugeType = (typeof _gaugeTypeOptions)[number]
@@ -35,9 +35,6 @@ export const useGetGaugesArray = () => {
     error: gaugesAddressError,
   } = useReadContracts<Address[]>({
     contracts: contractCalls,
-    query: {
-      refetchInterval: AVERAGE_BLOCKTIME,
-    },
   })
 
   const gauges = useMemo(() => gaugesAddress?.map(gauge => gauge.result as Address) ?? [], [gaugesAddress])

--- a/src/app/collective-rewards/user/hooks/useGetProposalsState.ts
+++ b/src/app/collective-rewards/user/hooks/useGetProposalsState.ts
@@ -1,11 +1,11 @@
-import { ProposalsToState } from '@/app/collective-rewards/types'
-import { GovernorAbi } from '@/lib/abis/Governor'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-import { GovernorAddress } from '@/lib/contracts'
-import { ProposalState } from '@/shared/types'
 import { useMemo } from 'react'
 import { Address } from 'viem'
 import { useReadContracts } from 'wagmi'
+
+import { ProposalsToState } from '@/app/collective-rewards/types'
+import { GovernorAbi } from '@/lib/abis/Governor'
+import { GovernorAddress } from '@/lib/contracts'
+import { ProposalState } from '@/shared/types'
 
 export const useGetProposalsState = (proposalIds: bigint[]) => {
   const contractCalls = useMemo(
@@ -27,9 +27,6 @@ export const useGetProposalsState = (proposalIds: bigint[]) => {
     error,
   } = useReadContracts<ProposalState[]>({
     contracts: contractCalls,
-    query: {
-      refetchInterval: AVERAGE_BLOCKTIME,
-    },
   })
 
   const proposalsToStates = useMemo(() => {

--- a/src/app/my-rewards/tx-history/hooks/useGetBackedBuilders.ts
+++ b/src/app/my-rewards/tx-history/hooks/useGetBackedBuilders.ts
@@ -42,6 +42,7 @@ export const useGetBackedBuilders = (address?: Address) => {
     },
     queryKey: ['backerToBuilder', address],
     enabled: !!address,
+    refetchInterval: false,
   })
 
   // Transform the data into filter options

--- a/src/app/my-rewards/tx-history/hooks/useGetTransactionHistory.ts
+++ b/src/app/my-rewards/tx-history/hooks/useGetTransactionHistory.ts
@@ -1,9 +1,10 @@
 import { useQuery, keepPreviousData } from '@tanstack/react-query'
-import { TransactionHistoryItem } from '../utils/types'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { useAccount } from 'wagmi'
+
 import { usePricesContext } from '@/shared/context/PricesContext'
 import { TOKENS } from '@/lib/tokens'
+
+import { TransactionHistoryItem } from '../utils/types'
 
 interface TransactionHistoryResponse {
   data: TransactionHistoryItem[]
@@ -113,7 +114,6 @@ export const useGetTransactionHistory = (params?: UseGetTransactionHistoryParams
       builder,
       rewardToken,
     ],
-    refetchInterval: AVERAGE_BLOCKTIME,
     enabled: !!address,
     placeholderData: keepPreviousData,
   })

--- a/src/app/proposals/[id]/hooks/useLike.ts
+++ b/src/app/proposals/[id]/hooks/useLike.ts
@@ -71,6 +71,7 @@ export const useLike = (proposalId: string, isConnected: boolean, signIn: () => 
       return response.json()
     },
     enabled: !!proposalId,
+    refetchInterval: false,
   })
 
   // User's own reaction query (only when authenticated)
@@ -78,6 +79,7 @@ export const useLike = (proposalId: string, isConnected: boolean, signIn: () => 
     queryKey: userReactionQueryKey(proposalId, jwtToken ?? ''),
     queryFn: () => fetchUserReaction(proposalId, jwtToken!),
     enabled: !!proposalId && !!jwtToken,
+    refetchInterval: false,
   })
 
   // Sync server-side user reaction into local state (only when uninitialized)

--- a/src/app/proposals/hooks/useFetchLatestProposals.ts
+++ b/src/app/proposals/hooks/useFetchLatestProposals.ts
@@ -4,15 +4,14 @@ import { SimplifiedRewardDistributorAbi } from '@/lib/abis/SimplifiedRewardDistr
 import { useQuery, UseQueryResult } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { getAddress, parseEventLogs, prepareEncodeFunctionData } from 'viem'
+
 import { ADDRESS_PADDING_LENGTH, RELAY_PARAMETER_PADDING_LENGTH } from '@/app/proposals/shared/utils'
 import { BuilderRegistryAbi } from '@/lib/abis/tok/BuilderRegistryAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 
 const useFetchLatestProposals = () => {
   return useQuery({
     queryFn: fetchProposalsCreatedCached,
     queryKey: ['proposalsCreated'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 }
 

--- a/src/app/proposals/hooks/useGetProposalSnapshot.ts
+++ b/src/app/proposals/hooks/useGetProposalSnapshot.ts
@@ -8,6 +8,7 @@ export const useGetProposalSnapshot = (proposalId: string) => {
     address: GovernorAddress,
     functionName: 'proposalSnapshot',
     args: [BigInt(proposalId)],
+    query: { refetchInterval: false },
   })
 
   return data

--- a/src/app/proposals/hooks/useGetProposalVotes.ts
+++ b/src/app/proposals/hooks/useGetProposalVotes.ts
@@ -12,7 +12,7 @@ export const useGetProposalVotes = (proposalId: string, shouldRefetch = false) =
     functionName: 'proposalVotes',
     args: [BigInt(proposalId)],
     query: {
-      ...(shouldRefetch && { refetchInterval: 5000 }),
+      refetchInterval: shouldRefetch ? 5000 : false,
     },
   })
 

--- a/src/app/proposals/hooks/useGetProposalsWithGraph.ts
+++ b/src/app/proposals/hooks/useGetProposalsWithGraph.ts
@@ -1,16 +1,16 @@
 import { useMemo } from 'react'
-import { useBlockNumber } from 'wagmi'
+import { useBlockNumber, useReadContracts } from 'wagmi'
+import { formatEther, Address } from 'viem'
+import moment from 'moment'
 import { useQuery } from '@tanstack/react-query'
-import { useReadContracts } from 'wagmi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
+
+import { useBlockTime } from '@/shared/context/BlockTimeContext'
 import Big from '@/lib/big'
 import { ProposalState } from '@/shared/types'
 import { Proposal } from '../shared/types'
 import { ProposalApiResponse } from '@/app/proposals/shared/types'
-import moment from 'moment'
 import { GovernorAbi } from '@/lib/abis/Governor'
 import { GOVERNOR_ADDRESS } from '@/lib/constants'
-import { formatEther, Address } from 'viem'
 
 function toProposalState(value: number | string | undefined): ProposalState {
   if (typeof value === 'number') {
@@ -172,10 +172,10 @@ function transformProposalsData(
 }
 
 export function useGetProposalsWithGraph() {
+  const { averageBlockTimeMs } = useBlockTime()
   const { data: latestBlockNumber } = useBlockNumber({
     query: {
-      refetchInterval: AVERAGE_BLOCKTIME,
-      staleTime: AVERAGE_BLOCKTIME,
+      staleTime: averageBlockTimeMs,
     },
   })
 
@@ -186,7 +186,6 @@ export function useGetProposalsWithGraph() {
   } = useQuery({
     queryFn: fetchProposalsFromAPI,
     queryKey: ['proposals'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   const proposalsFromNode = useMemo(
@@ -234,7 +233,7 @@ export function useGetProposalsWithGraph() {
     contracts: votesContracts,
     query: {
       enabled: proposalsFromNode.length > 0,
-      staleTime: AVERAGE_BLOCKTIME,
+      staleTime: averageBlockTimeMs,
     },
   })
 
@@ -250,7 +249,7 @@ export function useGetProposalsWithGraph() {
     contracts: stateContracts,
     query: {
       enabled: proposalsFromNode.length > 0,
-      staleTime: AVERAGE_BLOCKTIME,
+      staleTime: averageBlockTimeMs,
     },
   })
 

--- a/src/app/proposals/hooks/useVoteCast.ts
+++ b/src/app/proposals/hooks/useVoteCast.ts
@@ -35,7 +35,7 @@ export const useGetVoteForSpecificProposal = (
   const { data: voteEvents } = useQuery({
     queryFn: () => parseVoteCastEvents(address),
     queryKey: ['VoteCast', address],
-    enabled: !!address && !!proposalId, // Query will only run if both address and proposalId are present
+    enabled: !!address && !!proposalId,
   })
 
   const event = voteEvents?.find(event => event.args.proposalId.toString() === proposalId)

--- a/src/app/proposals/hooks/useVotingPower.ts
+++ b/src/app/proposals/hooks/useVotingPower.ts
@@ -10,6 +10,7 @@ export const useVotingPower = () => {
   const { data: proposalDetails, isLoading: isProposalsDetailsLoading } = useQuery({
     queryFn: getCachedProposalSharedDetails,
     queryKey: ['cachedProposalsSharedDetails'],
+    refetchInterval: false,
   })
 
   const { data, isLoading: isLoadingVotes } = useReadContracts({

--- a/src/app/providers/ContextProviders.tsx
+++ b/src/app/providers/ContextProviders.tsx
@@ -13,6 +13,7 @@ import { REOWN_METADATA_URL, REOWN_PROJECT_ID } from '@/lib/constants'
 import { useChunkErrorHandler } from '@/lib/hooks/useChunkErrorHandler'
 import { FeatureFlagProvider } from '@/shared/context/FeatureFlag'
 import { ConnectWalletProvider } from '@/shared/walletConnection/connection/ConnectWalletProvider'
+import { BlockTimeProvider } from '@/shared/context/BlockTimeContext'
 import { AllocationsContextProvider } from '../collective-rewards/allocations/context'
 import { BuilderContextProviderWithPrices } from '../collective-rewards/user'
 import { BoosterProvider } from './NFT/BoosterContext'
@@ -89,21 +90,23 @@ export const ContextProviders = ({ children, initialState }: Props) => {
         <FeatureFlagProvider>
           <WagmiProvider config={wagmiAdapterConfig} initialState={initialState}>
             <QueryClientProvider client={queryClient}>
-              <ConnectWalletProvider>
-                <BuilderContextProviderWithPrices>
-                  <BoosterProvider>
-                    <AllocationsContextProvider>
-                      <BalancesProvider>
-                        <TooltipProvider>
-                          <ReviewProposalProvider>
-                            <NavigationGuardProvider>{children}</NavigationGuardProvider>
-                          </ReviewProposalProvider>
-                        </TooltipProvider>
-                      </BalancesProvider>
-                    </AllocationsContextProvider>
-                  </BoosterProvider>
-                </BuilderContextProviderWithPrices>
-              </ConnectWalletProvider>
+              <BlockTimeProvider>
+                <ConnectWalletProvider>
+                  <BuilderContextProviderWithPrices>
+                    <BoosterProvider>
+                      <AllocationsContextProvider>
+                        <BalancesProvider>
+                          <TooltipProvider>
+                            <ReviewProposalProvider>
+                              <NavigationGuardProvider>{children}</NavigationGuardProvider>
+                            </ReviewProposalProvider>
+                          </TooltipProvider>
+                        </BalancesProvider>
+                      </AllocationsContextProvider>
+                    </BoosterProvider>
+                  </BuilderContextProviderWithPrices>
+                </ConnectWalletProvider>
+              </BlockTimeProvider>
             </QueryClientProvider>
           </WagmiProvider>
         </FeatureFlagProvider>

--- a/src/app/providers/NFT/BoosterContext.tsx
+++ b/src/app/providers/NFT/BoosterContext.tsx
@@ -1,10 +1,10 @@
 'use client'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { useQuery } from '@tanstack/react-query'
 import axios from 'axios'
 import { createContext, ReactNode, useCallback, useContext, useMemo } from 'react'
 import { Address } from 'viem'
 import { useAccount } from 'wagmi'
+
 import { fetchBoostData, fetchLatestFile } from './boost.utils'
 
 interface HolderRewards {
@@ -118,7 +118,6 @@ export const useFetchBoostData = () => {
   } = useQuery<string>({
     queryFn: async () => fetchLatestFile(now),
     queryKey: ['nftBoosterLatestFile'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   const hasActiveCampaign = !!latestFile && latestFile.trim() !== 'None'
@@ -130,7 +129,6 @@ export const useFetchBoostData = () => {
   } = useQuery<BoostData>({
     queryFn: async () => fetchBoostData(latestFile?.trim(), now),
     queryKey: ['nftBoosterData'],
-    refetchInterval: AVERAGE_BLOCKTIME,
     enabled: hasActiveCampaign,
   })
 

--- a/src/app/staking-history/hooks/useGetStakingHistory.ts
+++ b/src/app/staking-history/hooks/useGetStakingHistory.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { useAccount } from 'wagmi'
+
 import { fetchStakingHistory, StakingHistoryResponse } from '../utils/api'
 import { StakingHistoryItem } from '../utils/types'
 
@@ -45,7 +45,6 @@ export const useGetStakingHistory = (params?: UseGetStakingHistoryParams) => {
       sortDirection,
       type.length > 0 ? [...type].sort().join(',') : '',
     ],
-    refetchInterval: AVERAGE_BLOCKTIME,
     enabled: !!address,
   })
 

--- a/src/app/user/Balances/hooks/useGetAddressTokens.ts
+++ b/src/app/user/Balances/hooks/useGetAddressTokens.ts
@@ -1,13 +1,14 @@
-import { useBalance, useReadContracts } from 'wagmi'
+import { useCallback } from 'react'
 import { Address } from 'viem'
+import { useQuery } from '@tanstack/react-query'
+import { useBalance, useReadContracts } from 'wagmi'
+
+import { AddressToken } from '@/app/user/types'
+import { TokenInfoReturnType } from '@/app/user/api/tokens/route'
 import { RIFTokenAbi } from '@/lib/abis/RIFTokenAbi'
 import { tokenContracts, MulticallAddress } from '@/lib/contracts'
-import { AddressToken } from '@/app/user/types'
-import { useQuery } from '@tanstack/react-query'
+import { RBTC, RIF, STRIF, USDRIF, USDT0 } from '@/lib/constants'
 import { axiosInstance } from '@/lib/utils'
-import { TokenInfoReturnType } from '@/app/user/api/tokens/route'
-import { AVERAGE_BLOCKTIME, RBTC, RIF, STRIF, USDRIF, USDT0 } from '@/lib/constants'
-import { useCallback } from 'react'
 
 const getTokenFunction = (
   tokenAddress: Address,
@@ -54,9 +55,6 @@ export const useGetAddressTokens = (address: Address, chainId?: number) => {
       getTokenFunction(tokenContracts.USDT0, address, 'balanceOf'),
     ],
     multicallAddress: MulticallAddress,
-    query: {
-      refetchInterval: AVERAGE_BLOCKTIME,
-    },
   })
 
   const {
@@ -67,6 +65,7 @@ export const useGetAddressTokens = (address: Address, chainId?: number) => {
     queryKey: ['tokenData'],
     queryFn: () =>
       axiosInstance.get<TokenInfoReturnType>('/user/api/tokens', { baseURL: '/' }).then(({ data }) => data),
+    refetchInterval: false,
   })
 
   const rifTokenData =

--- a/src/app/user/Delegation/hooks/useGetDelegates.ts
+++ b/src/app/user/Delegation/hooks/useGetDelegates.ts
@@ -1,8 +1,8 @@
-import { StRIFTokenAbi } from '@/lib/abis/StRIFTokenAbi'
-import { tokenContracts } from '@/lib/contracts'
 import { Address } from 'viem'
 import { useReadContract } from 'wagmi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
+
+import { StRIFTokenAbi } from '@/lib/abis/StRIFTokenAbi'
+import { tokenContracts } from '@/lib/contracts'
 
 const stRifContract = {
   abi: StRIFTokenAbi,
@@ -19,9 +19,6 @@ export const useGetDelegates = (address: Address | undefined) => {
       ...stRifContract,
       functionName: 'delegates',
       args: [address],
-      query: {
-        refetchInterval: AVERAGE_BLOCKTIME,
-      },
     },
   )
 

--- a/src/app/vault/history/hooks/useGetVaultHistory.ts
+++ b/src/app/vault/history/hooks/useGetVaultHistory.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { useAccount } from 'wagmi'
+
 import { fetchVaultHistory, VaultHistoryResponse } from '../utils/api'
 import { VaultHistoryItemAPI } from '../utils/types'
 
@@ -56,7 +56,6 @@ export const useGetVaultHistory = (params?: UseGetVaultHistoryParams) => {
       sortDirection,
       type.length > 0 ? [...type].sort().join(',') : '',
     ],
-    refetchInterval: AVERAGE_BLOCKTIME,
     enabled: !!address,
   })
 

--- a/src/app/vault/hooks/useVaultDepositLimiter.ts
+++ b/src/app/vault/hooks/useVaultDepositLimiter.ts
@@ -1,7 +1,8 @@
-import { useReadContracts, useAccount } from 'wagmi'
-import { VaultDepositLimiterAbi } from '@/lib/abis/VaultDepositLimiterAbi'
 import { useMemo } from 'react'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
+import { useReadContracts, useAccount } from 'wagmi'
+
+import { VaultDepositLimiterAbi } from '@/lib/abis/VaultDepositLimiterAbi'
+
 import { useVaultDepositLimiterAddress } from './useVaultDepositLimiterAddress'
 
 /**
@@ -60,7 +61,6 @@ export function useVaultDepositLimiter() {
   } = useReadContracts({
     contracts,
     query: {
-      refetchInterval: AVERAGE_BLOCKTIME, // Refetch every minute
       enabled: !!depositLimiterAddress, // Only run when we have the address
     },
   })

--- a/src/app/vault/hooks/useVaultDepositLimiterAddress.ts
+++ b/src/app/vault/hooks/useVaultDepositLimiterAddress.ts
@@ -16,7 +16,7 @@ export function useVaultDepositLimiterAddress() {
     abi: vault.abi,
     functionName: 'depositLimiter',
     query: {
-      // No refetch interval since this value doesn't change
+      refetchInterval: false,
       staleTime: Infinity,
       gcTime: Infinity,
     },

--- a/src/components/Countdown/Countdown.stories.tsx
+++ b/src/components/Countdown/Countdown.stories.tsx
@@ -3,6 +3,7 @@ import { Countdown } from './Countdown'
 import { TimeSource } from './types'
 import Big from '@/lib/big'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { BlockTimeProvider } from '@/shared/context/BlockTimeContext'
 
 const queryClient = new QueryClient()
 
@@ -16,7 +17,9 @@ const meta: Meta<typeof Countdown> = {
   decorators: [
     Story => (
       <QueryClientProvider client={queryClient}>
-        <Story />
+        <BlockTimeProvider>
+          <Story />
+        </BlockTimeProvider>
       </QueryClientProvider>
     ),
   ],

--- a/src/components/Countdown/Countdown.tsx
+++ b/src/components/Countdown/Countdown.tsx
@@ -1,20 +1,29 @@
-import { Paragraph } from '@/components/Typography'
+'use client'
+
 import moment from 'moment'
-import { DEFAULT_NUMBER_OF_SECONDS_PER_BLOCK } from '@/lib/constants'
-import { cn } from '@/lib/utils'
-import { CountdownProps, TimeSource } from './types'
-import Big from '@/lib/big'
 import { useBlockNumber } from 'wagmi'
+
+import { Paragraph } from '@/components/Typography'
+import { cn } from '@/lib/utils'
+import { useBlockTime } from '@/shared/context/BlockTimeContext'
+import Big from '@/lib/big'
+
+import { CountdownProps, TimeSource } from './types'
 
 /**
  * Calculates the time remaining in seconds
  */
-const calculateTimeRemaining = (end: Big, currentTime: Big, timeSource: TimeSource): number => {
+const calculateTimeRemaining = (
+  end: Big,
+  currentTime: Big,
+  timeSource: TimeSource,
+  secondsPerBlock: number,
+): number => {
   const remaining = end.minus(currentTime)
   if (remaining.lte(0)) return 0
 
   if (timeSource === 'blocks') {
-    return remaining.mul(DEFAULT_NUMBER_OF_SECONDS_PER_BLOCK).toNumber()
+    return remaining.mul(secondsPerBlock).toNumber()
   } else {
     return remaining.toNumber()
   }
@@ -102,6 +111,7 @@ export function Countdown({
   className,
   colorDirection = 'normal',
 }: CountdownProps) {
+  const { secondsPerBlock } = useBlockTime()
   const { data: currentBlockNumber } = useBlockNumber()
 
   // Calculate current time based on timeSource
@@ -112,7 +122,7 @@ export function Countdown({
         : Big(0)
       : Big(Math.floor(Date.now() / 1000))
 
-  const timeRemainingSec = calculateTimeRemaining(end, currentTime, timeSource)
+  const timeRemainingSec = calculateTimeRemaining(end, currentTime, timeSource, secondsPerBlock)
   const ratio = calculateRatio(end, currentTime, referenceStart)
 
   // Color coding is automatically disabled if ratio cannot be calculated (no referenceStart)

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -50,7 +50,6 @@ export const BUILDER_REGISTRY_ADDRESS = process.env.NEXT_PUBLIC_BUILDER_REGISTRY
 export const REWARD_DISTRIBUTOR_ADDRESS = process.env.NEXT_PUBLIC_REWARD_DISTRIBUTOR_ADDRESS as Address
 export const NFT_BOOSTER_DATA_URL = (process.env.NEXT_PUBLIC_NFT_BOOSTER_DATA_URL as string) ?? ''
 
-export const AVERAGE_BLOCKTIME = 60_000
 export const CACHE_REVALIDATE_SECONDS = 20
 
 export const RIF = 'RIF'
@@ -71,7 +70,6 @@ export const GRANT_TOKEN_LIMITS = {
 export const RNS_REGISTRY_ADDRESS = process.env.NEXT_PUBLIC_RNS_REGISTRY_ADDRESS as Address
 
 export const NODE_URL = process.env.NEXT_PUBLIC_NODE_URL
-export const DEFAULT_NUMBER_OF_SECONDS_PER_BLOCK = 30
 
 export const GOOGLE_TAG_ID = 'GTM-PTL6VZMT'
 

--- a/src/shared/context/BlockTimeContext/BlockTimeContext.test.tsx
+++ b/src/shared/context/BlockTimeContext/BlockTimeContext.test.tsx
@@ -1,0 +1,46 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { type ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { BlockTimeProvider, useBlockTime } from './BlockTimeContext'
+
+vi.mock('./computeAverageBlockTime', () => ({
+  computeAverageBlockTime: vi.fn().mockResolvedValue(29_000),
+}))
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <BlockTimeProvider>{children}</BlockTimeProvider>
+      </QueryClientProvider>
+    )
+  }
+}
+
+describe('BlockTimeContext', () => {
+  it('should provide fetched block time values', async () => {
+    const { result } = renderHook(() => useBlockTime(), { wrapper: createWrapper() })
+
+    await waitFor(() => {
+      expect(result.current.averageBlockTimeMs).toBe(29_000)
+    })
+
+    expect(result.current.secondsPerBlock).toBe(29)
+  })
+
+  it('should throw when used outside BlockTimeProvider', () => {
+    const queryClient = new QueryClient()
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    expect(() => {
+      renderHook(() => useBlockTime(), { wrapper })
+    }).toThrow('useBlockTime must be used within a BlockTimeProvider')
+  })
+})

--- a/src/shared/context/BlockTimeContext/BlockTimeContext.tsx
+++ b/src/shared/context/BlockTimeContext/BlockTimeContext.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { createContext, ReactNode, useContext, useEffect, useMemo } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { computeAverageBlockTime } from './computeAverageBlockTime'
+
+const FALLBACK_BLOCK_TIME_MS = 25_000
+const ONE_HOUR_MS = 3_600_000
+
+interface BlockTimeContextType {
+  averageBlockTimeMs: number
+  secondsPerBlock: number
+}
+
+const BlockTimeContext = createContext<BlockTimeContextType | null>(null)
+
+interface Props {
+  children: ReactNode
+}
+
+/**
+ * Fetches the average Rootstock block time from Blockscout (server action, cached 1h)
+ * and provides it to the component tree via context. Also sets the fetched value
+ * as the default `refetchInterval` on the QueryClient, so all queries poll at
+ * block time by default — individual hooks only need to override when they want
+ * a different interval or opt out with `refetchInterval: false`.
+ */
+export const BlockTimeProvider = ({ children }: Props) => {
+  const queryClient = useQueryClient()
+  const { data: averageBlockTimeMs = FALLBACK_BLOCK_TIME_MS } = useQuery({
+    queryKey: ['averageBlockTime'],
+    queryFn: computeAverageBlockTime,
+    staleTime: ONE_HOUR_MS,
+    refetchInterval: ONE_HOUR_MS,
+  })
+
+  // Propagate fetched block time as the default refetchInterval for all queries
+  useEffect(() => {
+    queryClient.setDefaultOptions({
+      queries: {
+        ...queryClient.getDefaultOptions().queries,
+        refetchInterval: averageBlockTimeMs,
+      },
+    })
+  }, [averageBlockTimeMs, queryClient])
+
+  const value = useMemo<BlockTimeContextType>(
+    () => ({
+      averageBlockTimeMs,
+      secondsPerBlock: averageBlockTimeMs / 1000,
+    }),
+    [averageBlockTimeMs],
+  )
+
+  return <BlockTimeContext.Provider value={value}>{children}</BlockTimeContext.Provider>
+}
+
+/**
+ * Returns the current average Rootstock block time, fetched from Blockscout and
+ * cached for 1 hour. Falls back to 25s if the fetch fails.
+ *
+ * Most hooks don't need this — `refetchInterval` is set as a QueryClient default.
+ * Use this hook only when you need the block time value directly (e.g. for
+ * `setInterval`, `staleTime`, or block-to-time conversions).
+ *
+ * @returns averageBlockTimeMs — block time in milliseconds
+ * @returns secondsPerBlock — block time in seconds (for time calculations)
+ *
+ * @example
+ * ```ts
+ * const { secondsPerBlock } = useBlockTime()
+ * const seconds = remainingBlocks * secondsPerBlock
+ * ```
+ */
+export const useBlockTime = (): BlockTimeContextType => {
+  const context = useContext(BlockTimeContext)
+  if (context === null) {
+    throw new Error('useBlockTime must be used within a BlockTimeProvider')
+  }
+  return context
+}

--- a/src/shared/context/BlockTimeContext/computeAverageBlockTime.test.ts
+++ b/src/shared/context/BlockTimeContext/computeAverageBlockTime.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { computeAverageBlockTime } from './computeAverageBlockTime'
+
+const FALLBACK_BLOCK_TIME_MS = 25_000
+
+describe('computeAverageBlockTime', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should fall back to 25s when Blockscout is unreachable', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'))
+
+    const result = await computeAverageBlockTime()
+
+    expect(result).toBe(FALLBACK_BLOCK_TIME_MS)
+  })
+
+  it('should fall back to 25s when API returns invalid data', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ average_block_time: null }), { status: 200 }),
+    )
+
+    const result = await computeAverageBlockTime()
+
+    expect(result).toBe(FALLBACK_BLOCK_TIME_MS)
+  })
+})

--- a/src/shared/context/BlockTimeContext/computeAverageBlockTime.ts
+++ b/src/shared/context/BlockTimeContext/computeAverageBlockTime.ts
@@ -1,0 +1,35 @@
+const BLOCKSCOUT_STATS_URL = 'https://rootstock.blockscout.com/api/v2/stats'
+const FALLBACK_BLOCK_TIME_MS = 25_000
+
+interface BlockscoutStatsResponse {
+  average_block_time: number
+}
+
+/**
+ * Fetches the average Rootstock block time from the Blockscout stats API.
+ * Falls back to 25s if the API is unreachable or returns unexpected data.
+ *
+ * @returns Average block time in milliseconds
+ */
+export async function computeAverageBlockTime(): Promise<number> {
+  try {
+    const response = await fetch(BLOCKSCOUT_STATS_URL, { signal: AbortSignal.timeout(10_000) })
+
+    if (!response.ok) {
+      console.error(`[BlockTime] Blockscout API returned ${response.status}`)
+      return FALLBACK_BLOCK_TIME_MS
+    }
+
+    const data: BlockscoutStatsResponse = await response.json()
+    const blockTimeMs = data.average_block_time
+
+    if (typeof blockTimeMs !== 'number' || blockTimeMs <= 0) {
+      console.error('[BlockTime] Unexpected average_block_time value:', blockTimeMs)
+      return FALLBACK_BLOCK_TIME_MS
+    }
+    return Math.round(blockTimeMs)
+  } catch (error) {
+    console.error('[BlockTime] Failed to fetch block time from Blockscout:', error)
+    return FALLBACK_BLOCK_TIME_MS
+  }
+}

--- a/src/shared/context/BlockTimeContext/index.ts
+++ b/src/shared/context/BlockTimeContext/index.ts
@@ -1,0 +1,2 @@
+export { BlockTimeProvider, useBlockTime } from './BlockTimeContext'
+export { computeAverageBlockTime } from './computeAverageBlockTime'

--- a/src/shared/hooks/contracts/collective-rewards/useReadBackersManager.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadBackersManager.ts
@@ -1,5 +1,4 @@
 import { type BackersManagerAbi, getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BackersManagerAddress } from '@/lib/contracts'
 import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
@@ -22,7 +21,6 @@ export const useReadBackersManager = <TFunctionName extends BackersManagerFuncti
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/collective-rewards/useReadBuilderRegistry.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadBuilderRegistry.ts
@@ -1,5 +1,4 @@
 import { type BuilderRegistryAbi, getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BuilderRegistryAddress } from '@/lib/contracts'
 import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
@@ -22,7 +21,6 @@ export const useReadBuilderRegistry = <TFunctionName extends BuilderRegistryFunc
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/collective-rewards/useReadBuilderRegistryForMultipleArgs.test.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadBuilderRegistryForMultipleArgs.test.ts
@@ -1,12 +1,10 @@
 import { getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BuilderRegistryAddress } from '@/lib/contracts'
 import { renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, Mock, vi } from 'vitest'
 import { useReadContracts } from 'wagmi'
 import { useReadBuilderRegistryForMultipleArgs } from './useReadBuilderRegistryForMultipleArgs'
 
-// Mock wagmi's useReadContracts
 vi.mock('wagmi', () => ({
   useReadContracts: vi.fn(),
 }))
@@ -59,7 +57,6 @@ describe('useReadBuilderRegistries hook', () => {
         ],
         query: {
           retry: true,
-          refetchInterval: AVERAGE_BLOCKTIME,
         },
       }),
     )

--- a/src/shared/hooks/contracts/collective-rewards/useReadBuilderRegistryForMultipleArgs.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadBuilderRegistryForMultipleArgs.ts
@@ -1,5 +1,4 @@
 import { getAbi, type BuilderRegistryAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BuilderRegistryAddress } from '@/lib/contracts'
 import { useMemo } from 'react'
 import { UseReadContractParameters, UseReadContractReturnType, useReadContracts } from 'wagmi'
@@ -31,7 +30,6 @@ export const useReadBuilderRegistryForMultipleArgs = <TFunctionName extends Buil
     })),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/collective-rewards/useReadCycleTimeKeeper.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadCycleTimeKeeper.ts
@@ -1,5 +1,4 @@
 import { type CycleTimeKeeperAbi, getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BackersManagerAddress } from '@/lib/contracts'
 import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
@@ -22,7 +21,6 @@ export const useReadCycleTimeKeeper = <TFunctionName extends CycleTimeKeeperFunc
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/collective-rewards/useReadGauges.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadGauges.ts
@@ -1,8 +1,9 @@
-import { getAbi, type GaugeAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { useMemo } from 'react'
 import { Abi } from 'viem'
 import { UseReadContractParameters, UseReadContractReturnType, useReadContracts } from 'wagmi'
+
+import { getAbi, type GaugeAbi } from '@/lib/abis/tok'
+
 import { UseReadContractsConfig, ViewPureFunctionName } from '../types'
 
 type GaugeFunctionName = ViewPureFunctionName<GaugeAbi>
@@ -32,7 +33,6 @@ export const useReadGauges = <TFunctionName extends GaugeFunctionName>(
     })),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/collective-rewards/useReadRewardDistributor.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadRewardDistributor.ts
@@ -1,5 +1,4 @@
 import { getAbi, type RewardDistributorAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { RewardDistributorAddress } from '@/lib/contracts'
 import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
@@ -22,7 +21,6 @@ export const useReadRewardDistributor = <TFunctionName extends RewardDistributor
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/useCommunity.ts
+++ b/src/shared/hooks/useCommunity.ts
@@ -65,6 +65,7 @@ const useContractData = (nftAddress?: Address) => {
       axiosInstance
         .get<NftDataFromAddressesReturnType>('/user/api/communities', { baseURL: '/' })
         .then(({ data }) => data),
+    refetchInterval: false,
   })
 
   return useMemo(() => {

--- a/src/shared/hooks/useDiscourseTopic.ts
+++ b/src/shared/hooks/useDiscourseTopic.ts
@@ -5,7 +5,7 @@ import type { DiscourseTopicResponse } from '@/shared/types/discourse'
 interface UseDiscourseTopicOptions {
   enabled?: boolean
   staleTime?: number
-  refetchInterval?: number
+  refetchInterval?: number | false
 }
 
 /**
@@ -26,7 +26,7 @@ export function useDiscourseTopic(
   discourseUrl: string | null | undefined,
   options: UseDiscourseTopicOptions = {},
 ) {
-  const { enabled = true, staleTime = 5 * 60 * 1000, refetchInterval } = options
+  const { enabled = true, staleTime = 5 * 60 * 1000, refetchInterval = false } = options
 
   return useQuery<DiscourseTopicResponse, Error>({
     queryKey: ['discourse-topic', discourseUrl],

--- a/src/shared/hooks/useExecuteProposal.ts
+++ b/src/shared/hooks/useExecuteProposal.ts
@@ -33,6 +33,7 @@ export const useExecuteProposal = (proposalId: string) => {
   const { data: timelockAddress } = useReadContract({
     ...DAO_DEFAULT_PARAMS,
     functionName: 'timelock',
+    query: { refetchInterval: false },
   })
 
   const { data: minDelay } = useReadContract({
@@ -41,7 +42,8 @@ export const useExecuteProposal = (proposalId: string) => {
     functionName: 'getMinDelay',
     query: {
       enabled: !!timelockAddress,
-      staleTime: 60000, // Timelock delay rarely changes
+      refetchInterval: false,
+      staleTime: 60000,
     },
   })
 

--- a/src/shared/hooks/useGetExternalDelegatedAmount.ts
+++ b/src/shared/hooks/useGetExternalDelegatedAmount.ts
@@ -1,9 +1,10 @@
-import { Address } from 'viem'
-import { useGetDelegates } from '@/app/user/Delegation/hooks/useGetDelegates'
-import { useAccount, useReadContract } from 'wagmi'
-import { StRIFTokenAbi } from '@/lib/abis/StRIFTokenAbi'
-import { AVERAGE_BLOCKTIME, STRIF_ADDRESS } from '@/lib/constants'
 import { useEffect, useState } from 'react'
+import { Address } from 'viem'
+import { useAccount, useReadContract } from 'wagmi'
+
+import { useGetDelegates } from '@/app/user/Delegation/hooks/useGetDelegates'
+import { StRIFTokenAbi } from '@/lib/abis/StRIFTokenAbi'
+import { STRIF_ADDRESS } from '@/lib/constants'
 import { getEnsDomainName } from '@/lib/rns'
 
 /**
@@ -51,9 +52,6 @@ export const useGetExternalDelegatedAmount = (address: Address | undefined) => {
       address: STRIF_ADDRESS,
       functionName: 'getVotes',
       args: [ownAddress],
-      query: {
-        refetchInterval: AVERAGE_BLOCKTIME,
-      },
     },
   )
 
@@ -63,9 +61,6 @@ export const useGetExternalDelegatedAmount = (address: Address | undefined) => {
       address: STRIF_ADDRESS,
       functionName: 'getVotes',
       args: [delegateeAddress],
-      query: {
-        refetchInterval: AVERAGE_BLOCKTIME,
-      },
     },
   )
 
@@ -79,9 +74,6 @@ export const useGetExternalDelegatedAmount = (address: Address | undefined) => {
       address: STRIF_ADDRESS,
       functionName: 'balanceOf',
       args: [ownAddress],
-      query: {
-        refetchInterval: AVERAGE_BLOCKTIME,
-      },
     },
   )
 

--- a/src/shared/hooks/usePagination.ts
+++ b/src/shared/hooks/usePagination.ts
@@ -1,6 +1,5 @@
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-import { useQuery, UseQueryResult } from '@tanstack/react-query'
 import { useCallback, useMemo, useState } from 'react'
+import { useQuery, UseQueryResult } from '@tanstack/react-query'
 
 interface UsePaginatedQueryOptions<T> {
   queryKey: string[]
@@ -29,7 +28,6 @@ export function usePagination<T>({
     queryKey,
     queryFn,
     refetchOnWindowFocus: false,
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   const allItems = useMemo(() => (Array.isArray(data) ? data : []), [data])

--- a/src/shared/hooks/useProposalState.ts
+++ b/src/shared/hooks/useProposalState.ts
@@ -22,7 +22,7 @@ export const useProposalState = (proposalId: string, shouldRefetch = true) => {
     functionName: 'state',
     args: [BigInt(proposalId)],
     query: {
-      ...(shouldRefetch && { refetchInterval: 5000 }),
+      refetchInterval: shouldRefetch ? 5000 : false,
     },
   })
 

--- a/src/shared/hooks/useVoteOnProposal.ts
+++ b/src/shared/hooks/useVoteOnProposal.ts
@@ -26,7 +26,7 @@ export const useVoteOnProposal = (proposalId: string, shouldRefetch = true) => {
     functionName: 'hasVoted',
     args: [BigInt(proposalId), address as Address],
     query: {
-      ...(shouldRefetch && { refetchInterval: 5000 }),
+      refetchInterval: shouldRefetch ? 5000 : false,
     },
   })
 


### PR DESCRIPTION
## Why this change?

The app used two hardcoded constants to represent Rootstock's block time:

- `AVERAGE_BLOCKTIME = 60_000` — every hook that polled on-chain data used this as its `refetchInterval`, so the UI refreshed once per minute
- `DEFAULT_NUMBER_OF_SECONDS_PER_BLOCK = 30` — the `Countdown` component multiplied remaining blocks by this to show "2d 5h 30m" until a proposal deadline

Rootstock is merge-mined with Bitcoin. Its actual block time fluctuates between ~28–33 seconds. Neither constant reflected reality, causing:

1. **Inaccurate countdowns** — proposal deadlines drifted by minutes over multi-day voting periods because the 30s assumption didn't match the real ~28s average
2. **Unnecessarily stale data** — polling every 60s meant the UI was always at least one full block behind. Users saw outdated balances, vote counts, and proposal states

## How it works now

### Block time is fetched from Blockscout

`computeAverageBlockTime()` calls `rootstock.blockscout.com/api/v2/stats` and reads the `average_block_time` field — a single HTTP call, no block math. If Blockscout is unreachable or returns bad data, it falls back to 25 seconds.

### The fetched value becomes the default polling interval for all queries

`BlockTimeProvider` (mounted in `ContextProviders` after `QueryClientProvider`) does two things:

1. Fetches the block time via React Query with a 1-hour `staleTime` — so it re-fetches once per hour
2. Sets `averageBlockTimeMs` as the **default `refetchInterval`** on the `QueryClient` via `setDefaultOptions`

This means every `useQuery`, `useReadContract`, and `useReadContracts` call in the app automatically polls at block time without any code in individual hooks. The old pattern of importing `AVERAGE_BLOCKTIME` and passing it as `refetchInterval` in 35+ files is gone.

### Three hooks still use `useBlockTime()` directly

- `Countdown.tsx` — needs `secondsPerBlock` to convert remaining blocks into human-readable time
- `useIntervalTimestamp.ts` — needs `averageBlockTimeMs` for a `setInterval` duration
- `useGetProposalsWithGraph.ts` — needs `averageBlockTimeMs` for `staleTime`

### Queries that shouldn't poll opt out explicitly

Some queries fetch data that doesn't change at blockchain speed. These set `refetchInterval: false` to avoid inheriting the default:

- **Immutable on-chain values** — `proposalSnapshot` (set at creation), `depositLimiter` address (set at deployment), `timelock`/`getMinDelay` (governance config)
- **API calls to our backend** — token metadata, backed builders, like counts, transaction history filters
- **External APIs** — Discourse topic data

Conditional polling hooks (`useVoteOnProposal`, `useProposalState`, `useGetProposalVotes`) use `refetchInterval: shouldRefetch ? 5000 : false` — they poll fast during active voting and stop otherwise.

## What changed for the user

| Aspect | Before | After |
|--------|--------|-------|
| Data refresh rate | Every 60 seconds | Every ~28 seconds (once per block) |
| Countdown accuracy | Assumed 30s per block | Uses real average (~28s) |
| Balances, votes, proposal states | Only polled if the hook explicitly set `refetchInterval` | All on-chain data polls by default |
| Fallback if source fails | N/A (hardcoded) | 25 seconds |

The app will now feel more responsive — on-chain data updates roughly twice as fast as before.

---

## QA Testing Guidelines

### What changed under the hood

- **Every on-chain query now polls at ~28s** instead of 60s (or not at all). This includes balances, voting power, proposal states, collective rewards data, and vault information.
- **Countdown timers** (proposal vote deadlines, queue timers) now use the real block time instead of a hardcoded 30s assumption.
- A small number of queries (API calls, immutable values) explicitly opt out of polling — these should behave the same as before.

### What to test

**1. Proposal voting flow**
- Open a proposal in Active state → verify the countdown timer ticks and shows reasonable remaining time
- Cast a vote → verify the vote count updates within ~30 seconds without manual refresh
- Verify the "Vote" button disables after casting
- Check that proposal state transitions (Active → Succeeded → Queued → Executed) are reflected without page reload

**2. Balances and staking**
- Check the Balances page → verify RIF, stRIF, RBTC, USDRIF balances update after a transaction within ~30 seconds
- Stake/unstake → verify the balance change appears without manual refresh

**3. Collective rewards**
- Navigate to the rewards pages → verify builder rewards, backer data, and cycle information load correctly
- Verify active backers count and gauge data refresh

**4. Vault operations**
- Open the vault deposit/withdraw form → verify preview amounts update as you type
- Complete a deposit/withdraw → verify vault balance updates within ~30 seconds

**5. Countdown timers**
- Compare a proposal's displayed "vote ends in" time against the on-chain deadline — it should be accurate within a minute over a 24-hour period
- Check the queue timer on a Queued proposal

**6. Fallback behavior**
- If you can simulate Blockscout being unreachable (e.g. block the domain), verify the app still works with a 25-second polling interval — no errors, no broken UI

**7. Queries that should NOT poll**
- Verify Discourse topic data (proposal descriptions with forum links) doesn't cause repeated API calls in the Network tab
- Verify the like count on proposals doesn't poll (should only update on user click)
- Verify token metadata (symbols, decimals) isn't refetched repeatedly

### How to verify polling behavior

Open the browser DevTools **Network** tab, filter by `Fetch/XHR`, and observe:
- On-chain data requests should fire roughly every ~28 seconds
- API routes like `/api/like`, `/api/discourse/topic`, `/user/api/tokens` should NOT repeat on an interval
- The Blockscout stats call (`rootstock.blockscout.com/api/v2/stats`) should appear once on page load and not again for an hour