### PR TITLE
DAO-2223 Remove FC type annotations (part 2)

### DIFF
--- a/src/app/backing/components/RewardsInfo/RewardsInfo.tsx
+++ b/src/app/backing/components/RewardsInfo/RewardsInfo.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from 'react'
+import { useMemo } from 'react'
 
 import { TokenRewards } from '@/app/collective-rewards/rewards/types'
 import { weiToPercentage } from '@/app/collective-rewards/settings/utils'
@@ -19,11 +19,11 @@ export interface RewardsInfoProps {
   isInteractive?: boolean
 }
 
-export const RewardsInfo: FC<RewardsInfoProps> = ({
+export const RewardsInfo = ({
   backerRewardPercentage,
   estimatedRewards,
   isInteractive = false,
-}) => {
+}: RewardsInfoProps) => {
   const { current, next } = backerRewardPercentage ?? { current: 0n, next: 0n }
   const { prices } = usePricesContext()
 

--- a/src/app/backing/components/StickySlider/StickySlider.tsx
+++ b/src/app/backing/components/StickySlider/StickySlider.tsx
@@ -16,7 +16,7 @@ interface StickySliderProps {
   onMouseLeave?: () => void
 }
 
-export const StickySlider: React.FC<StickySliderProps> = ({
+export const StickySlider = ({
   value,
   onValueChange,
   max = 100,
@@ -27,7 +27,7 @@ export const StickySlider: React.FC<StickySliderProps> = ({
   ticksEdgesSize = 8,
   stickyThreshold = 2,
   onMouseLeave,
-}) => {
+}: StickySliderProps) => {
   // Snap during drag
   const handleValueChange = (val: number[]) => {
     const nearest = ticks.reduce((prev, curr) =>

--- a/src/app/btc-vault/deposit-history/components/MobileDepositHistoryCard.tsx
+++ b/src/app/btc-vault/deposit-history/components/MobileDepositHistoryCard.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import type { FC } from 'react'
 import { memo } from 'react'
 
 import { TokenImage } from '@/components/TokenImage'
@@ -13,7 +12,7 @@ interface Props {
   row: DepositHistoryTableType['Row']
 }
 
-export const MobileDepositHistoryCard: FC<Props> = memo(({ row }) => {
+export const MobileDepositHistoryCard = memo(({ row }: Props) => {
   const { data } = row
 
   return (

--- a/src/app/btc-vault/request-history/components/MobileBtcVaultHistoryCard.tsx
+++ b/src/app/btc-vault/request-history/components/MobileBtcVaultHistoryCard.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import Link from 'next/link'
-import type { FC } from 'react'
 import { memo } from 'react'
 
 import { MoneyIconKoto } from '@/components/Icons'
@@ -18,7 +17,7 @@ interface Props {
   row: BtcVaultHistoryTable['Row']
 }
 
-export const MobileBtcVaultHistoryCard: FC<Props> = memo(({ row }) => {
+export const MobileBtcVaultHistoryCard = memo(({ row }: Props) => {
   const { data } = row
 
   return (

--- a/src/app/btc-vault/request-history/components/RequestStatusBadge.tsx
+++ b/src/app/btc-vault/request-history/components/RequestStatusBadge.tsx
@@ -1,4 +1,4 @@
-import type { FC, JSX } from 'react'
+import type { JSX } from 'react'
 
 import { Paragraph } from '@/components/Typography'
 import { cn } from '@/lib/utils'
@@ -20,7 +20,7 @@ interface Props extends Omit<JSX.IntrinsicElements['div'], 'children'> {
   label: HistoryRowStatusLabel
 }
 
-export const RequestStatusBadge: FC<Props> = ({ displayStatus, label, className, ...props }) => {
+export const RequestStatusBadge = ({ displayStatus, label, className, ...props }: Props) => {
   return (
     <div
       className={cn(

--- a/src/app/builders/components/MultipleSelectDropdown/MultipleSelectDropdownItem.tsx
+++ b/src/app/builders/components/MultipleSelectDropdown/MultipleSelectDropdownItem.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { CheckboxChecked } from '@/components/Icons/CheckboxChecked'
 import { CheckboxUnchecked } from '@/components/Icons/CheckboxUnchecked'
 import { Paragraph } from '@/components/Typography'
@@ -12,12 +10,12 @@ interface MultipleSelectDropdownItemProps {
   className?: string
 }
 
-export const MultipleSelectDropdownItem: FC<MultipleSelectDropdownItemProps> = ({
+export const MultipleSelectDropdownItem = ({
   label,
   sublabel,
   checked,
   className,
-}) => {
+}: MultipleSelectDropdownItemProps) => {
   return (
     <label
       className={cn(

--- a/src/app/builders/components/Table/BuilderFilterDropdown/BuilderFilterDropdown.tsx
+++ b/src/app/builders/components/Table/BuilderFilterDropdown/BuilderFilterDropdown.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { CommonComponentProps } from '@/components/commonProps'
 import {
@@ -16,11 +16,11 @@ interface BuilderFilterDropdownProps extends CommonComponentProps {
   options?: BuilderFilterOption[]
 }
 
-export const BuilderFilterDropdown: FC<BuilderFilterDropdownProps> = ({
+export const BuilderFilterDropdown = ({
   className,
   onSelected,
   options = builderFilterOptions,
-}) => {
+}: BuilderFilterDropdownProps) => {
   const [selectedOptionId, setSelectedOptionId] = useState<BuilderFilterOptionId>(options[0].id)
 
   useEffect(() => {

--- a/src/app/builders/components/Table/BuilderHeaderRow.stories.tsx
+++ b/src/app/builders/components/Table/BuilderHeaderRow.stories.tsx
@@ -41,10 +41,12 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 // Custom TableProvider that accepts initial state
-const CustomTableProvider: FC<PropsWithChildren<{ initialState: TableState<ColumnId> }>> = ({
-  children,
-  initialState: customInitialState,
-}) => {
+const CustomTableProvider = (
+  {
+    children,
+    initialState: customInitialState
+  }: PropsWithChildren<{ initialState: TableState<ColumnId> }>
+) => {
   const [state, dispatch] = useReducer(tableReducer, customInitialState)
 
   return (

--- a/src/app/builders/components/Table/BuilderHeaderRow.tsx
+++ b/src/app/builders/components/Table/BuilderHeaderRow.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ReactElement, Suspense, useMemo } from 'react'
-import { Dispatch, FC, ReactNode } from 'react'
+import { Dispatch, ReactNode } from 'react'
 import { Address } from 'viem'
 
 import { Button } from '@/components/Button'
@@ -34,12 +34,14 @@ export const useSelectedBuildersActions = (actions: Action[]) => {
   return getSelectedBuildersActionState(actions, selectedBuilderIds)
 }
 
-const OrderIndicatorContainer: FC<CommonComponentProps> = ({ className, children }) => (
+const OrderIndicatorContainer = ({ className, children }: CommonComponentProps) => (
   <div className={cn('flex pt-1 justify-center gap-2', className)}>{children}</div>
 )
 
-const OrderIndicator: FC<CommonComponentProps & { columnId: BuilderTable['Column']['id'] }> = ({
+const OrderIndicator = ({
   columnId,
+}: CommonComponentProps & {
+  columnId: BuilderTable['Column']['id']
 }) => {
   const { sort } = useTableContext<ColumnId, BuilderCellDataMap>()
 
@@ -177,7 +179,7 @@ export const HeaderCell = ({
   )
 }
 
-export const HeaderTitle: FC<CommonComponentProps> = ({ className, children }) => (
+export const HeaderTitle = ({ className, children }: CommonComponentProps) => (
   <Label
     variant="tag"
     className={cn(
@@ -189,7 +191,7 @@ export const HeaderTitle: FC<CommonComponentProps> = ({ className, children }) =
   </Label>
 )
 
-export const HeaderSubtitle: FC<CommonComponentProps> = ({ className, children }) => (
+export const HeaderSubtitle = ({ className, children }: CommonComponentProps) => (
   <Paragraph
     variant="body-xs"
     className={cn('text-v3-bg-accent-40 rootstock-sans text-xs leading-5 lowercase font-normal', className)}

--- a/src/app/builders/components/Table/BuildersTable.tsx
+++ b/src/app/builders/components/Table/BuildersTable.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Big } from 'big.js'
-import { FC, Suspense, useContext, useEffect, useMemo, useState } from 'react'
+import { Suspense, useContext, useEffect, useMemo, useState } from 'react'
 import { Address } from 'viem'
 import { useAccount } from 'wagmi'
 
@@ -148,7 +148,7 @@ interface BuilderDataRowProps extends CommonComponentProps<HTMLTableRowElement> 
   actionCount: number
 }
 
-const BuilderDataRow: FC<BuilderDataRowProps> = ({ ...props }) => {
+const BuilderDataRow = ({ ...props }: BuilderDataRowProps) => {
   const isDesktop = useIsDesktop()
   return isDesktop ? <DesktopBuilderRow {...props} /> : <MobileBuilderRow {...props} />
 }


### PR DESCRIPTION
## Summary
- Remove `FC` / `React.FC` type annotations, replacing with direct prop typing on function parameters
- Part of DAO-2223: changing `@typescript-eslint/no-restricted-types` from `warn` to `error`