### PR TITLE
DAO-2223 Remove FC type annotations (part 1)

### DIFF
--- a/src/app/backing/components/AllocationBar/AllocationBar.tsx
+++ b/src/app/backing/components/AllocationBar/AllocationBar.tsx
@@ -40,20 +40,22 @@ const getSegmentsCollapsedState = (values: bigint[], totalValue: bigint): boolea
   return segmentsToShowDots
 }
 
-const AllocationBar: React.FC<AllocationBarProps> = ({
+const AllocationBar = ({
   itemsData,
   height = '96px',
   isDraggable = true,
   isResizable = true,
+
   valueDisplay = {
     showPercent: true,
     format: { percentDecimals: 0 },
   },
+
   showLegend = true,
   className = '',
   onChange,
   withModal = false,
-}) => {
+}: AllocationBarProps) => {
   const isControlled = typeof onChange === 'function'
   const [localItemsData, setLocalItemsData] = useState(itemsData)
   const [localValues, setLocalValues] = useState(itemsData.map(item => item.value))

--- a/src/app/backing/components/BackerPercentage/BackerRewardsPercentage.tsx
+++ b/src/app/backing/components/BackerPercentage/BackerRewardsPercentage.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { cn } from '@/lib/utils'
 
 import { DeltaIndicator } from '../../../../components/DeltaIndicator/DeltaIndicator'
@@ -10,11 +8,7 @@ interface BackerRewardsPercentageProps {
   nextPct?: number
 }
 
-export const BackerRewardsPercentage: FC<BackerRewardsPercentageProps> = ({
-  className,
-  currentPct,
-  nextPct,
-}) => {
+export const BackerRewardsPercentage = ({ className, currentPct, nextPct }: BackerRewardsPercentageProps) => {
   return (
     <div
       className={cn('flex flex-row gap-x-1 font-rootstock-sans justify-start font-normal', className)}

--- a/src/app/backing/components/BackingBanner/BackingBanner.tsx
+++ b/src/app/backing/components/BackingBanner/BackingBanner.tsx
@@ -1,12 +1,10 @@
-import { FC } from 'react'
-
 import { DecorativeSquares } from '@/app/backing/components/DecorativeSquares'
 import { CRWhitepaperLink } from '@/app/collective-rewards/shared/components/CRWhitepaperLinkNew'
 import { CommonComponentProps } from '@/components/commonProps'
 import { Header, Paragraph, Span } from '@/components/Typography'
 import { cn } from '@/lib/utils'
 
-export const BackingBanner: FC<CommonComponentProps> = ({ className = '' }) => {
+export const BackingBanner = ({ className = '' }: CommonComponentProps) => {
   return (
     <div
       className={cn(

--- a/src/app/backing/components/BuilderHeader/BuilderHeader.tsx
+++ b/src/app/backing/components/BuilderHeader/BuilderHeader.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { ComponentProps, FC } from 'react'
+import { ComponentProps } from 'react'
 import { Address } from 'viem'
 
 import { IpfsAvatar } from '@/components/IpfsAvatar'
@@ -17,7 +17,7 @@ interface BuilderHeaderProps {
   headerProps?: ComponentProps<typeof Header>
 }
 
-export const BuilderHeader: FC<BuilderHeaderProps> = ({
+export const BuilderHeader = ({
   address,
   name,
   imageIpfs,
@@ -26,7 +26,7 @@ export const BuilderHeader: FC<BuilderHeaderProps> = ({
   showFullName = true,
   shouldNotRedirect = false,
   headerProps,
-}) => {
+}: BuilderHeaderProps) => {
   const shortedAddress = shortAddress(address)
   const truncatedName = name ? (showFullName ? name : truncate(name, 15)) : undefined
 

--- a/src/app/backing/components/Container/BackingInfoContainer/BackingInfoContainer.tsx
+++ b/src/app/backing/components/Container/BackingInfoContainer/BackingInfoContainer.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { CommonComponentProps } from '@/components/commonProps'
 import { cn } from '@/lib/utils'
@@ -7,7 +7,7 @@ interface BackingInfoContainerProps extends CommonComponentProps {
   title: ReactNode
 }
 
-export const BackingInfoContainer: FC<BackingInfoContainerProps> = ({ className = '', title, children }) => {
+export const BackingInfoContainer = ({ className = '', title, children }: BackingInfoContainerProps) => {
   return (
     <div className={cn('relative w-full bg-v3-bg-accent-80 rounded p-4 md:p-6', className)}>
       <div className="flex flex-col gap-[56px]">

--- a/src/app/backing/components/CurrentBacking/CurrentBacking.tsx
+++ b/src/app/backing/components/CurrentBacking/CurrentBacking.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { formatSymbol } from '@/app/shared/formatter'
 import { Label } from '@/components/Typography'
 
@@ -9,7 +7,7 @@ interface CurrentBackingProps {
   existentAllocation: bigint
 }
 
-export const CurrentBacking: FC<CurrentBackingProps> = ({ existentAllocation }) => {
+export const CurrentBacking = ({ existentAllocation }: CurrentBackingProps) => {
   return (
     <div className="border-t border-v3-bg-accent-40 p-3" data-testid="currentBackingContainer">
       <Label className="text-xs text-v3-text-60" data-testid="currentBackingLabel">

--- a/src/app/backing/components/LabeledContent/LabeledContent.tsx
+++ b/src/app/backing/components/LabeledContent/LabeledContent.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { Label } from '@/components/Typography'
 import { cn } from '@/lib/utils'
@@ -9,7 +9,7 @@ interface LabeledContentProps {
   className?: string
 }
 
-export const LabeledContent: FC<LabeledContentProps> = ({ label, children, className }) => {
+export const LabeledContent = ({ label, children, className }: LabeledContentProps) => {
   return (
     <div className={cn('flex flex-col', className)} data-testid="labeledContainer">
       <Label className="text-xs text-v3-bg-accent-0" data-testid="labeledTitle">

--- a/src/app/backing/components/PendingAllocation/PendingAllocation.tsx
+++ b/src/app/backing/components/PendingAllocation/PendingAllocation.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react'
+import { useState } from 'react'
 
 import { HourglassAnimatedIcon } from '@/components/Icons/HourglassAnimatedIcon'
 import { NewPopover } from '@/components/NewPopover'
@@ -10,7 +10,7 @@ interface PendingAllocationProps {
   currentBacking: string
 }
 
-export const PendingAllocation: FC<PendingAllocationProps> = ({ pendingBacking, currentBacking }) => {
+export const PendingAllocation = ({ pendingBacking, currentBacking }: PendingAllocationProps) => {
   const [isOpen, setIsOpen] = useState(false)
 
   const popoverContent = (

--- a/src/app/backing/components/RIFToken/RIFToken.tsx
+++ b/src/app/backing/components/RIFToken/RIFToken.tsx
@@ -1,14 +1,16 @@
-import { FC } from 'react'
-
 import { TokenImage } from '@/components/TokenImage'
 import { Span } from '@/components/Typography'
 import { RIF } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 
-export const RIFToken: FC<{ size?: number; className?: string; textClassName?: string }> = ({
+export const RIFToken = ({
   className,
   textClassName,
   size = 16,
+}: {
+  size?: number
+  className?: string
+  textClassName?: string
 }) => {
   return (
     <div

--- a/src/app/backing/components/RewardsInfo/RewardsInfo.stories.tsx
+++ b/src/app/backing/components/RewardsInfo/RewardsInfo.stories.tsx
@@ -4,26 +4,27 @@ import { FC } from 'react'
 import { WeiPerEther } from '@/lib/constants'
 
 // Simple wrapper to convert numbers to BigInt
-const RewardsInfoWrapper: FC<
-  Omit<RewardsInfoProps, 'backerRewardPercentage'> & {
+const RewardsInfoWrapper = (
+  {
+    backerRewardPercentage,
+    ...props
+  }: Omit<RewardsInfoProps, 'backerRewardPercentage'> & {
     backerRewardPercentage: {
       current: number
       next: number
       cooldownEndTime: number
       previous: number
-    }
+    };
   }
-> = ({ backerRewardPercentage, ...props }) => (
-  <RewardsInfo
-    backerRewardPercentage={{
-      current: (BigInt(backerRewardPercentage.current) * WeiPerEther) / 100n,
-      next: (BigInt(backerRewardPercentage.next) * WeiPerEther) / 100n,
-      cooldownEndTime: BigInt(backerRewardPercentage.cooldownEndTime),
-      previous: (BigInt(backerRewardPercentage.previous) * WeiPerEther) / 100n,
-    }}
-    {...props}
-  />
-)
+) => (<RewardsInfo
+  backerRewardPercentage={{
+    current: (BigInt(backerRewardPercentage.current) * WeiPerEther) / 100n,
+    next: (BigInt(backerRewardPercentage.next) * WeiPerEther) / 100n,
+    cooldownEndTime: BigInt(backerRewardPercentage.cooldownEndTime),
+    previous: (BigInt(backerRewardPercentage.previous) * WeiPerEther) / 100n,
+  }}
+  {...props}
+/>)
 
 const meta: Meta<typeof RewardsInfoWrapper> = {
   title: 'Backing/RewardsInfo',


### PR DESCRIPTION
## Summary
- Remove `FC` / `React.FC` type annotations, replacing with direct prop typing on function parameters
- Part of DAO-2223: changing `@typescript-eslint/no-restricted-types` from `warn` to `error`