### PR TITLE
DAO-2223 Remove FC type annotations (part 3)

### DIFF
--- a/src/app/builders/components/Table/Cell/BackersPercentageCell/BackersPercentageCell.tsx
+++ b/src/app/builders/components/Table/Cell/BackersPercentageCell/BackersPercentageCell.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { weiToPercentage } from '@/app/collective-rewards/settings'
 import { BackerRewardPercentage } from '@/app/collective-rewards/types'
 import { StylableComponentProps } from '@/components/commonProps'
@@ -26,7 +24,7 @@ export const BackersPercentage = ({ percentage, className }: BackersPercentagePr
   )
 }
 
-export const BackersPercentageCell: FC<BackersPercentageProps> = ({ className, percentage }) => {
+export const BackersPercentageCell = ({ className, percentage }: BackersPercentageProps) => {
   return (
     <div className={cn('border-b-0', className)}>
       <BackersPercentage percentage={percentage} />

--- a/src/app/builders/components/Table/Cell/BackingShareCell/BackingShareCell.tsx
+++ b/src/app/builders/components/Table/Cell/BackingShareCell/BackingShareCell.tsx
@@ -1,5 +1,4 @@
 import * as Progress from '@radix-ui/react-progress'
-import { FC } from 'react'
 
 import { Paragraph } from '@/components/Typography'
 import { cn } from '@/lib/utils'
@@ -10,11 +9,11 @@ export interface BackingShareCellProps {
   className?: string
 }
 
-export const BackingShareCell: FC<BackingShareCellProps> = ({
+export const BackingShareCell = ({
   backingPercentage: allocationPct,
   step = 1,
   className,
-}) => {
+}: BackingShareCellProps) => {
   if (allocationPct === undefined) {
     return <div className={cn('flex items-center justify-center w-full h-full gap-2', className)}></div>
   }

--- a/src/app/builders/components/Table/Cell/BuilderNameCell/BuilderNameCell.tsx
+++ b/src/app/builders/components/Table/Cell/BuilderNameCell/BuilderNameCell.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { BuilderState } from '@/app/builders/components/Table/BuilderTable.config'
 import { Builder } from '@/app/collective-rewards/types'
 import {
@@ -92,11 +90,13 @@ interface BuilderDecorationProps {
   className?: string
 }
 
-const BuilderDecoration: FC<BuilderDecorationProps & { showTooltip?: boolean }> = ({
+const BuilderDecoration = ({
   decorationId,
   isHighlighted,
   className,
   showTooltip = true,
+}: BuilderDecorationProps & {
+  showTooltip?: boolean
 }) => {
   const icon = createIcon(decorationId, Boolean(isHighlighted))
 
@@ -133,12 +133,7 @@ const getStateDecorationId = (builder: Builder): Exclude<DecorationOptionId, 'ex
   return null
 }
 
-export const BuilderNameCell: FC<BuilderNameCellProps> = ({
-  builder,
-  isHighlighted,
-  hasAirdrop,
-  className,
-}) => {
+export const BuilderNameCell = ({ builder, isHighlighted, hasAirdrop, className }: BuilderNameCellProps) => {
   const stateDecorationId = getStateDecorationId(builder)
   const builderPageLink = `/proposals/${builder.proposal.id}`
   const isDesktop = useIsDesktop()

--- a/src/app/builders/components/Table/Cell/SelectorHeaderCell/SelectorHeaderCell.tsx
+++ b/src/app/builders/components/Table/Cell/SelectorHeaderCell/SelectorHeaderCell.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { CommonComponentProps } from '@/components/commonProps'
 import { CheckboxChecked } from '@/components/Icons/CheckboxChecked'
 import { CheckboxUnchecked } from '@/components/Icons/CheckboxUnchecked'
@@ -8,11 +6,12 @@ import { useTableContext } from '@/shared/context'
 
 import { BuilderCellDataMap, ColumnId } from '../../BuilderTable.config'
 
-export const SelectorHeaderCell: FC<
-  CommonComponentProps & {
-    onClick?: () => void
-  }
-> = ({ className, onClick }) => {
+export const SelectorHeaderCell = ({
+  className,
+  onClick,
+}: CommonComponentProps & {
+  onClick?: () => void
+}) => {
   const { selectedRows } = useTableContext<ColumnId, BuilderCellDataMap>()
 
   return (

--- a/src/app/builders/components/Table/DesktopBuilderRow.tsx
+++ b/src/app/builders/components/Table/DesktopBuilderRow.tsx
@@ -1,4 +1,4 @@
-import { FC, HtmlHTMLAttributes, useState } from 'react'
+import { HtmlHTMLAttributes, useState } from 'react'
 import { useAccount } from 'wagmi'
 
 import {
@@ -24,7 +24,7 @@ interface DesktopBuilderRowProps extends HtmlHTMLAttributes<HTMLTableRowElement>
   actionCount: number
 }
 
-export const DesktopBuilderRow: FC<DesktopBuilderRowProps> = ({ logic, actionCount, ...props }) => {
+export const DesktopBuilderRow = ({ logic, actionCount, ...props }: DesktopBuilderRowProps) => {
   const { isConnected } = useAccount()
   const { onConnectWalletButtonClick } = useAppKitFlow()
 

--- a/src/app/builders/components/Table/ExpandChevron.tsx
+++ b/src/app/builders/components/Table/ExpandChevron.tsx
@@ -1,14 +1,17 @@
-import { FC } from 'react'
-
 import { KotoChevronDownIcon } from '@/components/Icons'
 import { cn } from '@/lib/utils'
 
-export const ExpandChevron: FC<{
+export const ExpandChevron = ({
+  isExpanded,
+  onToggle,
+  className,
+  isRowSelected = false,
+}: {
   isExpanded: boolean
   onToggle?: () => void
   className?: string
   isRowSelected?: boolean
-}> = ({ isExpanded, onToggle, className, isRowSelected = false }) => (
+}) => (
   <KotoChevronDownIcon
     size={16}
     className={cn(

--- a/src/app/builders/components/Table/MobileBuilderRow.tsx
+++ b/src/app/builders/components/Table/MobileBuilderRow.tsx
@@ -1,4 +1,4 @@
-import { FC, HtmlHTMLAttributes, useState } from 'react'
+import { HtmlHTMLAttributes, useState } from 'react'
 import { useAccount } from 'wagmi'
 
 import { ConnectTooltip } from '@/app/components/Tooltip/ConnectTooltip/ConnectTooltip'
@@ -29,7 +29,7 @@ interface MobileBuilderRowProps extends HtmlHTMLAttributes<HTMLTableRowElement> 
   actionCount: number
 }
 
-export const MobileBuilderRow: FC<MobileBuilderRowProps> = ({ logic, actionCount, ...props }) => {
+export const MobileBuilderRow = ({ logic, actionCount, ...props }: MobileBuilderRowProps) => {
   const { isConnected } = useAccount()
   const { onConnectWalletButtonClick } = useAppKitFlow()
 

--- a/src/app/builders/components/Table/MobileFilterModal.tsx
+++ b/src/app/builders/components/Table/MobileFilterModal.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Button } from '@/components/Button'
 import { TrashIcon } from '@/components/Icons'
@@ -22,7 +22,7 @@ interface MobileFilterModalProps {
   onReset: () => void
 }
 
-export const MobileFilterModal: FC<MobileFilterModalProps> = ({
+export const MobileFilterModal = ({
   isOpen,
   filterOptions,
   currentFilter,
@@ -31,7 +31,7 @@ export const MobileFilterModal: FC<MobileFilterModalProps> = ({
   onClose,
   onApply,
   onReset,
-}) => {
+}: MobileFilterModalProps) => {
   // Internal state for temporary selections
   const [tempFilter, setTempFilter] = useState<BuilderFilterOptionId>(currentFilter)
   const [tempSort, setTempSort] = useState<ColumnId | null>(currentSort)

--- a/src/app/builders/components/Table/MobileSections/MobileBackerRewardsSection.tsx
+++ b/src/app/builders/components/Table/MobileSections/MobileBackerRewardsSection.tsx
@@ -1,13 +1,15 @@
-import { FC } from 'react'
-
 import { BackersPercentageCell, BackersPercentageProps } from '../Cell/BackersPercentageCell'
 import { MobileDataSection } from './MobileDataSection'
 
-export const MobileBackerRewardsSection: FC<{
+export const MobileBackerRewardsSection = ({
+  backer_rewards,
+  showChangeIndicator = false,
+  isRowSelected = false,
+}: {
   backer_rewards: BackersPercentageProps
   showChangeIndicator?: boolean
   isRowSelected?: boolean
-}> = ({ backer_rewards, showChangeIndicator = false, isRowSelected = false }) => {
+}) => {
   const hasValue = backer_rewards.percentage?.current != null
 
   return (

--- a/src/app/builders/components/Table/MobileSections/MobileBackingSection.tsx
+++ b/src/app/builders/components/Table/MobileSections/MobileBackingSection.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { BackingCell, BackingCellProps } from '../Cell/BackingCell'
 import { BackingShareCell } from '../Cell/BackingShareCell'
 import {
@@ -9,20 +7,20 @@ import {
   MobileTwoColumnWrapper,
 } from './MobileDataSection'
 
-export const MobileBackingSection: FC<{
-  backing: BackingCellProps
-  backingPercentage?: number
-  showShare?: boolean
-  showUsd?: boolean
-  className?: string
-  isRowSelected?: boolean
-}> = ({
+export const MobileBackingSection = ({
   backing,
   backingPercentage,
   showShare = false,
   showUsd = true,
   className,
   isRowSelected = false,
+}: {
+  backing: BackingCellProps
+  backingPercentage?: number
+  showShare?: boolean
+  showUsd?: boolean
+  className?: string
+  isRowSelected?: boolean
 }) => {
   const hasBackingValue = backing.amount != null
   const hasShareValue = backingPercentage != null


### PR DESCRIPTION
## Summary
- Remove `FC` / `React.FC` type annotations, replacing with direct prop typing on function parameters
- Part of DAO-2223: changing `@typescript-eslint/no-restricted-types` from `warn` to `error`