### PR TITLE
Fix proposal votes showing as zeros in the proposals table

### DIFF
--- a/src/app/proposals/hooks/useGetProposalsWithGraph.ts
+++ b/src/app/proposals/hooks/useGetProposalsWithGraph.ts
@@ -62,6 +62,12 @@ function convertVotesToBigNumbers(votes: ProposalApiResponse['votes']) {
   }
 }
 
+function hasNonZeroVotes(votes: ProposalApiResponse['votes']): boolean {
+  if (!votes) return false
+  const { forVotes, againstVotes, abstainVotes } = convertVotesToBigNumbers(votes)
+  return forVotes.gt(0) || againstVotes.gt(0) || abstainVotes.gt(0)
+}
+
 function parseBlockNumber(blockNumber: string | undefined): string {
   if (!blockNumber) return ''
   return blockNumber.startsWith('0x') ? parseInt(blockNumber, 16).toString() : blockNumber
@@ -118,8 +124,8 @@ function transformProposalsData(
   const transformedProposals = proposalsData.map((proposal: ProposalApiResponse) => {
     const blockchainInfo = blockchainData?.find(b => b.proposalId === proposal.proposalId)
 
-    // Convert blockchain votes (Big) to API format (string) if needed
-    const votes: ProposalApiResponse['votes'] | undefined = proposal.votes
+    // Prefer blockchain votes when API votes are missing or all zeros
+    const votes: ProposalApiResponse['votes'] | undefined = hasNonZeroVotes(proposal.votes)
       ? proposal.votes
       : blockchainInfo?.votes
         ? {
@@ -127,7 +133,7 @@ function transformProposalsData(
             forVotes: blockchainInfo.votes.forVotes.toString(),
             abstainVotes: blockchainInfo.votes.abstainVotes.toString(),
           }
-        : undefined
+        : proposal.votes // fallback to API votes if no blockchain data
 
     const quorum = proposal.quorumAtSnapshot || blockchainInfo?.quorum?.toString()
     const rawState = blockchainInfo?.rawState

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -42,8 +42,11 @@ export function Pagination<T>({ pagination, setPagination, data, table, pageSize
   // Update URL with 1-indexed page number
   useEffect(() => {
     if (!searchParams) return
+    const currentPage = searchParams.get('page') ?? '1'
+    const targetPage = (pagination.pageIndex + 1).toString()
+    if (currentPage === targetPage) return
     const params = new URLSearchParams(searchParams.toString())
-    params.set('page', (pagination.pageIndex + 1).toString())
+    params.set('page', targetPage)
     router.replace(`?${params.toString()}`, { scroll: false })
   }, [pagination.pageIndex, searchParams, router])
 


### PR DESCRIPTION
## Ticket

[DAO-2221 - Check votes in the proposal page](https://rsklabs.atlassian.net/browse/DAO-2221)

## Summary

- Fix proposal votes showing as zeros in the proposals table when Envio/API returns empty vote data but blockchain has actual votes
- Fix infinite request loop on `/proposals` page caused by `useEffect` dependency cycle in pagination

## Screenshot
<img width="367" height="215" alt="Screenshot 2026-04-10 at 04 58 34" src="https://github.com/user-attachments/assets/98c66458-9670-476d-a728-3146fa3cc8d5" />

## Details

### Votes display fix
The proposals table was showing zero votes for proposals that actually had votes recorded on-chain. Root cause: when Envio returns `votes: {forVotes: "0", againstVotes: "0", abstainVotes: "0"}`, the code treated this as valid data and ignored blockchain votes. Now we check if API votes contain non-zero values before preferring them over blockchain data.

### Pagination loop fix  
The `Pagination` component had an infinite loop: `useEffect` depended on `searchParams`, but also called `router.replace()` which changed `searchParams`, triggering the effect again (~15 requests/second). Added early return when URL already has the correct page value.

## Test plan

- [ ] Open `/proposals` page — verify no infinite requests in Network tab
- [ ] Find a proposal with votes on-chain but zeros in Envio — verify table shows correct vote count
- [ ] Click on that proposal — verify detail page shows same vote count as table
- [ ] Test pagination — verify page changes work correctly

