### PR TITLE
DAO-2223 Remove FC type annotations (part 5)

### DIFF
--- a/src/app/collective-rewards/rewards/backers/context/BackerRewardsContext.tsx
+++ b/src/app/collective-rewards/rewards/backers/context/BackerRewardsContext.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, FC, ReactNode, useContext, useMemo, useState } from 'react'
+import { createContext, ReactNode, useContext, useMemo, useState } from 'react'
 import { Address } from 'viem'
 
 import {
@@ -92,11 +92,11 @@ const useGetTokenRewards = (backer: Address, token: Token, gauges: Address[]) =>
 const getEarnedAddresses = (rewards: Record<Address, bigint>) =>
   Object.keys(rewards).filter(key => rewards[key as Address] > 0n) as Address[]
 
-export const BackerRewardsContextProvider: FC<BackerRewardsProviderProps> = ({
+export const BackerRewardsContextProvider = ({
   children,
   backer,
   tokens: { rif, rbtc, usdrif },
-}) => {
+}: BackerRewardsProviderProps) => {
   const { builders, isLoading: buildersLoading, error: buildersError } = useBuilderContext()
   const gauges = useMemo(() => {
     const filteredBuilders = filterBuildersByState<CompleteBuilder>(builders)

--- a/src/app/collective-rewards/settings/builder/context/BuilderSettingsContext.tsx
+++ b/src/app/collective-rewards/settings/builder/context/BuilderSettingsContext.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { DateTime } from 'luxon'
-import { createContext, FC, ReactNode, useContext, useMemo } from 'react'
+import { ComponentType, createContext, ReactNode, useContext, useMemo } from 'react'
 import { Address, zeroAddress } from 'viem'
 import { useAccount, UseReadContractReturnType } from 'wagmi'
 
@@ -33,7 +33,7 @@ const BuilderSettingsContext = createContext<BackerRewardsPercentageContext>(
 
 export const useBuilderSettingsContext = () => useContext(BuilderSettingsContext)
 
-const BuilderSettingsProvider: FC<{ children: ReactNode }> = ({ children }) => {
+const BuilderSettingsProvider = ({ children }: { children: ReactNode }) => {
   const { getBuilderByAddress } = useBuilderContext()
   const { address } = useAccount()
   const { data: rawCurrentRewardData, ...restCurrentResponse } = useReadBuilderRegistry({
@@ -71,7 +71,7 @@ const BuilderSettingsProvider: FC<{ children: ReactNode }> = ({ children }) => {
   return <BuilderSettingsContext.Provider value={contextValue}>{children}</BuilderSettingsContext.Provider>
 }
 
-export const withBuilderSettingsProvider = <P extends object>(Component: FC<P>) => {
+export const withBuilderSettingsProvider = <P extends object>(Component: ComponentType<P>) => {
   const WrappedComponent = (props: P) => {
     return (
       <BuilderSettingsProvider>

--- a/src/app/collective-rewards/user/context/BuilderContext.tsx
+++ b/src/app/collective-rewards/user/context/BuilderContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, FC, ReactNode, useCallback, useContext, useMemo } from 'react'
+import { createContext, ReactNode, useCallback, useContext, useMemo } from 'react'
 import { Address } from 'viem'
 
 import { useShuffledArray } from '@/app/backing/hooks/useShuffledArray'
@@ -30,7 +30,7 @@ interface BuilderProviderProps {
   children: ReactNode
 }
 
-const BuilderContextProvider: FC<BuilderProviderProps> = ({ children }) => {
+const BuilderContextProvider = ({ children }: BuilderProviderProps) => {
   const { data: buildersMap, isLoading, error } = useGetBuilders()
 
   const builders = useMemo(() => Object.values(buildersMap), [buildersMap])

--- a/src/app/delegate/components/DelegateCard/DelegateCard.tsx
+++ b/src/app/delegate/components/DelegateCard/DelegateCard.tsx
@@ -25,7 +25,7 @@ interface DelegateCardProps {
   isReclaimPending?: boolean
 }
 
-export const DelegateCard: React.FC<DelegateCardProps> = ({
+export const DelegateCard = ({
   address,
   name,
   imageIpfs,
@@ -41,7 +41,7 @@ export const DelegateCard: React.FC<DelegateCardProps> = ({
   buttonDisabled = false,
   isDelegationPending = false,
   isReclaimPending = false,
-}) => {
+}: DelegateCardProps) => {
   return (
     <div
       className={cn(

--- a/src/app/my-rewards/backers/components/BackerABI.tsx
+++ b/src/app/my-rewards/backers/components/BackerABI.tsx
@@ -1,4 +1,3 @@
-import { FC } from 'react'
 import { Address } from 'viem'
 
 import { ABIFormula } from '@/app/backing/components/ABIFormula'
@@ -9,7 +8,7 @@ import { RewardCard } from '@/app/my-rewards/components/RewardCard'
 interface BackerABIProps {
   backer: Address
 }
-export const BackerABI: FC<BackerABIProps> = ({ backer }) => {
+export const BackerABI = ({ backer }: BackerABIProps) => {
   const { data: abiPct, isLoading, error } = useGetBackerABI(backer)
   useHandleErrors({ error, title: 'Error loading backer abi' })
 

--- a/src/app/my-rewards/backers/components/BackerRewards.tsx
+++ b/src/app/my-rewards/backers/components/BackerRewards.tsx
@@ -1,4 +1,3 @@
-import { FC } from 'react'
 import { Address } from 'viem'
 
 import { BackerRewardsContextProvider } from '@/app/collective-rewards/rewards/backers/context/BackerRewardsContext'
@@ -8,7 +7,7 @@ import { TOKENS } from '@/lib/tokens'
 import { BackerRewardsMetrics } from './BackerRewardsMetrics'
 import { BackerRewardsTableContainer } from './Table'
 
-export const BackerRewards: FC<{ backer: Address }> = ({ backer }) => {
+export const BackerRewards = ({ backer }: { backer: Address }) => {
   return (
     <div className="flex flex-col w-full gap-10">
       <BackerRewardsContextProvider backer={backer} tokens={TOKENS}>

--- a/src/app/my-rewards/backers/components/RBI.tsx
+++ b/src/app/my-rewards/backers/components/RBI.tsx
@@ -1,4 +1,3 @@
-import { FC } from 'react'
 import { Address } from 'viem'
 
 import {
@@ -19,7 +18,7 @@ interface RBIContentProps {
   isLoading: boolean
 }
 
-const RBIContent: FC<RBIContentProps> = ({ rbiPct, isLoading }) => {
+const RBIContent = ({ rbiPct, isLoading }: RBIContentProps) => {
   return (
     <RewardCard
       isLoading={isLoading}
@@ -57,7 +56,7 @@ const RBIContent: FC<RBIContentProps> = ({ rbiPct, isLoading }) => {
   )
 }
 
-const RBIWStateSync: FC<RBIProps> = ({ backer, tokens }) => {
+const RBIWStateSync = ({ backer, tokens }: RBIProps) => {
   const {
     data: backerStakingHistory,
     isLoading: backerStakingHistoryLoading,
@@ -77,7 +76,7 @@ const RBIWStateSync: FC<RBIProps> = ({ backer, tokens }) => {
   return <RBIContent rbiPct={rbiPct} isLoading={isLoading} />
 }
 
-const RBIWTheGraph: FC<RBIProps> = ({ backer, tokens }) => {
+const RBIWTheGraph = ({ backer, tokens }: RBIProps) => {
   const {
     data: backerStakingHistory,
     isLoading: backerStakingHistoryLoading,
@@ -100,7 +99,7 @@ interface RBIProps {
   backer: Address
   tokens: Record<string, Token>
 }
-export const RBI: FC<RBIProps> = props => {
+export const RBI = (props: RBIProps) => {
   const {
     flags: { use_state_sync },
   } = useFeatureFlags()

--- a/src/app/my-rewards/backers/components/Table/BackerRewardsDataRow.tsx
+++ b/src/app/my-rewards/backers/components/Table/BackerRewardsDataRow.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { redirect, RedirectType } from 'next/navigation'
-import { FC, HtmlHTMLAttributes, ReactElement, ReactNode, useState } from 'react'
+import { HtmlHTMLAttributes, ReactElement, ReactNode, useState } from 'react'
 import { useAccount } from 'wagmi'
 
 import { selectedRowStyle, unselectedRowStyle } from '@/app/builders/components/Table'
@@ -187,7 +187,7 @@ interface BackerRewardsDataRowProps {
   row: BackerRewardsTable['Row']
 }
 
-export const BackerRewardsDataRow: FC<BackerRewardsDataRowProps> = ({ row, ...props }) => {
+export const BackerRewardsDataRow = ({ row, ...props }: BackerRewardsDataRowProps) => {
   const {
     id: rowId,
     data: { builder, backing, backer_rewards, unclaimed, estimated, total, actions },

--- a/src/app/my-rewards/backers/components/Table/BackerRewardsHeaderRow.tsx
+++ b/src/app/my-rewards/backers/components/Table/BackerRewardsHeaderRow.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ReactElement, Suspense } from 'react'
-import { Dispatch, FC, ReactNode } from 'react'
+import { Dispatch, ReactNode } from 'react'
 
 import { CombinedActionsHeaderCell, TableColumnDropdown } from '@/app/builders/components/Table'
 import { Action } from '@/app/builders/components/Table/Cell/ActionCell'
@@ -27,12 +27,14 @@ import {
 } from './BackerRewardsTable.config'
 
 // TODO: extract common components with the builder table
-const OrderIndicatorContainer: FC<CommonComponentProps> = ({ className, children }) => (
+const OrderIndicatorContainer = ({ className, children }: CommonComponentProps) => (
   <div className={cn('flex pt-1 justify-center gap-2', className)}>{children}</div>
 )
 
-const OrderIndicator: FC<CommonComponentProps & { columnId: BackerRewardsTable['Column']['id'] }> = ({
+const OrderIndicator = ({
   columnId,
+}: CommonComponentProps & {
+  columnId: BackerRewardsTable['Column']['id']
 }) => {
   const { sort } = useTableContext<ColumnId, BackerRewardsCellDataMap>()
 
@@ -169,7 +171,7 @@ export const HeaderCell = ({
   )
 }
 
-export const HeaderTitle: FC<CommonComponentProps> = ({ className, children }) => (
+export const HeaderTitle = ({ className, children }: CommonComponentProps) => (
   <Label
     variant="tag"
     className={cn(
@@ -181,7 +183,7 @@ export const HeaderTitle: FC<CommonComponentProps> = ({ className, children }) =
   </Label>
 )
 
-export const HeaderSubtitle: FC<CommonComponentProps> = ({ className, children }) => (
+export const HeaderSubtitle = ({ className, children }: CommonComponentProps) => (
   <Paragraph
     variant="body-xs"
     className={cn('text-v3-bg-accent-40 rootstock-sans text-xs leading-5 lowercase font-normal', className)}

--- a/src/app/my-rewards/backers/components/Table/MobileSortModal.tsx
+++ b/src/app/my-rewards/backers/components/Table/MobileSortModal.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Button } from '@/components/Button'
 import { TrashIcon } from '@/components/Icons'
@@ -16,7 +16,7 @@ interface MobileSortModalProps {
   onClose: () => void
 }
 
-export const MobileSortModal: FC<MobileSortModalProps> = ({ isOpen, onClose }) => {
+export const MobileSortModal = ({ isOpen, onClose }: MobileSortModalProps) => {
   const { sort, defaultSort, columns } = useTableContext<ColumnId, BackerRewardsCellDataMap>()
   const dispatch = useTableActionsContext<ColumnId, BackerRewardsCellDataMap>()
 


### PR DESCRIPTION
## Summary
- Remove `FC` / `React.FC` type annotations, replacing with direct prop typing on function parameters
- Part of DAO-2223: changing `@typescript-eslint/no-restricted-types` from `warn` to `error`