### PR TITLE
Chore: Audit fix and patches for axios, dompurify, minimatch and next

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@hookform/resolvers": "^3.10.0",
-        "@next/third-parties": "16.1.6",
-        "@prisma/client": "6.19.2",
+        "@next/third-parties": "16.1.7",
+        "@prisma/client": "6.19.3",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-popover": "^1.1.15",
@@ -30,7 +30,7 @@
         "@radix-ui/react-tooltip": "^1.2.7",
         "@reown/appkit": "^1.8.14",
         "@reown/appkit-adapter-wagmi": "^1.8.14",
-        "@rsksmart/rlogin-ledger-provider": "^1.0.5-alpha",
+        "@rsksmart/rlogin-ledger-provider": "1.0.5-alpha",
         "@rsksmart/rns-sdk": "^1.0.0-beta.9",
         "@sentry/nextjs": "10.35.0",
         "@tanstack/react-query": "^5.90.2",
@@ -39,7 +39,7 @@
         "@uiw/react-md-editor": "4.0.11",
         "big.js": "^6.2.2",
         "clsx": "^2.1.1",
-        "dompurify": "3.3.0",
+        "dompurify": "3.3.3",
         "dotenv": "^17.2.3",
         "graphql": "16.12.0",
         "html-react-parser": "5.2.7",
@@ -52,12 +52,12 @@
         "luxon": "^3.7.1",
         "moment": "^2.30.1",
         "motion": "^12.23.12",
-        "next": "16.1.6",
+        "next": "16.1.7",
         "next-logger": "5.0.2",
         "next-navigation-guard": "^0.2.0",
         "pg": "^8.16.3",
         "pino": "10.3.1",
-        "prisma": "6.19.2",
+        "prisma": "6.19.3",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-error-boundary": "^6.1.1",
@@ -89,7 +89,7 @@
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
         "@types/big.js": "^6.2.2",
-        "@types/dompurify": "3.0.5",
+        "@types/dompurify": "3.2.0",
         "@types/lodash": "^4.17.20",
         "@types/luxon": "^3.7.1",
         "@types/mock-knex": "^0.4.8",
@@ -101,7 +101,7 @@
         "@vitejs/plugin-react": "^4.7.0",
         "cypress": "^13.17.0",
         "eslint": "9.39.3",
-        "eslint-config-next": "16.1.6",
+        "eslint-config-next": "16.1.7",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.4",
         "eslint-plugin-simple-import-sort": "12.1.1",
@@ -3080,15 +3080,15 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3121,20 +3121,20 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -4762,12 +4762,12 @@
       }
     },
     "node_modules/@ledgerhq/client-ids": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/client-ids/-/client-ids-0.5.1.tgz",
-      "integrity": "sha512-G1+2GJj3VuYIuUwnuWVRBSKTpxMiqznv5oS1gHc8B2SCBjjvu3opZcCWYNfzJZACCf1Bn08ZrjM097wfbn0UVg==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/client-ids/-/client-ids-0.8.1.tgz",
+      "integrity": "sha512-NkcFNyp6oAvzFL3uplSDfc8Cfgfm5sxqhCQvcNYINjz85dCEzMxyj3/XukNbB2zHTomz5j4PyDTzBPiZM20VCw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/live-env": "^2.27.0",
+        "@ledgerhq/live-env": "^2.31.0",
         "@reduxjs/toolkit": "2.11.2",
         "uuid": "^9.0.0"
       }
@@ -4795,69 +4795,62 @@
       }
     },
     "node_modules/@ledgerhq/domain-service": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/domain-service/-/domain-service-1.6.4.tgz",
-      "integrity": "sha512-9vAY3qFEnOonH/gvVzuHVP+8cEssh2kcm2QEFHhYgUan8+dwQ06Nio9JkbZq2lMF5G4Bc1hpmr2WNu1jci5/+Q==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/domain-service/-/domain-service-1.7.3.tgz",
+      "integrity": "sha512-H4xDzpMFSklAecFEk06o43sQz6GhBCDeeDy+W4nX2jxic/oCQGPnTQtS2+Ds+Tdy/FXRTV8RASBq6eN69yTf2w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/errors": "^6.29.0",
-        "@ledgerhq/logs": "^6.14.0",
-        "@ledgerhq/types-live": "^6.97.0",
+        "@ledgerhq/errors": "^6.32.0",
+        "@ledgerhq/logs": "^6.16.0",
+        "@ledgerhq/types-live": "^6.103.0",
         "axios": "1.13.2",
         "eip55": "^2.1.1",
-        "react": "18.3.1",
-        "react-dom": "18.3.1"
+        "react": "19.0.0",
+        "react-dom": "19.0.0"
       }
     },
     "node_modules/@ledgerhq/domain-service/node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/@ledgerhq/domain-service/node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.25.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.0.0"
       }
     },
     "node_modules/@ledgerhq/domain-service/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
     },
     "node_modules/@ledgerhq/errors": {
-      "version": "6.29.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.29.0.tgz",
-      "integrity": "sha512-mmDsGN662zd0XGKyjzSKkg+5o1/l9pvV1HkVHtbzaydvHAtRypghmVoWMY9XAQDLXiUBXGIsLal84NgmGeuKWA==",
+      "version": "6.32.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.32.0.tgz",
+      "integrity": "sha512-BjjvhLM6UXYUbhllqAduo9PSneLt9FXZ3TBEUFQ3MMSZOCHt0gAgDySLwul99R8fdYWkXBza4DYQjUNckpN2lg==",
       "license": "Apache-2.0"
     },
     "node_modules/@ledgerhq/evm-tools": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/evm-tools/-/evm-tools-1.11.0.tgz",
-      "integrity": "sha512-8M9iuNJPdR7imlXhMDNWvqh2P91J9CVVILsXIQ85niBTql3+jy+QAxA8tXFtqsOcXbl/jbLFldamuzMZv+xKtQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/evm-tools/-/evm-tools-1.12.2.tgz",
+      "integrity": "sha512-Er3oPhjIzIadFjo6FCDO0aMpTo4mZDIgBlExIdcwDV50gs0tMDhQup8XxoWV09FgA0M7Ho5iIxXSTUoGFnFP3g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ethersproject/constants": "^5.7.0",
         "@ethersproject/hash": "^5.7.0",
-        "@ledgerhq/live-env": "^2.27.0",
+        "@ledgerhq/live-env": "^2.31.0",
         "axios": "1.13.2",
         "crypto-js": "4.2.0"
       }
@@ -5040,9 +5033,9 @@
       }
     },
     "node_modules/@ledgerhq/live-env": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/live-env/-/live-env-2.27.0.tgz",
-      "integrity": "sha512-b6FZB3/bQOvG5IshJFrNxgY9Zrq070XjAq3g3TXm0cvO3cG2eOhVj7WK2cF7Rz5osZ9XGQjh9dnpvNxGmYjfxw==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/live-env/-/live-env-2.31.0.tgz",
+      "integrity": "sha512-Hl5ldGa7lT7bKkNHruFepKhEWvb0hvjvQ1cXBbR7yp9I7EPceDXQt/uySOyaY41caWX0x27TUQIz3PVEv67HJA==",
       "license": "Apache-2.0",
       "dependencies": {
         "rxjs": "7.8.2",
@@ -5050,18 +5043,18 @@
       }
     },
     "node_modules/@ledgerhq/logs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.14.0.tgz",
-      "integrity": "sha512-kJFu1+asWQmU9XlfR1RM3lYR76wuEoPyZvkI/CNjpft78BQr3+MMf3Nu77ABzcKFnhIcmAkOLlDQ6B8L6hDXHA==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.16.0.tgz",
+      "integrity": "sha512-v/PLfb1dq1En35kkpbfRWp8jLYgbPUXxGhmd4pmvPSIe0nRGkNTomsZASmWQAv6pRonVGqHIBVlte7j1MBbOww==",
       "license": "Apache-2.0"
     },
     "node_modules/@ledgerhq/types-live": {
-      "version": "6.97.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/types-live/-/types-live-6.97.0.tgz",
-      "integrity": "sha512-jncRKmRTbMEousZjb3Qjz/pjGVnZm6La1aVfOqnjOWGxmlWoKQKay/BbgaPYkwPQ6lx87bVwRnERBKvMIxaoKw==",
+      "version": "6.103.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/types-live/-/types-live-6.103.0.tgz",
+      "integrity": "sha512-e/cc0zZs7f/6/g2dTd0RX7TZf7NeM7A7dMbmTOPdojkhXvdiSksZZJeSABBSpwJpiKYcgi/ABRDr3dQMiwNq0A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/client-ids": "0.5.1",
+        "@ledgerhq/client-ids": "0.8.1",
         "bignumber.js": "^9.1.2",
         "rxjs": "7.8.2"
       }
@@ -5896,15 +5889,15 @@
       "license": "MIT"
     },
     "node_modules/@next/env": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
-      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.7.tgz",
+      "integrity": "sha512-rJJbIdJB/RQr2F1nylZr/PJzamvNNhfr3brdKP6s/GW850jbtR70QlSfFselvIBbcPUOlQwBakexjFzqLzF6pg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.6.tgz",
-      "integrity": "sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.7.tgz",
+      "integrity": "sha512-v/bRGOJlfRCO+NDKt0bZlIIWjhMKU8xbgEQBo+rV9C8S6czZvs96LZ/v24/GvpEnovZlL4QDpku/RzWHVbmPpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5912,9 +5905,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
-      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.7.tgz",
+      "integrity": "sha512-b2wWIE8sABdyafc4IM8r5Y/dS6kD80JRtOGrUiKTsACFQfWWgUQ2NwoUX1yjFMXVsAwcQeNpnucF2ZrujsBBPg==",
       "cpu": [
         "arm64"
       ],
@@ -5928,9 +5921,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
-      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.7.tgz",
+      "integrity": "sha512-zcnVaaZulS1WL0Ss38R5Q6D2gz7MtBu8GZLPfK+73D/hp4GFMrC2sudLky1QibfV7h6RJBJs/gOFvYP0X7UVlQ==",
       "cpu": [
         "x64"
       ],
@@ -5944,9 +5937,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
-      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.7.tgz",
+      "integrity": "sha512-2ant89Lux/Q3VyC8vNVg7uBaFVP9SwoK2jJOOR0L8TQnX8CAYnh4uctAScy2Hwj2dgjVHqHLORQZJ2wH6VxhSQ==",
       "cpu": [
         "arm64"
       ],
@@ -5960,9 +5953,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
-      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.7.tgz",
+      "integrity": "sha512-uufcze7LYv0FQg9GnNeZ3/whYfo+1Q3HnQpm16o6Uyi0OVzLlk2ZWoY7j07KADZFY8qwDbsmFnMQP3p3+Ftprw==",
       "cpu": [
         "arm64"
       ],
@@ -5976,9 +5969,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
-      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.7.tgz",
+      "integrity": "sha512-KWVf2gxYvHtvuT+c4MBOGxuse5TD7DsMFYSxVxRBnOzok/xryNeQSjXgxSv9QpIVlaGzEn/pIuI6Koosx8CGWA==",
       "cpu": [
         "x64"
       ],
@@ -5992,9 +5985,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
-      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.7.tgz",
+      "integrity": "sha512-HguhaGwsGr1YAGs68uRKc4aGWxLET+NevJskOcCAwXbwj0fYX0RgZW2gsOCzr9S11CSQPIkxmoSbuVaBp4Z3dA==",
       "cpu": [
         "x64"
       ],
@@ -6008,9 +6001,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
-      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.7.tgz",
+      "integrity": "sha512-S0n3KrDJokKTeFyM/vGGGR8+pCmXYrjNTk2ZozOL1C/JFdfUIL9O1ATaJOl5r2POe56iRChbsszrjMAdWSv7kQ==",
       "cpu": [
         "arm64"
       ],
@@ -6024,9 +6017,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
-      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.7.tgz",
+      "integrity": "sha512-mwgtg8CNZGYm06LeEd+bNnOUfwOyNem/rOiP14Lsz+AnUY92Zq/LXwtebtUiaeVkhbroRCQ0c8GlR4UT1U+0yg==",
       "cpu": [
         "x64"
       ],
@@ -6040,9 +6033,9 @@
       }
     },
     "node_modules/@next/third-parties": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.1.6.tgz",
-      "integrity": "sha512-/cLY1egaH529ylSMSK+C8dA3nWDLL4hOFR4fca9OLWWxjcNwzsbuq2pPb/tmdWL9Zj3K1nTjd1pWQoSlaDQ0VA==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.1.7.tgz",
+      "integrity": "sha512-rwzBlYHQlK7hnqZ3ItQ/tORqpBV3EOHHlcGABWbW9XBlYxn11G8EwlgL7wI5mX2+THBHfv0W9kTD2ABCzHqXGA==",
       "license": "MIT",
       "dependencies": {
         "third-party-capital": "1.0.20"
@@ -6792,9 +6785,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.2.tgz",
-      "integrity": "sha512-gR2EMvfK/aTxsuooaDA32D8v+us/8AAet+C3J1cc04SW35FPdZYgLF+iN4NDLUgAaUGTKdAB0CYenu1TAgGdMg==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.3.tgz",
+      "integrity": "sha512-mKq3jQFhjvko5LTJFHGilsuQs+W+T3Gm451NzuTDGQxwCzwXHYnIu2zGkRoW+Exq3Rob7yp2MfzSrdIiZVhrBg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -6814,34 +6807,34 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.2.tgz",
-      "integrity": "sha512-kadBGDl+aUswv/zZMk9Mx0C8UZs1kjao8H9/JpI4Wh4SHZaM7zkTwiKn/iFLfRg+XtOAo/Z/c6pAYhijKl0nzQ==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.3.tgz",
+      "integrity": "sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
         "deepmerge-ts": "7.1.5",
-        "effect": "3.18.4",
+        "effect": "3.21.0",
         "empathic": "2.0.0"
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.2.tgz",
-      "integrity": "sha512-lFnEZsLdFLmEVCVNdskLDCL8Uup41GDfU0LUfquw+ercJC8ODTuL0WNKgOKmYxCJVvFwf0OuZBzW99DuWmoH2A==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.3.tgz",
+      "integrity": "sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==",
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.2.tgz",
-      "integrity": "sha512-TTkJ8r+uk/uqczX40wb+ODG0E0icVsMgwCTyTHXehaEfb0uo80M9g1aW1tEJrxmFHeOZFXdI2sTA1j1AgcHi4A==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.3.tgz",
+      "integrity": "sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.2",
+        "@prisma/debug": "6.19.3",
         "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
-        "@prisma/fetch-engine": "6.19.2",
-        "@prisma/get-platform": "6.19.2"
+        "@prisma/fetch-engine": "6.19.3",
+        "@prisma/get-platform": "6.19.3"
       }
     },
     "node_modules/@prisma/engines-version": {
@@ -6851,23 +6844,23 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.2.tgz",
-      "integrity": "sha512-h4Ff4Pho+SR1S8XerMCC12X//oY2bG3Iug/fUnudfcXEUnIeRiBdXHFdGlGOgQ3HqKgosTEhkZMvGM9tWtYC+Q==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.3.tgz",
+      "integrity": "sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.2",
+        "@prisma/debug": "6.19.3",
         "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
-        "@prisma/get-platform": "6.19.2"
+        "@prisma/get-platform": "6.19.3"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.2.tgz",
-      "integrity": "sha512-PGLr06JUSTqIvztJtAzIxOwtWKtJm5WwOG6xpsgD37Rc84FpfUBGLKz65YpJBGtkRQGXTYEFie7pYALocC3MtA==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.3.tgz",
+      "integrity": "sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.2"
+        "@prisma/debug": "6.19.3"
       }
     },
     "node_modules/@prisma/instrumentation": {
@@ -10441,9 +10434,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@stellar/stellar-base": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-14.0.4.tgz",
-      "integrity": "sha512-UbNW6zbdOBXJwLAV2mMak0bIC9nw3IZVlQXkv2w2dk1jgCbJjy3oRVC943zeGE5JAm0Z9PHxrIjmkpGhayY7kw==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-14.1.0.tgz",
+      "integrity": "sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.9.6",
@@ -11464,9 +11457,9 @@
       }
     },
     "node_modules/@trezor/blockchain-link-types": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-types/-/blockchain-link-types-1.5.0.tgz",
-      "integrity": "sha512-wD6FKKxNr89MTWYL+NikRkBcWXhiWNFR0AuDHW6GHmlCEHhKu/hAvQtcER8X5jt/Wd0hSKNZqtHBXJ1ZkpJ6rg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-types/-/blockchain-link-types-1.5.1.tgz",
+      "integrity": "sha512-Idavz6LwLBW8sXc69fh5AJEnl666EDl2Nt3io7updvBgOR0/P12I900DgjNhCKtiWuv66A33/5RE7zLcj3lfnw==",
       "license": "See LICENSE.md in repo root",
       "dependencies": {
         "@trezor/utils": "9.5.0",
@@ -11477,15 +11470,15 @@
       }
     },
     "node_modules/@trezor/blockchain-link-utils": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-utils/-/blockchain-link-utils-1.5.1.tgz",
-      "integrity": "sha512-2tDGLEj5jzydjsJQONGTWVmCDDy6FTZ4ytr1/2gE6anyYEJU8MbaR+liTt3UvcP5jwZTNutwYLvZixRfrb8JpA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-utils/-/blockchain-link-utils-1.5.2.tgz",
+      "integrity": "sha512-OSS5OEE98FMnYfjoEALPjBt7ebjC/FKnq3HOolHdEWXBpVlXZNN2+Vo1R9J6WbZUU087sHuUTJJy/GJYWY13Tg==",
       "license": "See LICENSE.md in repo root",
       "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
         "@stellar/stellar-sdk": "14.2.0",
         "@trezor/env-utils": "1.5.0",
-        "@trezor/protobuf": "1.5.1",
+        "@trezor/protobuf": "1.5.2",
         "@trezor/utils": "9.5.0",
         "xrpl": "4.4.3"
       },
@@ -12194,10 +12187,54 @@
         "typescript": ">=5.3.3"
       }
     },
+    "node_modules/@trezor/blockchain-link/node_modules/@trezor/blockchain-link-types": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-types/-/blockchain-link-types-1.5.0.tgz",
+      "integrity": "sha512-wD6FKKxNr89MTWYL+NikRkBcWXhiWNFR0AuDHW6GHmlCEHhKu/hAvQtcER8X5jt/Wd0hSKNZqtHBXJ1ZkpJ6rg==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@trezor/utils": "9.5.0",
+        "@trezor/utxo-lib": "2.5.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@trezor/blockchain-link-utils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-utils/-/blockchain-link-utils-1.5.1.tgz",
+      "integrity": "sha512-2tDGLEj5jzydjsJQONGTWVmCDDy6FTZ4ytr1/2gE6anyYEJU8MbaR+liTt3UvcP5jwZTNutwYLvZixRfrb8JpA==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@mobily/ts-belt": "^3.13.1",
+        "@stellar/stellar-sdk": "14.2.0",
+        "@trezor/env-utils": "1.5.0",
+        "@trezor/protobuf": "1.5.1",
+        "@trezor/utils": "9.5.0",
+        "xrpl": "4.4.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@trezor/protobuf": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.5.1.tgz",
+      "integrity": "sha512-nAkaCCAqLpErBd+IuKeG5MpbyLR/2RMgCw18TWc80m1Ws/XgQirhHY9Jbk6gLImTXb9GTrxP0+MDSahzd94rSA==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@trezor/schema-utils": "1.4.0",
+        "long": "5.2.5",
+        "protobufjs": "7.4.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
     "node_modules/@trezor/connect": {
-      "version": "9.7.1",
-      "resolved": "https://registry.npmjs.org/@trezor/connect/-/connect-9.7.1.tgz",
-      "integrity": "sha512-W2ym0bs4FVmXByEr9gANBp+bRErzNcmqqqYzSJLOVkawxikqYXag2aCpdiXU3LlZbFbhFhIsT/fpDLfwiLRySA==",
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@trezor/connect/-/connect-9.7.2.tgz",
+      "integrity": "sha512-Sn6F4mNH+yi2vAHy29kwhs50bRLn92drg3znm3pkY+8yEBxI4MmuP8sKYjdgUEJnQflWh80KlcvEDeVa4olVRA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@ethereumjs/common": "^10.1.0",
@@ -12212,18 +12249,18 @@
         "@solana-program/token-2022": "^0.4.2",
         "@solana/kit": "^2.3.0",
         "@trezor/blockchain-link": "2.6.1",
-        "@trezor/blockchain-link-types": "1.5.0",
-        "@trezor/blockchain-link-utils": "1.5.1",
+        "@trezor/blockchain-link-types": "1.5.1",
+        "@trezor/blockchain-link-utils": "1.5.2",
         "@trezor/connect-analytics": "1.4.0",
-        "@trezor/connect-common": "0.5.0",
+        "@trezor/connect-common": "0.5.1",
         "@trezor/crypto-utils": "1.2.0",
-        "@trezor/device-authenticity": "1.1.1",
+        "@trezor/device-authenticity": "1.1.2",
         "@trezor/device-utils": "1.2.0",
         "@trezor/env-utils": "^1.5.0",
-        "@trezor/protobuf": "1.5.1",
+        "@trezor/protobuf": "1.5.2",
         "@trezor/protocol": "1.3.0",
         "@trezor/schema-utils": "1.4.0",
-        "@trezor/transport": "1.6.1",
+        "@trezor/transport": "1.6.2",
         "@trezor/type-utils": "1.2.0",
         "@trezor/utils": "9.5.0",
         "@trezor/utxo-lib": "2.5.0",
@@ -12251,9 +12288,9 @@
       }
     },
     "node_modules/@trezor/connect-common": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@trezor/connect-common/-/connect-common-0.5.0.tgz",
-      "integrity": "sha512-WE71iaFcWmfQxDCiTUNynj2DccRgUiLBJ+g3nrqCBJqEYzu+cD6eZ5k/OLtZ3hfh5gyB5EQwXdGvRT07iNdxAA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-common/-/connect-common-0.5.1.tgz",
+      "integrity": "sha512-wdpVCwdylBh4SBO5Ys40tB/d59UlfjmxgBHDkkLgaR+JcqkthCfiw5VlUrV9wu65lquejAZhA5KQL4mUUUhCow==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@trezor/env-utils": "1.5.0",
@@ -12265,13 +12302,13 @@
       }
     },
     "node_modules/@trezor/connect-web": {
-      "version": "9.7.1",
-      "resolved": "https://registry.npmjs.org/@trezor/connect-web/-/connect-web-9.7.1.tgz",
-      "integrity": "sha512-L9rv8R4bOwXoZlbWr8NnsdR2bYjehNY+eEog7fhOPzcRqW30+P06Ari1ZzOMeg469s4GlwvkVA34wqSGxLeelQ==",
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-web/-/connect-web-9.7.2.tgz",
+      "integrity": "sha512-r4wMnQ51KO1EaMpO8HLB95E+4s+aaZE9Vjx1dHYaD+Xj40LR7OJmR6DyDKuF0Ioji3Jxx1MwZCaFfvA+0JW+Sg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@trezor/connect": "9.7.1",
-        "@trezor/connect-common": "0.5.0",
+        "@trezor/connect": "9.7.2",
+        "@trezor/connect-common": "0.5.1",
         "@trezor/utils": "9.5.0",
         "@trezor/websocket-client": "1.3.0"
       },
@@ -13002,14 +13039,14 @@
       }
     },
     "node_modules/@trezor/device-authenticity": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@trezor/device-authenticity/-/device-authenticity-1.1.1.tgz",
-      "integrity": "sha512-WlYbQgc5l0pWUVP9GkMp+Oj3rVAqMKsWF0HyxujoymNjEB7rLTl2hXs+GFjlz7VnldaSslECc6EBex/eQiNOnA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@trezor/device-authenticity/-/device-authenticity-1.1.2.tgz",
+      "integrity": "sha512-313uSXYR4XKDv3CjtCpgHA+yEe9xxqN7EFl/D68FEn70SPsuWI0+2zUvjPPh6TIOh/EcLv7hCO/QTHUAGd7ZWQ==",
       "license": "See LICENSE.md in repo root",
       "dependencies": {
         "@noble/curves": "^2.0.1",
         "@trezor/crypto-utils": "1.2.0",
-        "@trezor/protobuf": "1.5.1",
+        "@trezor/protobuf": "1.5.2",
         "@trezor/schema-utils": "1.4.0",
         "@trezor/utils": "9.5.0"
       }
@@ -13074,9 +13111,9 @@
       }
     },
     "node_modules/@trezor/protobuf": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.5.1.tgz",
-      "integrity": "sha512-nAkaCCAqLpErBd+IuKeG5MpbyLR/2RMgCw18TWc80m1Ws/XgQirhHY9Jbk6gLImTXb9GTrxP0+MDSahzd94rSA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.5.2.tgz",
+      "integrity": "sha512-zViaL1jKue8DUTVEDg0C/lMipqNMd/Z3kr29/+MeZOoupjaXIQ2Lqp3WAMe8hvNTKKX8aNQH9JrbapJ6w9FMXw==",
       "license": "See LICENSE.md in repo root",
       "dependencies": {
         "@trezor/schema-utils": "1.4.0",
@@ -13110,12 +13147,12 @@
       }
     },
     "node_modules/@trezor/transport": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@trezor/transport/-/transport-1.6.1.tgz",
-      "integrity": "sha512-RQNQingZ1TOVKSJu3Av9bmQovsu9n1NkcAYJ64+ZfapORfl/AzmZizRflhxU3FlIujQJK1gbIaW79+L54g7a8w==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@trezor/transport/-/transport-1.6.2.tgz",
+      "integrity": "sha512-w0HlD1fU+qTGO3tefBGHF/YS/ts/TWFja9FGIJ4+7+Z9NphvIG06HGvy2HzcD9AhJy9pvDeIsyoM2TTZTiyjkQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@trezor/protobuf": "1.5.1",
+        "@trezor/protobuf": "1.5.2",
         "@trezor/protocol": "1.3.0",
         "@trezor/type-utils": "1.2.0",
         "@trezor/utils": "9.5.0",
@@ -13390,13 +13427,14 @@
       "license": "MIT"
     },
     "node_modules/@types/dompurify": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
-      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.2.0.tgz",
+      "integrity": "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==",
+      "deprecated": "This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/trusted-types": "*"
+        "dompurify": "*"
       }
     },
     "node_modules/@types/eslint": {
@@ -13668,9 +13706,9 @@
       "license": "MIT"
     },
     "node_modules/@types/w3c-web-usb": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.13.tgz",
-      "integrity": "sha512-N2nSl3Xsx8mRHZBvMSdNGtzMyeleTvtlEw+ujujgXalPqOjIA6UtrqcB6OzyUjkTbDm3J7P1RNK1lgoO7jxtsw==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.14.tgz",
+      "integrity": "sha512-Qu3Nn6JFuF4+sHKYl+IcX9vYiI40ogleXzFFSxoE1W94rG98o/kXs8uJ0QSfFzuwBCZWlGfUGpPkgwuuX4PchA==",
       "license": "MIT"
     },
     "node_modules/@types/web": {
@@ -17165,9 +17203,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -17583,14 +17621,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-retry": {
@@ -17603,6 +17641,15 @@
       },
       "peerDependencies": {
         "axios": "0.x || 1.x"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/axobject-query": {
@@ -18068,9 +18115,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -18564,9 +18611,9 @@
       }
     },
     "node_modules/cbor": {
-      "version": "10.0.11",
-      "resolved": "https://registry.npmjs.org/cbor/-/cbor-10.0.11.tgz",
-      "integrity": "sha512-vIwORDd/WyB8Nc23o2zNN5RrtFGlR6Fca61TtjkUXueI3Jf2DOZDl1zsshvBntZ3wZHBM9ztjnkXSmzQDaq3WA==",
+      "version": "10.0.12",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-10.0.12.tgz",
+      "integrity": "sha512-exQDevYd7ZQLP4moMQcZkKCVZsXLAtUSflObr3xTh4xzFIv/xBCdvCd6L259kQOUP2kcTC0jvC6PpZIf/WmRXA==",
       "license": "MIT",
       "dependencies": {
         "nofilter": "^3.0.2"
@@ -19127,9 +19174,9 @@
       "license": "MIT"
     },
     "node_modules/cookie-es": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
-      "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "license": "MIT"
     },
     "node_modules/core-js": {
@@ -20091,9 +20138,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
     "node_modules/delay": {
@@ -20337,9 +20384,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
-      "integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -20483,9 +20530,9 @@
       }
     },
     "node_modules/effect": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
-      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
+      "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -21078,13 +21125,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.1.6.tgz",
-      "integrity": "sha512-vKq40io2B0XtkkNDYyleATwblNt8xuh3FWp8SpSz3pt7P01OkBFlKsJZ2mWt5WsCySlDQLckb1zMY9yE9Qy0LA==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.1.7.tgz",
+      "integrity": "sha512-FTq1i/QDltzq+zf9aB/cKWAiZ77baG0V7h8dRQh3thVx7I4dwr6ZXQrWKAaTB7x5VwVXlzoUTyMLIVQPLj2gJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.1.6",
+        "@next/eslint-plugin-next": "16.1.7",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -22651,9 +22698,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -23298,14 +23345,14 @@
       }
     },
     "node_modules/h3": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.5.tgz",
-      "integrity": "sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
       "license": "MIT",
       "dependencies": {
-        "cookie-es": "^1.2.2",
+        "cookie-es": "^1.2.3",
         "crossws": "^0.3.5",
-        "defu": "^6.1.4",
+        "defu": "^6.1.6",
         "destr": "^2.0.5",
         "iron-webcrypto": "^1.2.1",
         "node-mock-http": "^1.0.4",
@@ -23770,9 +23817,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
-      "integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -25260,9 +25307,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
-      "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
+      "integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -25272,7 +25319,7 @@
         "@hapi/pinpoint": "^2.0.1",
         "@hapi/tlds": "^1.1.1",
         "@hapi/topo": "^6.0.2",
-        "@standard-schema/spec": "^1.0.0"
+        "@standard-schema/spec": "^1.1.0"
       },
       "engines": {
         "node": ">= 20"
@@ -26429,9 +26476,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -27674,9 +27721,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -27772,15 +27819,15 @@
       "license": "MIT"
     },
     "node_modules/minimatch": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
-      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+      "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -27985,14 +28032,14 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
-      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.1.7.tgz",
+      "integrity": "sha512-WM0L7WrSvKwoLegLYr6V+mz+RIofqQgVAfHhMp9a88ms0cFX8iX9ew+snpWlSBwpkURJOUdvCEt3uLl3NNzvWg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.6",
+        "@next/env": "16.1.7",
         "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.8.3",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -28004,14 +28051,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.6",
-        "@next/swc-darwin-x64": "16.1.6",
-        "@next/swc-linux-arm64-gnu": "16.1.6",
-        "@next/swc-linux-arm64-musl": "16.1.6",
-        "@next/swc-linux-x64-gnu": "16.1.6",
-        "@next/swc-linux-x64-musl": "16.1.6",
-        "@next/swc-win32-arm64-msvc": "16.1.6",
-        "@next/swc-win32-x64-msvc": "16.1.6",
+        "@next/swc-darwin-arm64": "16.1.7",
+        "@next/swc-darwin-x64": "16.1.7",
+        "@next/swc-linux-arm64-gnu": "16.1.7",
+        "@next/swc-linux-arm64-musl": "16.1.7",
+        "@next/swc-linux-x64-gnu": "16.1.7",
+        "@next/swc-linux-x64-musl": "16.1.7",
+        "@next/swc-win32-arm64-msvc": "16.1.7",
+        "@next/swc-win32-x64-msvc": "16.1.7",
         "sharp": "^0.34.4"
       },
       "peerDependencies": {
@@ -28402,15 +28449,15 @@
       }
     },
     "node_modules/nypm/node_modules/citty": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
-      "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "license": "MIT"
     },
     "node_modules/nypm/node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -29380,9 +29427,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -30072,14 +30119,14 @@
       "license": "MIT"
     },
     "node_modules/prisma": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.2.tgz",
-      "integrity": "sha512-XTKeKxtQElcq3U9/jHyxSPgiRgeYDKxWTPOf6NkXA0dNj5j40MfEsZkMbyNpwDWCUv7YBFUl7I2VK/6ALbmhEg==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.3.tgz",
+      "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.19.2",
-        "@prisma/engines": "6.19.2"
+        "@prisma/config": "6.19.3",
+        "@prisma/engines": "6.19.3"
       },
       "bin": {
         "prisma": "build/index.js"
@@ -32088,15 +32135,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/seroval": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.1.tgz",
@@ -32477,9 +32515,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
-      "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -32695,9 +32733,9 @@
       }
     },
     "node_modules/start-server-and-test": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-2.1.3.tgz",
-      "integrity": "sha512-k4EcbNjeg0odaDkAMlIeDVDByqX9PIgL4tivgP2tES6Zd8o+4pTq/HgbWCyA3VHIoZopB+wGnNPKYGGSByNriQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-2.1.5.tgz",
+      "integrity": "sha512-A/SbXpgXE25ScSkpLLqvGvVZT0ykN6+AzS8tVqMBCTxbJy2Nwuen59opT+afalK5aS+AuQmZs0EsLwjnuDN+/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -32708,7 +32746,7 @@
         "execa": "5.1.1",
         "lazy-ass": "1.6.0",
         "ps-tree": "1.2.0",
-        "wait-on": "9.0.3"
+        "wait-on": "9.0.4"
       },
       "bin": {
         "server-test": "src/bin/start.js",
@@ -33417,15 +33455,14 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {
@@ -34369,9 +34406,9 @@
       }
     },
     "node_modules/unplugin/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -34657,9 +34694,9 @@
       }
     },
     "node_modules/usb/node_modules/node-addon-api": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
-      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
@@ -35073,9 +35110,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -35298,15 +35335,15 @@
       }
     },
     "node_modules/wait-on": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.0.3.tgz",
-      "integrity": "sha512-13zBnyYvFDW1rBvWiJ6Av3ymAaq8EDQuvxZnPIw3g04UqGi4TyoIJABmfJ6zrvKo9yeFQExNkOk7idQbDJcuKA==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.0.4.tgz",
+      "integrity": "sha512-k8qrgfwrPVJXTeFY8tl6BxVHiclK11u72DVKhpybHfUL/K6KM4bdyK9EhIVYGytB5MJe/3lq4Tf0hrjM+pvJZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.13.2",
-        "joi": "^18.0.1",
-        "lodash": "^4.17.21",
+        "axios": "^1.13.5",
+        "joi": "^18.0.2",
+        "lodash": "^4.17.23",
         "minimist": "^1.2.8",
         "rxjs": "^7.8.2"
       },
@@ -35896,9 +35933,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@hookform/resolvers": "^3.10.0",
-    "@next/third-parties": "16.1.6",
-    "@prisma/client": "6.19.2",
+    "@next/third-parties": "16.1.7",
+    "@prisma/client": "6.19.3",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-popover": "^1.1.15",
@@ -49,7 +49,7 @@
     "@radix-ui/react-tooltip": "^1.2.7",
     "@reown/appkit": "^1.8.14",
     "@reown/appkit-adapter-wagmi": "^1.8.14",
-    "@rsksmart/rlogin-ledger-provider": "^1.0.5-alpha",
+    "@rsksmart/rlogin-ledger-provider": "1.0.5-alpha",
     "@rsksmart/rns-sdk": "^1.0.0-beta.9",
     "@sentry/nextjs": "10.35.0",
     "@tanstack/react-query": "^5.90.2",
@@ -58,7 +58,7 @@
     "@uiw/react-md-editor": "4.0.11",
     "big.js": "^6.2.2",
     "clsx": "^2.1.1",
-    "dompurify": "3.3.0",
+    "dompurify": "3.3.3",
     "dotenv": "^17.2.3",
     "graphql": "16.12.0",
     "html-react-parser": "5.2.7",
@@ -71,12 +71,12 @@
     "luxon": "^3.7.1",
     "moment": "^2.30.1",
     "motion": "^12.23.12",
-    "next": "16.1.6",
+    "next": "16.1.7",
     "next-logger": "5.0.2",
     "next-navigation-guard": "^0.2.0",
     "pg": "^8.16.3",
     "pino": "10.3.1",
-    "prisma": "6.19.2",
+    "prisma": "6.19.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-error-boundary": "^6.1.1",
@@ -108,7 +108,7 @@
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
     "@types/big.js": "^6.2.2",
-    "@types/dompurify": "3.0.5",
+    "@types/dompurify": "3.2.0",
     "@types/lodash": "^4.17.20",
     "@types/luxon": "^3.7.1",
     "@types/mock-knex": "^0.4.8",
@@ -120,7 +120,7 @@
     "@vitejs/plugin-react": "^4.7.0",
     "cypress": "^13.17.0",
     "eslint": "9.39.3",
-    "eslint-config-next": "16.1.6",
+    "eslint-config-next": "16.1.7",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-simple-import-sort": "12.1.1",
@@ -145,14 +145,14 @@
   },
   "overrides": {
     "elliptic": "6.6.1",
-    "minimatch": "10.2.1",
+    "minimatch": "10.2.3",
     "next-navigation-guard": {
       "next": "$next"
     },
     "@reown/appkit-adapter-wagmi": {
       "@wagmi/connectors": "6.2.0"
     },
-    "axios": "1.13.5"
+    "axios": "1.15.0"
   },
   "lint-staged": {
     "*.{ts,tsx}": "eslint --fix"


### PR DESCRIPTION
## Summary

Dependency and **`npm overrides`** updates to address **`npm audit`** findings using **controlled semver bumps** instead of **`npm audit fix --force`** (which would downgrade **`@rsksmart/rlogin-ledger-provider`** or **Storybook**).

## Direct dependency changes

| Package | From → To | Why |
|--------|-----------|-----|
| **next** | `16.1.6` → **`16.1.7`** | Clears Next.js advisories for **`16.0.0-beta.0`–`16.1.6`**: [GHSA-ggv3-7p47-pfv8](https://github.com/advisories/GHSA-ggv3-7p47-pfv8), [GHSA-3x4c-7xq6-9pq8](https://github.com/advisories/GHSA-3x4c-7xq6-9pq8), [GHSA-h27x-g6w4-24gq](https://github.com/advisories/GHSA-h27x-g6w4-24gq), [GHSA-mq59-m269-xvcx](https://github.com/advisories/GHSA-mq59-m269-xvcx), [GHSA-jcc7-9wpm-mj36](https://github.com/advisories/GHSA-jcc7-9wpm-mj36) |
| **@next/third-parties** | → **`16.1.7`** | Aligned with **next** release line |
| **eslint-config-next** | `16.1.6` → **`16.1.7`** | Aligned with **next** `16.1.7` |
| **dompurify** | `≤3.3.1` → **`3.3.3`** | Patched XSS-class issues in older **dompurify** ranges ([advisory search](https://github.com/advisories?query=dompurify)) |
| **@prisma/client** / **prisma** | → **`6.19.3`** | Client + CLI aligned; clears prior audit noise tied to older Prisma / **effect** reporting |
| **@rsksmart/rlogin-ledger-provider** | `^1.0.5-alpha` → **`1.0.5-alpha`** (exact) | **`1.0.5`** on npm is a **broken tarball** (`fileCount: 2`, no `dist/`), which breaks **`tsc`** and runtime. **`1.0.5-alpha`** includes **`dist/`** (types + bundle). |

## `package.json` overrides (transitive)

| Override | Version | Why |
|----------|---------|-----|
| **axios** | **`1.15.0`** | [GHSA-3p68-rc4w-qgx5](https://github.com/advisories/GHSA-3p68-rc4w-qgx5) (NO_PROXY / SSRF) |
| **minimatch** | **`10.2.3`** | [GHSA-23c5-xmqv-rm74](https://github.com/advisories/GHSA-23c5-xmqv-rm74) (ReDoS, **10.0.0–10.2.2**); also related: [GHSA-3ppc-4f35-3m26](https://github.com/advisories/GHSA-3ppc-4f35-3m26) |
| **elliptic** | **`6.6.1`** | Pin where possible; npm may still report [GHSA-848j-6mx2-7j84](https://github.com/advisories/GHSA-848j-6mx2-7j84) via **ethers@5** / wallet / Storybook — do not use **`npm audit fix --force`** to downgrade Storybook |
| **next-navigation-guard** → **next** | **`$next`** | Single **next** version for the guard + app |

## Deferred / still under `npm audit` (documented, not `--force`)

- **bn.js** `<4.12.3` — [GHSA-378v-28hj-76wf](https://github.com/advisories/GHSA-378v-28hj-76wf) via **ethjs** / rlogin; **`npm audit fix --force`** suggests **`@rsksmart/rlogin-ledger-provider@1.0.4`** — **rejected** (incompatible with our Ledger integration).
- **elliptic** — [GHSA-848j-6mx2-7j84](https://github.com/advisories/GHSA-848j-6mx2-7j84); **`--force`** suggests **`@storybook/nextjs@7.x`** — **rejected**.

## How to verify

- [ ] `npm ci` (or `npm install`) — lockfile matches
- [ ] `npm audit` — note before/after counts
- [ ] `npm run lint` && `npm run lint-tsc` && `npm run test` && `npm run build`
- [ ] Smoke: wallets, **Ledger**, markdown/HTML paths using **dompurify**