### PR TITLE
DAO-2223 Remove FC type annotations (part 8)

### DIFF
--- a/src/components/ComparativeProgressBar/ComparativeProgressBar.tsx
+++ b/src/components/ComparativeProgressBar/ComparativeProgressBar.tsx
@@ -1,4 +1,4 @@
-import { FC, JSX } from 'react'
+import { JSX } from 'react'
 const DEFAULT_CLASSES = 'rounded-[6px] bg-white h-[6px] rounded-[20px] relative flex overflow-hidden'
 
 interface Value {
@@ -10,7 +10,7 @@ interface Props {
   values: Value[]
 }
 
-export const ComparativeProgressBar: FC<Props> = ({ values }) => {
+export const ComparativeProgressBar = ({ values }: Props) => {
   const total = values.reduce((acc, { value }) => acc + value, 0)
 
   return (

--- a/src/components/CopyButton/CopyButton.stories.tsx
+++ b/src/components/CopyButton/CopyButton.stories.tsx
@@ -20,13 +20,11 @@ const address = '0xB62BD53308fb2834b3114a5f725D0382CBe9f008'
 /**
  * Demonstrates the CopyButton surrounded by components from left and right
  */
-const Surrounding: FC<CopyButtonProps> = args => (
-  <div className="flex gap-4">
-    <span className="border">Leading</span>
-    <CopyButton {...args} />
-    <span className="border">Trailing</span>
-  </div>
-)
+const Surrounding = (args: CopyButtonProps) => (<div className="flex gap-4">
+  <span className="border">Leading</span>
+  <CopyButton {...args} />
+  <span className="border">Trailing</span>
+</div>)
 
 export const Default: Story = {
   args: {

--- a/src/components/CopyButton/CopyButton.tsx
+++ b/src/components/CopyButton/CopyButton.tsx
@@ -1,4 +1,4 @@
-import { FC, HTMLAttributes, ReactElement, ReactNode, useEffect, useRef, useState } from 'react'
+import { HTMLAttributes, ReactElement, ReactNode, useEffect, useRef, useState } from 'react'
 
 import { cn } from '@/lib/utils'
 
@@ -41,7 +41,7 @@ enum CopyStatus {
  * A button that copies its `text` prop to the clipboard.
  * Provides visual feedback based on the success or failure of the copy action.
  */
-export const CopyButton: FC<CopyButtonProps> = ({
+export const CopyButton = ({
   copyText,
   successLabel = 'Copied!',
   errorLabel = 'Error',
@@ -51,7 +51,7 @@ export const CopyButton: FC<CopyButtonProps> = ({
   className,
   children,
   ...props
-}) => {
+}: CopyButtonProps) => {
   const ref = useRef<HTMLDivElement>(null)
   const [minWidth, setMinWidth] = useState<number>()
   const [status, setStatus] = useState<CopyStatus>(CopyStatus.Idle)

--- a/src/components/DeltaIndicator/DeltaIndicator.tsx
+++ b/src/components/DeltaIndicator/DeltaIndicator.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { ArrowDownIcon, ArrowUpIcon } from '@/components/Icons'
 import { SeparatorBar } from '@/components/SeparatorBar/SeparatorBar'
 import { cn } from '@/lib/utils'
@@ -20,7 +18,7 @@ const deltaMap = {
   },
 }
 
-export const DeltaIndicator: FC<DeltaIndicatorProps> = ({ currentPct, nextPct }) => {
+export const DeltaIndicator = ({ currentPct, nextPct }: DeltaIndicatorProps) => {
   if (currentPct === undefined || nextPct === undefined) return null
   if (currentPct === nextPct) return null
 

--- a/src/components/DottedUnderlineLabel/DottedUnderlineLabel.tsx
+++ b/src/components/DottedUnderlineLabel/DottedUnderlineLabel.tsx
@@ -1,9 +1,7 @@
-import { FC } from 'react'
-
 import { CommonComponentProps } from '@/components/commonProps'
 import { cn } from '@/lib/utils'
 
-export const DottedUnderlineLabel: FC<CommonComponentProps> = ({ className = '', children }) => {
+export const DottedUnderlineLabel = ({ className = '', children }: CommonComponentProps) => {
   return (
     <span
       className={cn('relative inline-block', className)}

--- a/src/components/Expandable/Expandable.tsx
+++ b/src/components/Expandable/Expandable.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { FC, ReactNode, useState } from 'react'
+import { ReactNode, useState } from 'react'
 
 import { cn } from '@/lib/utils'
 
@@ -42,13 +42,13 @@ interface Props {
  * </Expandable>
  * ```
  */
-export const Expandable: FC<Props> = ({
+export const Expandable = ({
   children,
   className,
   dataTestId,
   expanded = false,
   onToggleExpanded,
-}) => {
+}: Props) => {
   const [isExpanded, setIsExpanded] = useState(expanded)
   const toggleExpanded = () => {
     setIsExpanded(!isExpanded)

--- a/src/components/Expandable/ExpandableComponent.tsx
+++ b/src/components/Expandable/ExpandableComponent.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { Expandable } from './Expandable'
 import { ExpandableContent } from './ExpandableContent'
@@ -15,13 +15,13 @@ interface Props {
   footer?: ReactNode
 }
 
-export const ExpandableComponent: FC<Props> = ({
+export const ExpandableComponent = ({
   alwaysVisible,
   expandable,
   className,
   contentClassName,
   footer,
-}) => {
+}: Props) => {
   return (
     <Expandable className={className}>
       <ExpandableHeader>{alwaysVisible}</ExpandableHeader>

--- a/src/components/Expandable/ExpandableContent.tsx
+++ b/src/components/Expandable/ExpandableContent.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { FC, isValidElement, ReactNode } from 'react'
+import React, { isValidElement, ReactNode } from 'react'
 
 import { cn } from '@/lib/utils'
 
@@ -50,14 +50,14 @@ const splitContent = (children: ReactNode): [ReactNode, ReactNode] => {
  * Expandable content section with optional preview functionality
  * This component MUST be used inside the Expandable component.
  */
-export const ExpandableContent: FC<Props> = ({
+export const ExpandableContent = ({
   children,
   className,
   contentClassName,
   showPreview = false,
   previewCharLimit = 200,
   previewClassName,
-}) => {
+}: Props) => {
   const { isExpanded } = useExpandableContext()
 
   if (!showPreview) {

--- a/src/components/Expandable/ExpandableFooter.tsx
+++ b/src/components/Expandable/ExpandableFooter.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { cn } from '@/lib/utils'
 
@@ -13,6 +13,6 @@ interface Props {
  * Expandable footer section.
  * This component MUST be used inside the Expandable component.
  */
-export const ExpandableFooter: FC<Props> = ({ children, className }) => {
+export const ExpandableFooter = ({ children, className }: Props) => {
   return <div className={cn('flex flex-col', className)}>{children}</div>
 }

--- a/src/components/Expandable/ExpandableHeader.tsx
+++ b/src/components/Expandable/ExpandableHeader.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { cn } from '@/lib/utils'
 
@@ -18,7 +18,7 @@ interface Props {
  * Expandable header section.
  * This component MUST be used inside the Expandable component.
  */
-export const ExpandableHeader: FC<Props> = ({ children, className, triggerColor, toggleOnClick = false }) => {
+export const ExpandableHeader = ({ children, className, triggerColor, toggleOnClick = false }: Props) => {
   const { toggleExpanded } = useExpandableContext()
   return (
     <div


### PR DESCRIPTION
## Summary
- Remove `FC` / `React.FC` type annotations, replacing with direct prop typing on function parameters
- Part of DAO-2223: changing `@typescript-eslint/no-restricted-types` from `warn` to `error`