### PR TITLE
DAO-2223 Remove FC type annotations (part 6)

### DIFF
--- a/src/app/my-rewards/builder/components/AdjustBackersRewardButton.tsx
+++ b/src/app/my-rewards/builder/components/AdjustBackersRewardButton.tsx
@@ -8,10 +8,7 @@ interface AdjustBackersRewardsButtonProps {
   className?: string
 }
 
-export const AdjustBackersRewardsButton: React.FC<AdjustBackersRewardsButtonProps> = ({
-  onClick,
-  className = '',
-}) => {
+export const AdjustBackersRewardsButton = ({ onClick, className = '' }: AdjustBackersRewardsButtonProps) => {
   return (
     <button
       onClick={onClick}

--- a/src/app/my-rewards/components/ClaimRewardsButton.tsx
+++ b/src/app/my-rewards/components/ClaimRewardsButton.tsx
@@ -7,7 +7,7 @@ interface ClaimRewardsButtonProps {
   disabled?: boolean
 }
 
-export const ClaimRewardsButton: React.FC<ClaimRewardsButtonProps> = ({ onClick, disabled = false }) => {
+export const ClaimRewardsButton = ({ onClick, disabled = false }: ClaimRewardsButtonProps) => {
   return (
     <Button
       variant="secondary-outline"

--- a/src/app/my-rewards/components/SeeRewardsHistoryButton.tsx
+++ b/src/app/my-rewards/components/SeeRewardsHistoryButton.tsx
@@ -9,7 +9,7 @@ interface SeeRewardsHistoryButtonProps {
 }
 
 // TODO: not used yet, Im not sure if we need it
-export const SeeRewardsHistoryButton: React.FC<SeeRewardsHistoryButtonProps> = ({ onClick, icon }) => {
+export const SeeRewardsHistoryButton = ({ onClick, icon }: SeeRewardsHistoryButtonProps) => {
   return (
     <button
       className="flex h-12 py-1 px-0 items-center gap-2 rounded border-none bg-transparent cursor-pointer mt-2"

--- a/src/app/my-rewards/tx-history/components/desktop/DesktopHeaderRow.tsx
+++ b/src/app/my-rewards/tx-history/components/desktop/DesktopHeaderRow.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ReactElement, Suspense } from 'react'
-import { Dispatch, FC } from 'react'
+import { Dispatch } from 'react'
 
 import { ArrowDownWFill } from '@/components/Icons/v3design/ArrowDownWFill'
 import { ArrowsUpDown } from '@/components/Icons/v3design/ArrowsUpDown'
@@ -25,11 +25,11 @@ interface ChildrenWithClassNameProps {
   className?: string
 }
 
-const OrderIndicatorContainer: FC<ChildrenWithClassNameProps> = ({ children, className }) => (
+const OrderIndicatorContainer = ({ children, className }: ChildrenWithClassNameProps) => (
   <div className={cn('flex justify-center gap-2', className)}>{children}</div>
 )
 
-const OrderIndicator: FC<{ columnId: ColumnId }> = ({ columnId }) => {
+const OrderIndicator = ({ columnId }: { columnId: ColumnId }) => {
   const { sort } = useTableContext<ColumnId, TransactionHistoryCellDataMap>()
 
   if (!sort || columnId === undefined) return null
@@ -74,13 +74,13 @@ const dispatchSortRoundRobin = (
   dispatch({ type: 'SORT_BY_COLUMN', payload: { columnId: nextSort ? columnId : null, direction: nextSort } })
 }
 
-const HeaderTitle: FC<ChildrenWithClassNameProps> = ({ children, className }) => (
+const HeaderTitle = ({ children, className }: ChildrenWithClassNameProps) => (
   <Label variant="tag-s" className={cn('cursor-[inherit]', className)}>
     {children}
   </Label>
 )
 
-const HeaderSubtotal: FC<{ value: string }> = ({ value }) => (
+const HeaderSubtotal = ({ value }: { value: string }) => (
   <Paragraph variant="body" bold className="mt-1 text-v3-text-100">
     {value}
   </Paragraph>

--- a/src/app/providers/NFT/BoosterContext.test.tsx
+++ b/src/app/providers/NFT/BoosterContext.test.tsx
@@ -319,11 +319,15 @@ describe('useFetchBoostData', () => {
         },
       },
     })
-    const wrapper: FC<{ children: React.ReactNode }> = ({ children }) => (
-      <realReactQuery.QueryClientProvider client={queryClient}>
-        <BoosterProvider>{children}</BoosterProvider>
-      </realReactQuery.QueryClientProvider>
-    )
+    const wrapper = (
+      {
+        children
+      }: {
+        children: React.ReactNode;
+      }
+    ) => (<realReactQuery.QueryClientProvider client={queryClient}>
+      <BoosterProvider>{children}</BoosterProvider>
+    </realReactQuery.QueryClientProvider>)
 
     vi.mocked(boostUtils.fetchLatestFile).mockResolvedValueOnce(testLatestFile)
     const mockedFetchBoostData = vi.fn().mockResolvedValueOnce(testBoostData)

--- a/src/app/shared/components/AnnualBackersIncentivesLoader/AnnualBackerIncentivesLoader.tsx
+++ b/src/app/shared/components/AnnualBackersIncentivesLoader/AnnualBackerIncentivesLoader.tsx
@@ -1,5 +1,5 @@
 import Big from 'big.js'
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import {
   useGetABIFromChain,
@@ -20,7 +20,7 @@ const useFallbackWithErrors = () => {
   return { data, isLoading, error }
 }
 
-export const AnnualBackerIncentivesLoader: FC<AnnualBackerIncentivesLoaderProps> = ({ render }) => {
+export const AnnualBackerIncentivesLoader = ({ render }: AnnualBackerIncentivesLoaderProps) => {
   const {
     flags: { use_state_sync },
   } = useFeatureFlags()

--- a/src/app/shared/components/BuilderCard/BackMoreBuildersCard.tsx
+++ b/src/app/shared/components/BuilderCard/BackMoreBuildersCard.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/navigation'
-import { FC, useState } from 'react'
+import { useState } from 'react'
 
 import { Button } from '@/components/Button'
 import { BuildingBrick, CloseIconKoto } from '@/components/Icons'
@@ -12,11 +12,7 @@ interface BackMoreBuildersCardProps {
   className?: string
 }
 
-export const BackMoreBuildersCard: FC<BackMoreBuildersCardProps> = ({
-  dataTestId,
-  topBarColor,
-  className,
-}) => {
+export const BackMoreBuildersCard = ({ dataTestId, topBarColor, className }: BackMoreBuildersCardProps) => {
   const [isVisible, setIsVisible] = useState(true)
 
   const router = useRouter()

--- a/src/app/shared/components/BuilderCard/BuilderCardControl.tsx
+++ b/src/app/shared/components/BuilderCard/BuilderCardControl.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/navigation'
-import { FC, useContext, useEffect } from 'react'
+import { useContext, useEffect } from 'react'
 import { Address } from 'viem'
 import { useAccount } from 'wagmi'
 
@@ -63,12 +63,12 @@ const AllocationDrawerContent = () => {
   )
 }
 
-export const BuilderCardControl: FC<BuilderCardControlProps> = ({
+export const BuilderCardControl = ({
   builder,
   index,
   showAnimation = false,
   ...props
-}) => {
+}: BuilderCardControlProps) => {
   const { isConnected } = useAccount()
   const { prices } = usePricesContext()
   const { openDrawer, closeDrawer } = useLayoutContext()

--- a/src/app/shared/components/Fallback/withDataFallback.tsx
+++ b/src/app/shared/components/Fallback/withDataFallback.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 
 import { withFallbackRetry } from './FallbackWithRetry'
@@ -10,15 +10,15 @@ interface DataLoaderProps<T> {
 export function withDataFallback<T>(
   usePrimary: () => { data: T; isLoading: boolean; error?: unknown },
   useFallback: () => { data: T; isLoading: boolean; error?: unknown },
-): FC<DataLoaderProps<T>> {
-  const DataLoader: FC<DataLoaderProps<T>> = ({ render }) => {
-    const PrimaryLoader: FC = () => {
+) {
+  const DataLoader = ({ render }: DataLoaderProps<T>) => {
+    const PrimaryLoader = () => {
       const { data, isLoading, error } = usePrimary()
       if (error) throw error
       return <>{render({ data, isLoading })}</>
     }
 
-    const FallbackLoader: FC = () => {
+    const FallbackLoader = () => {
       const { data, isLoading } = useFallback()
       return <>{render({ data, isLoading })}</>
     }

--- a/src/app/shared/components/NFTBoosterCard/NFTBoosterCard.tsx
+++ b/src/app/shared/components/NFTBoosterCard/NFTBoosterCard.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image'
-import { FC } from 'react'
 
 import { applyPinataImageOptions } from '@/lib/ipfs'
 
@@ -10,7 +9,7 @@ interface NFTBoosterCardProps {
   content: string
 }
 
-export const NFTBoosterCard: FC<NFTBoosterCardProps> = ({ nftThumbPath, boostValue, title, content }) => {
+export const NFTBoosterCard = ({ nftThumbPath, boostValue, title, content }: NFTBoosterCardProps) => {
   const isExternalImage = nftThumbPath.startsWith('http')
   const image = isExternalImage
     ? applyPinataImageOptions(nftThumbPath, { width: 50, height: 50, quality: 90 })


### PR DESCRIPTION
## Summary
- Remove `FC` / `React.FC` type annotations, replacing with direct prop typing on function parameters
- Part of DAO-2223: changing `@typescript-eslint/no-restricted-types` from `warn` to `error`