### PR TITLE
DAO-2223 Remove FC type annotations (part 4)

### DIFF
--- a/src/app/builders/components/Table/MobileSections/MobileDataSection.tsx
+++ b/src/app/builders/components/Table/MobileSections/MobileDataSection.tsx
@@ -1,22 +1,22 @@
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { EmptyPlaceholder } from '@/components/Table/components'
 import { Paragraph } from '@/components/Typography'
 import { cn } from '@/lib/utils'
 
 // Mobile row wrapper component
-const MobileRowWrapper: FC<{ children: ReactNode; className?: string }> = ({ children, className }) => (
+const MobileRowWrapper = ({ children, className }: { children: ReactNode; className?: string }) => (
   <div className={cn('w-full min-w-full flex', className)}>
     <div className="flex flex-col items-start text-left">{children}</div>
   </div>
 )
 
 // Mobile two-column wrapper component
-const MobileTwoColumnWrapper: FC<{ children: ReactNode; className?: string }> = ({ children, className }) => (
+const MobileTwoColumnWrapper = ({ children, className }: { children: ReactNode; className?: string }) => (
   <div className={cn('w-full flex', className)}>{children}</div>
 )
 
-const MobileColumnItem: FC<{ children: ReactNode; className?: string }> = ({ children, className }) => (
+const MobileColumnItem = ({ children, className }: { children: ReactNode; className?: string }) => (
   <div className={cn('w-[50%] flex flex-col items-start text-left', className)}>{children}</div>
 )
 
@@ -30,14 +30,14 @@ interface MobileSectionWrapperProps {
 }
 
 // Generic mobile section wrapper with title, subtitle, and content
-const MobileSectionWrapper: FC<MobileSectionWrapperProps> = ({
+const MobileSectionWrapper = ({
   title,
   subtitle,
   children,
   className,
   hasValue = true,
   isRowSelected = false,
-}) => (
+}: MobileSectionWrapperProps) => (
   <div className={cn('flex flex-col w-full', className)}>
     <Paragraph
       variant="body-xs"
@@ -62,15 +62,7 @@ const MobileSectionWrapper: FC<MobileSectionWrapperProps> = ({
 )
 
 // Generic mobile data section component
-export const MobileDataSection: FC<{
-  title: string
-  children: ReactNode
-  subtitle?: string
-  className?: string
-  hasValue?: boolean
-  layout?: 'single' | 'two-column'
-  isRowSelected?: boolean
-}> = ({
+export const MobileDataSection = ({
   title,
   subtitle,
   children,
@@ -78,6 +70,14 @@ export const MobileDataSection: FC<{
   hasValue = true,
   layout = 'single',
   isRowSelected = false,
+}: {
+  title: string
+  children: ReactNode
+  subtitle?: string
+  className?: string
+  hasValue?: boolean
+  layout?: 'single' | 'two-column'
+  isRowSelected?: boolean
 }) => {
   const content = (
     <MobileSectionWrapper title={title} subtitle={subtitle} hasValue={hasValue} isRowSelected={isRowSelected}>

--- a/src/app/builders/components/Table/MobileSections/MobileRewardsSection.tsx
+++ b/src/app/builders/components/Table/MobileSections/MobileRewardsSection.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { EmptyPlaceholder } from '@/components/Table/components'
 
 import { RewardsCell, RewardsCellProps } from '../Cell/RewardsCell'
@@ -13,12 +11,17 @@ import {
 const hasValidValue = (rewards: RewardsCellProps) =>
   rewards.usdValue != null || rewards.rbtcValue != null || rewards.rifValue != null
 
-export const MobileRewardsSection: FC<{
+export const MobileRewardsSection = ({
+  rewards_past_cycle,
+  rewards_upcoming,
+  showBothColumns = true,
+  isRowSelected = false,
+}: {
   rewards_past_cycle: RewardsCellProps
   rewards_upcoming: RewardsCellProps
   showBothColumns?: boolean
   isRowSelected?: boolean
-}> = ({ rewards_past_cycle, rewards_upcoming, showBothColumns = true, isRowSelected = false }) => {
+}) => {
   const hasUpcomingValue = hasValidValue(rewards_upcoming)
   const hasPastValue = hasValidValue(rewards_past_cycle)
 

--- a/src/app/builders/components/Table/MobileStickyActionBar.tsx
+++ b/src/app/builders/components/Table/MobileStickyActionBar.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { Button } from '@/components/Button'
 import { ActionsContainer } from '@/components/containers/ActionsContainer'
 import { DeselectIcon } from '@/components/Icons/DeselectIcon'
@@ -16,13 +14,13 @@ interface MobileStickyActionBarContentProps {
   onClose?: () => void
 }
 
-export const MobileStickyActionBarContent: FC<MobileStickyActionBarContentProps> = ({
+export const MobileStickyActionBarContent = ({
   actions,
   selectedCount,
   selectedBuilderIds,
   onDeselectAll,
   onClose,
-}) => {
+}: MobileStickyActionBarContentProps) => {
   const { showAction, handleActionClick } = getSelectedBuildersActionState(actions, selectedBuilderIds)
 
   const handleDeselectClick = () => {

--- a/src/app/collective-rewards/allocations/context/AllocationsContext.tsx
+++ b/src/app/collective-rewards/allocations/context/AllocationsContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, FC, ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
+import { createContext, ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import { Address, zeroAddress } from 'viem'
 import { useAccount } from 'wagmi'
 
@@ -91,7 +91,7 @@ const DEFAULT_CONTEXT: AllocationsContext = {
   },
 }
 export const AllocationsContext = createContext<AllocationsContext>(DEFAULT_CONTEXT)
-export const AllocationsContextProvider: FC<{ children: ReactNode }> = ({ children }) => {
+export const AllocationsContextProvider = ({ children }: { children: ReactNode }) => {
   const { address: backerAddress } = useAccount()
   /**
    * Context states

--- a/src/app/collective-rewards/components/ClaimRewardModal/ClaimRewardRadioGroup.tsx
+++ b/src/app/collective-rewards/components/ClaimRewardModal/ClaimRewardRadioGroup.tsx
@@ -1,5 +1,5 @@
 import * as RadioGroup from '@radix-ui/react-radio-group'
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { ClaimRewardRadioOption } from './ClaimRewardRadioOption'
 import { ClaimRewardType } from './types'
@@ -18,13 +18,13 @@ interface ClaimRewardRadioGroupProps {
   className?: string
 }
 
-export const ClaimRewardRadioGroup: FC<ClaimRewardRadioGroupProps> = ({
+export const ClaimRewardRadioGroup = ({
   value,
   onValueChange,
   options,
   isLoading = false,
   className,
-}) => {
+}: ClaimRewardRadioGroupProps) => {
   return (
     <RadioGroup.Root
       className={`flex flex-col md:flex-row gap-2 w-full ${className || ''}`}

--- a/src/app/collective-rewards/components/ClaimRewardModal/ClaimRewardRadioOption.tsx
+++ b/src/app/collective-rewards/components/ClaimRewardModal/ClaimRewardRadioOption.tsx
@@ -1,5 +1,5 @@
 import * as RadioGroup from '@radix-ui/react-radio-group'
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { LoadingSpinner } from '@/components/LoadingSpinner'
 import { Header, Span } from '@/components/Typography'
@@ -13,12 +13,12 @@ interface ClaimRewardRadioOptionProps {
   isLoading?: boolean
 }
 
-export const ClaimRewardRadioOption: FC<ClaimRewardRadioOptionProps> = ({
+export const ClaimRewardRadioOption = ({
   value,
   label,
   subLabel,
   isLoading,
-}) => {
+}: ClaimRewardRadioOptionProps) => {
   return (
     <RadioGroup.Item
       value={value}

--- a/src/app/collective-rewards/components/ClaimRewardModal/ClaimRewardsModalView.tsx
+++ b/src/app/collective-rewards/components/ClaimRewardModal/ClaimRewardsModalView.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { ConditionalTooltip } from '@/app/components'
 import { formatSymbol } from '@/app/shared/formatter'
@@ -28,7 +28,7 @@ interface ClaimRewardsModalViewProps {
   isLoading?: boolean
 }
 
-export const ClaimRewardsModalView: FC<ClaimRewardsModalViewProps> = ({
+export const ClaimRewardsModalView = ({
   onClose,
   selectedRewardType,
   onRewardTypeChange,
@@ -39,7 +39,7 @@ export const ClaimRewardsModalView: FC<ClaimRewardsModalViewProps> = ({
   isClaimable,
   isTxPending = false,
   isLoading = false,
-}) => {
+}: ClaimRewardsModalViewProps) => {
   const radioOptions: Array<{
     value: ClaimRewardType
     label: ReactNode

--- a/src/app/collective-rewards/components/CountMetric/CountMetric.tsx
+++ b/src/app/collective-rewards/components/CountMetric/CountMetric.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { CommonComponentProps } from '@/components/commonProps'
 import { LoadingSpinner } from '@/components/LoadingSpinner'
 import { Metric } from '@/components/Metric'
@@ -9,7 +7,7 @@ interface CountMetricProps extends CommonComponentProps {
   title: string
   isLoading: boolean
 }
-export const CountMetric: FC<CountMetricProps> = ({ title, children, isLoading }) => {
+export const CountMetric = ({ title, children, isLoading }: CountMetricProps) => {
   return (
     <Metric
       className="text-v3-text-0 items-start"

--- a/src/app/collective-rewards/components/RewardsMetrics/RewardsMetrics.tsx
+++ b/src/app/collective-rewards/components/RewardsMetrics/RewardsMetrics.tsx
@@ -1,5 +1,4 @@
 import Big from 'big.js'
-import { FC } from 'react'
 
 import { FiatTooltipLabel } from '@/app/components'
 import { MetricTooltipContent } from '@/app/components/Metric/MetricTooltipContent'
@@ -20,7 +19,7 @@ export interface RewardsMetricsProps {
   rewardTokens: TokenWithValue[]
 }
 
-export const RewardsMetrics: FC<RewardsMetricsProps> = ({ title, rewardTokens }) => {
+export const RewardsMetrics = ({ title, rewardTokens }: RewardsMetricsProps) => {
   const { prices } = usePricesContext()
 
   const {

--- a/src/app/collective-rewards/metrics/context/CycleContext.tsx
+++ b/src/app/collective-rewards/metrics/context/CycleContext.tsx
@@ -1,5 +1,5 @@
 import { DateTime, Duration } from 'luxon'
-import { createContext, FC, ReactNode, useContext, useMemo, useState } from 'react'
+import { createContext, ReactNode, useContext, useMemo, useState } from 'react'
 
 import { useReadCycleTimeKeeper } from '@/shared/hooks/contracts'
 
@@ -37,7 +37,7 @@ const DEFAULT_CYCLE_DATA: Cycle = {
   endDistributionWindow: DateTime.fromSeconds(0),
 }
 
-export const CycleContextProvider: FC<CycleProviderProps> = ({ children }) => {
+export const CycleContextProvider = ({ children }: CycleProviderProps) => {
   const timestamp = useIntervalTimestamp()
   const [cycleData, setCycleData] = useState<Cycle>(DEFAULT_CYCLE_DATA)
 


### PR DESCRIPTION
## Summary
- Remove `FC` / `React.FC` type annotations, replacing with direct prop typing on function parameters
- Part of DAO-2223: changing `@typescript-eslint/no-restricted-types` from `warn` to `error`