### PR TITLE
DAO-2216 Duplicate slippage options with same value in swap modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ node_modules/.prisma
 # Sentry Config File
 .env.sentry-build-plugin
 
+# Git worktrees (local parallel branches)
+.worktrees/
+
 # AI workflow — only canonical .workflow/ is committed; adapters generated locally
 .claude/
 CLAUDE.md

--- a/src/app/user/Swap/Steps/SwapStepOne.test.tsx
+++ b/src/app/user/Swap/Steps/SwapStepOne.test.tsx
@@ -153,6 +153,19 @@ describe('SwapStepOne', () => {
     expect(document.querySelectorAll('[data-testid="swap-fee-tier-buttons"]')).toHaveLength(1)
   })
 
+  it('omits Auto when the probe finds exactly one fee tier (DAO-2216)', () => {
+    vi.mocked(useSwapInput).mockReturnValue({
+      ...defaultSwapInput,
+      availableFeeTiers: [3000],
+      selectedFeeTier: 3000,
+    } as ReturnType<typeof useSwapInput>)
+
+    renderStepOne()
+
+    expect(screen.queryByTestId('fee-tier-auto')).not.toBeInTheDocument()
+    expect(screen.getByTestId('fee-tier-3000')).toBeInTheDocument()
+  })
+
   it('shows USDT0 bridge hint when the quote has multiple hops', () => {
     renderStepOne()
     expect(screen.getByTestId('swap-route-bridge-hint')).toHaveTextContent('Route includes USDT0')

--- a/src/app/user/Swap/Steps/SwapStepOne.tsx
+++ b/src/app/user/Swap/Steps/SwapStepOne.tsx
@@ -24,17 +24,6 @@ import { LOW_LIQUIDITY_WARNING_MESSAGE, shouldShowLowLiquidityWarning } from '..
 
 const AUTO_FEE_TIER = 'auto' as const
 
-function buildFeeTierOptions(): PercentageButtonItem<string>[] {
-  return [
-    { value: AUTO_FEE_TIER, label: 'Auto', testId: 'fee-tier-auto' },
-    ...UNISWAP_FEE_TIERS.map(tier => ({
-      value: String(tier),
-      label: `${feeTierToPercent(tier)}%`,
-      testId: `fee-tier-${tier}`,
-    })),
-  ]
-}
-
 export const SwapStepOne = ({ onGoNext, setButtonActions }: SwapStepProps) => {
   const {
     amountIn,
@@ -249,12 +238,17 @@ export const SwapStepOne = ({ onGoNext, setButtonActions }: SwapStepProps) => {
   )
 
   const feeTierOptions = useMemo(() => {
-    const allOptions = buildFeeTierOptions()
-    return allOptions.filter(option => {
-      if (option.value === AUTO_FEE_TIER) return true
-      const tier = Number(option.value)
-      return availableFeeTiers.some(f => f === tier)
-    })
+    const tierOptions: PercentageButtonItem<string>[] = UNISWAP_FEE_TIERS.filter(tier =>
+      availableFeeTiers.some(f => f === tier),
+    ).map(tier => ({
+      value: String(tier),
+      label: `${feeTierToPercent(tier)}%`,
+      testId: `fee-tier-${tier}`,
+    }))
+    if (availableFeeTiers.length === 1) {
+      return tierOptions
+    }
+    return [{ value: AUTO_FEE_TIER, label: 'Auto', testId: 'fee-tier-auto' }, ...tierOptions]
   }, [availableFeeTiers])
 
   const selectedToken: SwapInputToken = useMemo(

--- a/src/shared/stores/swap/hooks.ts
+++ b/src/shared/stores/swap/hooks.ts
@@ -180,10 +180,18 @@ export const useSwapInput = () => {
   })
 
   // `availableFeeTiers` lists tiers that probe successfully for this route (single-hop pools or
-  // multihop uniform paths). If the user’s explicit tier is not in that set, fall back to Auto.
+  // multihop uniform paths). Single tier: no Auto in UI — pin selection to that pool. Otherwise,
+  // if the user’s explicit tier is not in that set, fall back to Auto.
   useEffect(() => {
-    if (selectedFeeTier === null) return
     if (availableFeeTiers === undefined) return
+    if (availableFeeTiers.length === 1) {
+      const only = availableFeeTiers[0]
+      if (selectedFeeTier !== only) {
+        setSelectedFeeTier(only)
+      }
+      return
+    }
+    if (selectedFeeTier === null) return
     if (availableFeeTiers.length === 0 || !availableFeeTiers.some(t => t === selectedFeeTier)) {
       setSelectedFeeTier(null)
     }


### PR DESCRIPTION
## Context

The swap step lets users pick a **pool fee tier** (Uniswap V3 fee) or **Auto**, which asks the quoter to choose the best tier for the route. We also **probe** the chain to see which tiers have liquidity and only show those tiers in the UI.

## Problem

For some pairs only **one** pool tier actually exists or is usable. In that situation the UI still showed **Auto** plus that single tier. **Auto** and the explicit tier both resolve to the same pool, so users saw two options that meant the same thing. That showed up as confusing duplicate controls (see DAO-2216).

## What we changed

When the probe returns **exactly one** fee tier, we **stop offering Auto** and only show that tier. Store state is aligned so the selected tier is that pool—there is nothing to “auto-pick.”

When **multiple** tiers are available, behavior is unchanged: **Auto** stays the default and every probed tier remains selectable.

## Tests

A unit test covers the single-tier case so we do not regress to showing **Auto** next to the only real option.
