### PR TITLE
DAO-2223 Remove FC type annotations (part 9)

### DIFF
--- a/src/components/Expandable/ExpandableTrigger.tsx
+++ b/src/components/Expandable/ExpandableTrigger.tsx
@@ -1,5 +1,4 @@
 'use client'
-import { FC } from 'react'
 
 import { cn } from '@/lib/utils'
 
@@ -16,7 +15,7 @@ interface Props {
  * Expandable trigger button.
  * This component MUST be used inside the Expandable component.
  */
-export const ExpandableTrigger: FC<Props> = ({ className, color = 'var(--color-text-0)' }) => {
+export const ExpandableTrigger = ({ className, color = 'var(--color-text-0)' }: Props) => {
   const { isExpanded, toggleExpanded } = useExpandableContext()
 
   return (

--- a/src/components/HeroComponent/HeroComponentDesktop.tsx
+++ b/src/components/HeroComponent/HeroComponentDesktop.tsx
@@ -1,6 +1,6 @@
 'use client'
 import Image from 'next/image'
-import { FC, ReactNode, useMemo } from 'react'
+import { ReactNode, useMemo } from 'react'
 
 import { cn } from '@/lib/utils'
 import { useImagePreloader } from '@/shared/hooks/useImagePreloader'
@@ -13,7 +13,7 @@ import { HeroComponentProps } from './types'
  * Hero component for desktop screens.
  * Displays a hero image with a title and subtitle.
  */
-export const HeroComponentDesktop: FC<HeroComponentProps> = ({
+export const HeroComponentDesktop = ({
   imageSrc,
   title,
   subtitle,
@@ -23,7 +23,7 @@ export const HeroComponentDesktop: FC<HeroComponentProps> = ({
   button,
   className,
   dataTestId,
-}) => {
+}: HeroComponentProps) => {
   // Memoize image sources is needed to prevent unnecessary re-renders
   const imageSources = useMemo(() => [imageSrc], [imageSrc])
   const { isLoaded } = useImagePreloader(imageSources)

--- a/src/components/HeroComponent/HeroComponentMobile.tsx
+++ b/src/components/HeroComponent/HeroComponentMobile.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { Expandable, ExpandableContent, ExpandableFooter, ExpandableHeader } from '@/components/Expandable'
 import { cn } from '@/lib/utils'
@@ -23,7 +23,7 @@ export interface HeroComponentMobileProps {
  * Displays a hero image with a title and subtitle.
  * This component uses the Expandable component to display the content.
  */
-export const HeroComponentMobile: FC<HeroComponentMobileProps> = ({
+export const HeroComponentMobile = ({
   title,
   subtitle,
   topText,
@@ -32,7 +32,7 @@ export const HeroComponentMobile: FC<HeroComponentMobileProps> = ({
   button,
   className,
   dataTestId,
-}) => {
+}: HeroComponentMobileProps) => {
   const hasExpandableContent = content || items.length > 0
   return (
     <Expandable className={cn('bg-text-80 rounded-sm p-4', className)} dataTestId={dataTestId}>

--- a/src/components/IconButton/InfoIconButton.tsx
+++ b/src/components/IconButton/InfoIconButton.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { KotoQuestionMarkIcon } from '@/components/Icons/KotoQuestionMarkIcon'
 import { Tooltip, type TooltipProps } from '@/components/Tooltip'
@@ -11,12 +11,12 @@ export interface InfoIconButtonProps extends CommonComponentProps, Omit<TooltipP
   tooltipClassName?: string
 }
 
-export const InfoIconButton: FC<InfoIconButtonProps> = ({
+export const InfoIconButton = ({
   info,
   className = '',
   tooltipClassName = '',
   ...tooltipProps
-}) => (
+}: InfoIconButtonProps) => (
   <div data-testid="InfoIconButton" className={cn('items-center flex gap-2 self-center', className)}>
     <Tooltip
       text={info}

--- a/src/components/Icons/CaretRight.tsx
+++ b/src/components/Icons/CaretRight.tsx
@@ -1,11 +1,11 @@
-import React, { FC } from 'react'
+import React from 'react'
 
 interface CaretRightProps {
   color?: string
   className?: string
 }
 
-export const CaretRight: FC<CaretRightProps> = ({ color = 'var(--background-0)', className }) => {
+export const CaretRight = ({ color = 'var(--background-0)', className }: CaretRightProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/Label/GlowingLabel.tsx
+++ b/src/components/Label/GlowingLabel.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, FC, HTMLAttributes } from 'react'
+import { CSSProperties, HTMLAttributes } from 'react'
 
 import { cn } from '@/lib/utils'
 
@@ -7,7 +7,7 @@ type GlowingLabelProps = HTMLAttributes<HTMLDivElement> & {
   faded?: boolean
 }
 
-export const GlowingLabel: FC<GlowingLabelProps> = ({ children, showGlow, faded, className, ...props }) => {
+export const GlowingLabel = ({ children, showGlow, faded, className, ...props }: GlowingLabelProps) => {
   const backgroundStyle: CSSProperties['background'] = faded
     ? 'linear-gradient(270deg, #4B171A -8.88%, #C0F7FF 31.43%, #E3FFEB 78.65%)'
     : 'linear-gradient(270deg, #4B171A -456.96%, #C0F7FF -195.47%, #E3FFEB 110.84%)'

--- a/src/components/Link/ExternalLink.tsx
+++ b/src/components/Link/ExternalLink.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { cn } from '@/lib/utils'
 
 import { ArrowRight, ArrowUpRightLightIcon } from '../Icons'
@@ -9,15 +7,17 @@ import { ExternalLinkProps } from './types'
  * Styled anchor tag. The wrapped 'a' tag can be replaced by a custom
  * component by providing a `component` prop
  */
-export const ExternalLink: FC<ExternalLinkProps> = ({
+export const ExternalLink = ({
   children,
   variant = 'default',
   component: Component = 'a',
   underline = true,
+
   // can be customized by providing additional classnames
   className,
+
   ...props
-}) => {
+}: ExternalLinkProps) => {
   return (
     <Component
       {...props}

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,5 +1,4 @@
 import NextLink from 'next/link'
-import { FC } from 'react'
 
 import { ExternalLink } from './ExternalLink'
 import { LinkProps } from './types'
@@ -7,6 +6,6 @@ import { LinkProps } from './types'
 /**
  * Base link component uses Next.js router link
  */
-export const Link: FC<LinkProps> = props => {
+export const Link = (props: LinkProps) => {
   return <ExternalLink {...props} component={NextLink} />
 }

--- a/src/components/LoadingSpinner/withLoadingSpinner.tsx
+++ b/src/components/LoadingSpinner/withLoadingSpinner.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, FC } from 'react'
+import { ComponentType } from 'react'
 
 import { LoadingSpinner, SpinnerSize } from '@/components/LoadingSpinner'
 
@@ -11,16 +11,13 @@ interface SpinnerOptions {
   size?: SpinnerSize
 }
 
-export const withSpinner = <P extends {}>(
-  Component: ComponentType<P>,
-  options?: SpinnerOptions,
-): FC<P & WithLoadingProps> => {
-  const WrappedComponent = ({ isLoading, ...props }: WithLoadingProps) => (
+export const withSpinner = <P extends {}>(Component: ComponentType<P>, options?: SpinnerOptions) => {
+  const WrappedComponent = ({ isLoading, ...props }: P & WithLoadingProps) => (
     <>
       {isLoading ? (
         <LoadingSpinner className={options?.className} size={options?.size} />
       ) : (
-        <Component {...(props as P)} />
+        <Component {...(props as unknown as P)} />
       )}
     </>
   )

--- a/src/components/MainContainer/MainContainer.tsx
+++ b/src/components/MainContainer/MainContainer.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { FC, PropsWithChildren } from 'react'
+import { PropsWithChildren } from 'react'
 import { ToastContainer } from 'react-toastify'
 import { useAccount } from 'wagmi'
 
@@ -13,7 +13,7 @@ import { ContainerDesktop } from './ContainerDesktop'
 import ContainerMobile from './ContainerMobile'
 import { LayoutProvider } from './LayoutProvider'
 
-export const MainContainer: FC<PropsWithChildren> = ({ children }) => {
+export const MainContainer = ({ children }: PropsWithChildren) => {
   const isDesktop = useIsDesktop()
   const { isConnected, chainId } = useAccount()
   const wrongNetwork = chainId !== currentEnvChain.id


### PR DESCRIPTION
## Summary
- Remove `FC` / `React.FC` type annotations, replacing with direct prop typing on function parameters
- Part of DAO-2223: changing `@typescript-eslint/no-restricted-types` from `warn` to `error`