### PR TITLE
DAO-2223 Remove FC type annotations (part 7)

### DIFF
--- a/src/app/shared/components/NFTBoosterCard/SelfContainedNFTBoosterCard.tsx
+++ b/src/app/shared/components/NFTBoosterCard/SelfContainedNFTBoosterCard.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { communitiesMapByContract } from '@/app/communities/communityUtils'
 import { useNFTBoosterContext } from '@/app/providers/NFT/BoosterContext'
 import { NFTBoosterCard } from '@/app/shared/components'
@@ -7,7 +5,7 @@ import { NFTBoosterCard } from '@/app/shared/components'
 interface SelfContainedNFTBoosterCardPros {
   forceRender?: boolean
 }
-export const SelfContainedNFTBoosterCard: FC<SelfContainedNFTBoosterCardPros> = ({ forceRender = false }) => {
+export const SelfContainedNFTBoosterCard = ({ forceRender = false }: SelfContainedNFTBoosterCardPros) => {
   const { userHasRewards, boostData } = useNFTBoosterContext()
 
   const { title, leftImageSrc } = communitiesMapByContract[boostData?.nftContractAddress ?? ''] ?? {}

--- a/src/app/shared/context/BackingContext.tsx
+++ b/src/app/shared/context/BackingContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, FC, ReactNode, useContext, useMemo } from 'react'
+import { createContext, ReactNode, useContext, useMemo } from 'react'
 
 import { AllocationsContext } from '@/app/collective-rewards/allocations/context'
 import { BackerEstimatedRewards } from '@/app/collective-rewards/types'
@@ -22,10 +22,7 @@ interface BackingProviderProps {
   dynamicAllocations?: boolean
 }
 
-export const BackingContextProvider: FC<BackingProviderProps> = ({
-  children,
-  dynamicAllocations = false,
-}) => {
+export const BackingContextProvider = ({ children, dynamicAllocations = false }: BackingProviderProps) => {
   const {
     state: { allocations, isContextLoading },
     initialState: { allocations: initialAllocations },

--- a/src/app/staking-history/components/StakingHistoryDataRow.tsx
+++ b/src/app/staking-history/components/StakingHistoryDataRow.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FC, Fragment, memo, useCallback, useState } from 'react'
+import { Fragment, memo, useCallback, useState } from 'react'
 
 import { cn } from '@/lib/utils'
 
@@ -11,7 +11,7 @@ interface TransactionHistoryDataRowProps {
   row: StakingHistoryTable['Row']
 }
 
-export const StakingHistoryDataRow: FC<TransactionHistoryDataRowProps> = memo(({ row, ...props }) => {
+export const StakingHistoryDataRow = memo(({ row, ...props }: TransactionHistoryDataRowProps) => {
   const {
     data: { period, action, amount, transactions, total_amount },
   }: StakingHistoryTable['Row'] = row

--- a/src/app/user/Balances/context/BalancesContext.tsx
+++ b/src/app/user/Balances/context/BalancesContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, FC, ReactNode, useContext } from 'react'
+import { createContext, ReactNode, useContext } from 'react'
 
 import { useGetAddressBalances } from '@/app/user/Balances/hooks/useGetAddressBalances'
 import { useGetSpecificPrices } from '@/app/user/Balances/hooks/useGetSpecificPrices'
@@ -29,7 +29,7 @@ interface BalancesProviderProps {
   children: ReactNode
 }
 
-export const BalancesProvider: FC<BalancesProviderProps> = ({ children }) => {
+export const BalancesProvider = ({ children }: BalancesProviderProps) => {
   const { balances, isBalancesLoading } = useGetAddressBalances()
   const prices = useGetSpecificPrices()
 

--- a/src/app/user/Stake/StakingContext.tsx
+++ b/src/app/user/Stake/StakingContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, FC, ReactNode, useCallback, useContext, useMemo, useState } from 'react'
+import { createContext, ReactNode, useCallback, useContext, useMemo, useState } from 'react'
 
 import { StakingToken } from '@/app/user/Stake/types'
 import Big from '@/lib/big'
@@ -71,7 +71,7 @@ interface Props {
   tokenToReceive: StakingToken
 }
 
-export const StakingProvider: FC<Props> = ({ tokenToSend, tokenToReceive, children }) => {
+export const StakingProvider = ({ tokenToSend, tokenToReceive, children }: Props) => {
   const [stakeData, setStakeData] = useState({ amount: '' })
   const [buttonActions, setButtonActions] = useState<ButtonActions>(DEFAULT_BUTTON_ACTIONS)
 

--- a/src/app/vault/components/VaultDisclaimer.tsx
+++ b/src/app/vault/components/VaultDisclaimer.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { DecorativeSquares } from '@/app/backing/components/DecorativeSquares'
 import { formatSymbol } from '@/app/shared/formatter'
 import { useVaultDepositLimiter } from '@/app/vault/hooks/useVaultDepositLimiter'
@@ -8,7 +6,7 @@ import { Header, Paragraph } from '@/components/Typography'
 import { USDRIF } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 
-export const VaultDisclaimer: FC<CommonComponentProps> = ({ className = '' }) => {
+export const VaultDisclaimer = ({ className = '' }: CommonComponentProps) => {
   const { maxDefaultDepositLimit } = useVaultDepositLimiter()
   const formattedDefaultLimit = formatSymbol(maxDefaultDepositLimit, USDRIF)
   return (

--- a/src/app/vault/history/components/VaultHistoryDataRow.tsx
+++ b/src/app/vault/history/components/VaultHistoryDataRow.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FC, Fragment, memo, useCallback, useState } from 'react'
+import { Fragment, memo, useCallback, useState } from 'react'
 
 import { cn } from '@/lib/utils'
 
@@ -11,7 +11,7 @@ interface VaultHistoryDataRowProps {
   row: VaultHistoryTable['Row']
 }
 
-export const VaultHistoryDataRow: FC<VaultHistoryDataRowProps> = memo(({ row, ...props }) => {
+export const VaultHistoryDataRow = memo(({ row, ...props }: VaultHistoryDataRowProps) => {
   const {
     data: { period, action, assets, transactions, total_usd },
   }: VaultHistoryTable['Row'] = row

--- a/src/components/BoltSvg/BoltSvg.tsx
+++ b/src/components/BoltSvg/BoltSvg.tsx
@@ -1,9 +1,9 @@
-import { FC, SVGProps } from 'react'
+import { SVGProps } from 'react'
 
 type BoltSvgProps = SVGProps<SVGSVGElement> & {
   showGlow?: boolean
 }
-export const BoltSvg: FC<BoltSvgProps> = ({ showGlow, ...rest }) => (
+export const BoltSvg = ({ showGlow, ...rest }: BoltSvgProps) => (
   <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" {...rest}>
     <g filter={showGlow ? 'url(#filter0_d_671_52312)' : ''}>
       <path

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { ButtonHTMLAttributes, FC, RefAttributes } from 'react'
+import { ButtonHTMLAttributes, RefAttributes } from 'react'
 
 import { cn } from '@/lib/utils'
 
@@ -15,7 +15,7 @@ interface Props extends RefAttributes<HTMLButtonElement>, ButtonHTMLAttributes<H
   textClassName?: string
 }
 
-export const Button: FC<Props> = ({
+export const Button = ({
   children,
   variant = 'primary',
   disabled = false,
@@ -24,7 +24,7 @@ export const Button: FC<Props> = ({
   'data-testid': dataTestId,
   textClassName = '',
   ...props
-}) => {
+}: Props) => {
   const styles = {
     primary:
       'bg-primary text-bg-100 border border-primary disabled:bg-disabled-primary disabled:border-transparent',

--- a/src/components/CollapsibleWithPreview/CollapsibleWithPreview.tsx
+++ b/src/components/CollapsibleWithPreview/CollapsibleWithPreview.tsx
@@ -22,7 +22,7 @@ interface CollapsibleWithPreviewProps {
   className?: string
 }
 
-const CollapsibleWithPreview: React.FC<CollapsibleWithPreviewProps> = ({
+const CollapsibleWithPreview = ({
   expandedContent,
   collapsedContent,
   expandedState,
@@ -30,7 +30,7 @@ const CollapsibleWithPreview: React.FC<CollapsibleWithPreviewProps> = ({
   defaultOpen = true,
   onStateChange,
   className,
-}) => {
+}: CollapsibleWithPreviewProps) => {
   const [isOpen, setIsOpen] = useState(defaultOpen)
   const [expandedHeight, setExpandedHeight] = useState<number>(0)
   const [collapsedHeight, setCollapsedHeight] = useState<number>(0)


### PR DESCRIPTION
## Summary
- Remove `FC` / `React.FC` type annotations, replacing with direct prop typing on function parameters
- Part of DAO-2223: changing `@typescript-eslint/no-restricted-types` from `warn` to `error`