### PR TITLE
DAO-2215 Rejecting transaction shows “hash is null” in swap flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ node_modules/.prisma
 # Sentry Config File
 .env.sentry-build-plugin
 
+# Git worktrees (local parallel branches)
+.worktrees/
+
 # AI workflow — only canonical .workflow/ is committed; adapters generated locally
 .claude/
 CLAUDE.md

--- a/src/app/user/Stake/components/TransactionStatus.tsx
+++ b/src/app/user/Stake/components/TransactionStatus.tsx
@@ -1,8 +1,9 @@
+import Image from 'next/image'
+
 import { ExternalLink } from '@/components/Link/ExternalLink'
 import { Paragraph, Span } from '@/components/Typography'
 import { EXPLORER_URL } from '@/lib/constants'
 import { cn } from '@/lib/utils'
-import Image from 'next/image'
 
 interface Props {
   txHash?: string
@@ -17,7 +18,8 @@ export const TransactionStatus = ({
   failureMessage = 'Transaction failed.',
   className,
 }: Props) => {
-  if (!txHash) return null
+  const showExplorer = Boolean(txHash)
+  if (!isTxFailed && !showExplorer) return null
 
   return (
     <div className={cn('flex flex-col mb-5', className)}>
@@ -29,13 +31,15 @@ export const TransactionStatus = ({
           </Paragraph>
         </div>
       )}
-      <div className={cn({ 'ml-12': isTxFailed })}>
-        <ExternalLink href={`${EXPLORER_URL}/tx/${txHash}`} target="_blank" variant="menu">
-          <Span variant="body-s" bold>
-            View transaction in Explorer
-          </Span>
-        </ExternalLink>
-      </div>
+      {showExplorer && (
+        <div className={cn({ 'ml-12': isTxFailed })}>
+          <ExternalLink href={`${EXPLORER_URL}/tx/${txHash}`} target="_blank" variant="menu">
+            <Span variant="body-s" bold>
+              View transaction in Explorer
+            </Span>
+          </ExternalLink>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/app/user/Swap/Steps/SwapStepOne.tsx
+++ b/src/app/user/Swap/Steps/SwapStepOne.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { Hash, parseUnits } from 'viem'
 
 import { useBalancesContext } from '@/app/user/Balances/context/BalancesContext'
+import { createUserCanceledTxError } from '@/components/ErrorPage/commonErrors'
 import { ArrowsUpDown } from '@/components/Icons'
 import { PercentageButtonItem, PercentageButtons } from '@/components/PercentageButtons'
 import { SwapInputComponent, SwapInputToken } from '@/components/SwapInput'
@@ -150,7 +151,7 @@ export const SwapStepOne = ({ onGoNext, setButtonActions }: SwapStepProps) => {
         onRequestTx: async () => {
           const txHash = await approve(requiredAmount)
           if (!txHash) {
-            throw new Error('Transaction hash is null')
+            throw createUserCanceledTxError()
           }
           return txHash as Hash
         },

--- a/src/app/user/Swap/Steps/SwapStepThree.tsx
+++ b/src/app/user/Swap/Steps/SwapStepThree.tsx
@@ -11,7 +11,7 @@ import { Label } from '@/components/Typography'
 import Big from '@/lib/big'
 import { formatForDisplay } from '@/lib/utils'
 import { useExecuteTxFlow } from '@/shared/notification'
-import { useSwapExecution, useSwapInput, useTokenSelection } from '@/shared/stores/swap'
+import { useSwapExecution, useSwapInput, useSwapStore, useTokenSelection } from '@/shared/stores/swap'
 
 import { LowLiquidityWarning, SwapStepWarning } from '../components/SwapStepWarning'
 import { SwapStepProps } from '../types'
@@ -121,7 +121,11 @@ export const SwapStepThree = ({ onGoToStep, onCloseModal, setButtonActions }: Sw
       onRequestTx: async () => {
         const txHash = await execute(amountOutMinimum)
         if (!txHash) {
-          throw new Error('Transaction hash is null')
+          const swapErr = useSwapStore.getState().swapError
+          if (swapErr) {
+            throw swapErr
+          }
+          throw new Error('Unable to submit swap. Please try again.')
         }
         return txHash as Hash
       },
@@ -222,7 +226,7 @@ export const SwapStepThree = ({ onGoToStep, onCloseModal, setButtonActions }: Sw
       <TransactionStatus
         txHash={swapTxHash || undefined}
         isTxFailed={!!swapError}
-        failureMessage="Swap TX failed."
+        failureMessage={swapError?.message ?? 'Swap TX failed.'}
       />
     </>
   )

--- a/src/components/ErrorPage/commonErrors.test.ts
+++ b/src/components/ErrorPage/commonErrors.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createUserCanceledTxError,
+  isUserRejectedTxError,
+  USER_CANCELED_TX_MESSAGE,
+} from './commonErrors'
+
+describe('isUserRejectedTxError', () => {
+  it('should return true for EIP-1193 code 4001 on the error object', () => {
+    expect(isUserRejectedTxError({ code: 4001, message: 'rejected' })).toBe(true)
+  })
+
+  it('should return true for viem UserRejectedRequestError name', () => {
+    expect(isUserRejectedTxError({ name: 'UserRejectedRequestError', message: 'x' })).toBe(true)
+  })
+
+  it('should return true for MetaMask-style message', () => {
+    expect(isUserRejectedTxError(new Error('User rejected the request'))).toBe(true)
+  })
+
+  it('should return true for swap UX copy', () => {
+    expect(isUserRejectedTxError(new Error(USER_CANCELED_TX_MESSAGE))).toBe(true)
+  })
+
+  it('should return true for createUserCanceledTxError', () => {
+    expect(isUserRejectedTxError(createUserCanceledTxError())).toBe(true)
+  })
+
+  it('should return true when rejection is nested on cause', () => {
+    const err = new Error('wrapped')
+    Object.assign(err, { cause: { code: 4001 } })
+    expect(isUserRejectedTxError(err)).toBe(true)
+  })
+
+  it('should return false for unrelated errors', () => {
+    expect(isUserRejectedTxError(new Error('insufficient funds'))).toBe(false)
+    expect(isUserRejectedTxError(null)).toBe(false)
+  })
+
+  it('should treat connector "hash is null/undefined" messages as user dismissal (DAO-2215 swap)', () => {
+    expect(isUserRejectedTxError(new Error('hash is null'))).toBe(true)
+    expect(isUserRejectedTxError(new Error('Transaction hash is null'))).toBe(true)
+    expect(isUserRejectedTxError(new Error('hash is undefined'))).toBe(true)
+  })
+})
+
+describe('createUserCanceledTxError', () => {
+  it('should produce the canonical canceled message', () => {
+    const err = createUserCanceledTxError()
+    expect(err.message).toBe(USER_CANCELED_TX_MESSAGE)
+  })
+})

--- a/src/components/ErrorPage/commonErrors.ts
+++ b/src/components/ErrorPage/commonErrors.ts
@@ -30,19 +30,65 @@ export const toError = (value: unknown): Error => {
   return new Error(String(value))
 }
 
+/** UX copy when the user dismisses or rejects a wallet transaction prompt. */
+export const USER_CANCELED_TX_MESSAGE = 'Transaction canceled by user'
+
+/**
+ * Error shaped like a wallet/user rejection so `executeTxFlow` can treat it as non-actionable.
+ */
+export const createUserCanceledTxError = (): Error => {
+  const err = new Error(USER_CANCELED_TX_MESSAGE)
+  return Object.assign(err, { cause: { code: 4001 as const } })
+}
+
+const USER_REJECTION_MESSAGE_MARKERS = [
+  'user rejected the request',
+  'user rejected',
+  'rejected the transaction',
+  'transaction rejected',
+  'denied transaction',
+  'request rejected',
+  USER_CANCELED_TX_MESSAGE.toLowerCase(),
+  'transaction cancelled by user',
+  'user rejected transaction',
+  // Some connectors return no hash on dismiss and surface internal wording instead of 4001
+  'hash is null',
+  'hash is undefined',
+  'transaction hash is null',
+  'transaction hash is undefined',
+] as const
+
 /**
  * Detects if an error represents a user-rejected wallet transaction
- * (e.g. MetaMask "User rejected the request" or EIP-1193 code 4001).
+ * (e.g. MetaMask "User rejected the request", viem `UserRejectedRequestError`, EIP-1193 code 4001).
  * Accepts `unknown` for compatibility with catch blocks and react-error-boundary FallbackProps.
  */
-export const isUserRejectedTxError = (error: unknown): boolean => {
+export const isUserRejectedTxError = (error: unknown, depth = 0): boolean => {
+  if (error === null || error === undefined || depth > 6) return false
+
   if (typeof error === 'object' && error !== null) {
-    const msg = (error as Record<string, unknown>).message
-    if (typeof msg === 'string' && msg.includes('User rejected the request')) return true
-    const cause = (error as Record<string, unknown>).cause
-    if (typeof cause === 'object' && cause !== null && (cause as Record<string, unknown>).code === 4001)
-      return true
+    const rec = error as Record<string, unknown>
+
+    if (rec.code === 4001) return true
+    if (rec.name === 'UserRejectedRequestError') return true
+
+    const msg = rec.message
+    if (typeof msg === 'string') {
+      const lower = msg.toLowerCase()
+      for (const marker of USER_REJECTION_MESSAGE_MARKERS) {
+        if (lower.includes(marker)) return true
+      }
+    }
+
+    const shortMessage = rec.shortMessage
+    if (typeof shortMessage === 'string' && shortMessage.toLowerCase().includes('reject')) return true
+
+    const cause = rec.cause
+    if (cause !== null && cause !== undefined) {
+      return isUserRejectedTxError(cause, depth + 1)
+    }
   }
+
   return false
 }
 

--- a/src/shared/notification/executeTxFlow.hashNullRejection.test.ts
+++ b/src/shared/notification/executeTxFlow.hashNullRejection.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { executeTxFlow } from './executeTxFlow'
+import { showToast, updateToast } from '@/shared/notification'
+import { waitForTransactionReceipt } from '@wagmi/core'
+
+vi.mock('@/shared/notification', () => ({
+  showToast: vi.fn(),
+  updateToast: vi.fn(),
+}))
+
+vi.mock('@wagmi/core', () => ({
+  waitForTransactionReceipt: vi.fn(),
+}))
+
+vi.mock('@/config', () => ({
+  config: {},
+}))
+
+vi.mock('@/lib/sentry/sentry-client', () => ({
+  sentryClient: { captureException: vi.fn() },
+}))
+
+const mockShowToast = vi.mocked(showToast)
+const mockUpdateToast = vi.mocked(updateToast)
+const mockWaitForTransactionReceipt = vi.mocked(waitForTransactionReceipt)
+
+describe('executeTxFlow + real isUserRejectedTxError (DAO-2215)', () => {
+  const mockOnRequestTx = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    console.error = vi.fn()
+  })
+
+  it('should treat "hash is null" request errors like a user-dismissed tx (no error toast)', async () => {
+    mockOnRequestTx.mockRejectedValue(new Error('hash is null'))
+    const action = 'swap' as const
+
+    await executeTxFlow({
+      onRequestTx: mockOnRequestTx,
+      action,
+    })
+
+    expect(mockShowToast).not.toHaveBeenCalled()
+    expect(mockUpdateToast).not.toHaveBeenCalled()
+    expect(mockWaitForTransactionReceipt).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/notification/executeTxFlow.test.ts
+++ b/src/shared/notification/executeTxFlow.test.ts
@@ -243,6 +243,26 @@ describe('executeTxFlow', () => {
     })
   })
 
+  describe('Missing transaction hash (DAO-2215)', () => {
+    it('should not show toasts or wait for receipt when onRequestTx resolves without a hash', async () => {
+      mockOnRequestTx.mockResolvedValue(undefined as unknown as Hash)
+      const onComplete = vi.fn()
+      const action = 'swap' as const
+
+      const result = await executeTxFlow({
+        onRequestTx: mockOnRequestTx,
+        onComplete,
+        action,
+      })
+
+      expect(mockShowToast).not.toHaveBeenCalled()
+      expect(mockWaitForTransactionReceipt).not.toHaveBeenCalled()
+      expect(mockUpdateToast).not.toHaveBeenCalled()
+      expect(onComplete).toHaveBeenCalledWith(undefined)
+      expect(result).toBeUndefined()
+    })
+  })
+
   describe('Toast Configuration', () => {
     it('should create correct toast configuration for pending state', async () => {
       // Arrange

--- a/src/shared/notification/executeTxFlow.ts
+++ b/src/shared/notification/executeTxFlow.ts
@@ -1,12 +1,13 @@
-import { isUserRejectedTxError } from '@/components/ErrorPage/commonErrors'
-import { config } from '@/config'
-import { showToast, updateToast, ToastAlertOptions } from '@/shared/notification'
-import { TX_MESSAGES } from '@/shared/txMessages'
-import { TxStatus } from '@/shared/types'
 import { waitForTransactionReceipt } from '@wagmi/core'
 import { Id } from 'react-toastify'
 import { Hash } from 'viem'
+
+import { isUserRejectedTxError } from '@/components/ErrorPage/commonErrors'
+import { config } from '@/config'
 import { sentryClient } from '@/lib/sentry/sentry-client'
+import { showToast, ToastAlertOptions, updateToast } from '@/shared/notification'
+import { TX_MESSAGES } from '@/shared/txMessages'
+import { TxStatus } from '@/shared/types'
 
 interface Props {
   action: keyof typeof TX_MESSAGES
@@ -99,6 +100,12 @@ export const executeTxFlow = async ({
 
   try {
     txHash = await onRequestTx()
+
+    // Avoid passing a missing hash into viem/wagmi wait (some wallets surface that as "hash is null" errors).
+    if (!txHash) {
+      onComplete?.(txHash)
+      return undefined
+    }
 
     onPending?.(txHash)
     showToast(createToastConfig(pending, txHash))

--- a/src/shared/stores/swap/hooks.ts
+++ b/src/shared/stores/swap/hooks.ts
@@ -7,6 +7,7 @@ import { type Address, formatUnits, Hex, parseUnits } from 'viem'
 import { useAccount, useReadContract, useSignTypedData, useWriteContract } from 'wagmi'
 import { useShallow } from 'zustand/shallow'
 
+import { isUserRejectedTxError, USER_CANCELED_TX_MESSAGE } from '@/components/ErrorPage/commonErrors'
 import { Permit2Abi } from '@/lib/abis/Permit2Abi'
 import { RIFTokenAbi } from '@/lib/abis/RIFTokenAbi'
 import { UniswapUniversalRouterAbi } from '@/lib/abis/UniswapUniversalRouterAbi'
@@ -657,6 +658,11 @@ export const useSwapExecution = () => {
           args: [commands, inputs],
         })
 
+        if (!hash) {
+          failSwap(new Error(USER_CANCELED_TX_MESSAGE))
+          return null
+        }
+
         completeSwap(hash)
         return hash
       } catch (error) {
@@ -691,9 +697,8 @@ export const useSwapExecution = () => {
           return null
         }
 
-        // User rejected transaction
-        if (errorMessage.includes('rejected') || errorMessage.includes('denied')) {
-          failSwap(new Error('Transaction cancelled by user'))
+        if (isUserRejectedTxError(error)) {
+          failSwap(new Error(USER_CANCELED_TX_MESSAGE))
         } else {
           const swapError = error instanceof Error ? error : new Error(`Swap failed: ${errorMessage}`)
           sentryClient.captureException(swapError, {


### PR DESCRIPTION
## Context

In the swap flow, a user can **approve** a token or **submit** the swap transaction. The app only moves forward once the wallet returns a **transaction hash**. If the user **closes the wallet prompt**, **rejects** the transaction, or the connector returns **no hash**, the UI still needs to behave like a deliberate cancellation—not like an internal bug.

## What was going wrong

Different wallets and libraries surface “no transaction happened” in inconsistent ways. Besides the standard EIP-1193 user-rejection code, we also see:

- **`null` / missing hash** when the user dismisses the prompt  
- Error **messages** that mention **`hash is null`** or similar (internal wording from the stack, not something a user should read)

The product then showed that raw wording, which reads like a broken app even though the user simply chose not to sign.

Separately, shared transaction helpers assumed that if `onRequestTx` resolved, a hash would always be present. Feeding an empty hash into receipt-waiting logic can produce more low-level errors instead of stopping cleanly.

## What we changed (conceptually)

1. **Treat “user didn’t send a tx” as a first-class outcome**  
   We normalize user cancellation to a single, intentional message so the experience is predictable across approve and swap steps.

2. **Recognize more real-world rejection shapes**  
   User rejection detection now covers additional message patterns (including “hash is null” style text), nested `cause` chains, common connector codes, and viem’s user-rejection error type—so we don’t mislabel a dismissal as a generic failure (or the opposite).

3. **Don’t propagate “null hash” as the headline error**  
   Where we previously threw errors that literally said the hash was null, we now either raise a **user-cancel-shaped** error or surface a **short, actionable** message when something else prevented submission.

4. **Stop downstream code from “waiting” on a missing hash**  
   If there is no hash, we exit the flow early instead of continuing into receipt polling.

5. **Show failure copy even when there is no explorer link**  
   If the transaction never landed on chain, there is nothing to link—but the user should still see a clear **failure / canceled** state instead of a blank area.

## How to review this PR

Focus on whether **every path** where the wallet can return without a hash is classified the way you’d expect: **calm copy for user intent**, **Sentry / error reporting only for real failures**, and **no misleading explorer links**.
