### PR TITLE
DAO-2223 Remove FC type annotations (part 10)

### DIFF
--- a/src/components/MainContainer/drawers/BottomDrawer.tsx
+++ b/src/components/MainContainer/drawers/BottomDrawer.tsx
@@ -1,5 +1,4 @@
 import { AnimatePresence, motion, Transition, type Variants } from 'motion/react'
-import { FC } from 'react'
 import { createPortal } from 'react-dom'
 
 import { CommonComponentProps } from '@/components/commonProps'
@@ -25,7 +24,7 @@ interface BottomActionBarBaseProps extends CommonComponentProps {
   portalContainer?: HTMLElement | null
 }
 
-export const BottomDrawer: FC<BottomActionBarBaseProps> = ({ className = '', portalContainer }) => {
+export const BottomDrawer = ({ className = '', portalContainer }: BottomActionBarBaseProps) => {
   const { isSidebarOpen, isDrawerOpen, drawerContent, setDrawerRef } = useLayoutContext()
   const isDesktop = useIsDesktop()
 

--- a/src/components/Metric/Metric.tsx
+++ b/src/components/Metric/Metric.tsx
@@ -1,4 +1,4 @@
-import { FC, isValidElement, ReactNode } from 'react'
+import { isValidElement, ReactNode } from 'react'
 
 import { MetricTitle } from '@/components/Metric/MetricTitle'
 import { cn } from '@/lib/utils'
@@ -13,14 +13,14 @@ type MetricProps = CommonComponentProps & {
   'data-testid'?: string
 }
 
-export const Metric: FC<MetricProps> = ({
+export const Metric = ({
   title,
   children,
   className = '',
   containerClassName = '',
   contentClassName = '',
   'data-testid': dataTestId = 'Metric',
-}) => {
+}: MetricProps) => {
   return (
     <div data-testid={dataTestId} className={cn('flex items-center gap-4 w-full', className)}>
       <div className={cn('w-full flex flex-col gap-0.5 md:gap-2', containerClassName)}>

--- a/src/components/Metric/MetricContent.tsx
+++ b/src/components/Metric/MetricContent.tsx
@@ -1,4 +1,4 @@
-import { FC, PropsWithChildren } from 'react'
+import { PropsWithChildren } from 'react'
 
 import { cn } from '@/lib/utils'
 
@@ -6,7 +6,7 @@ import { CommonComponentProps } from '../../components/commonProps'
 
 type MetricContentProps = CommonComponentProps & PropsWithChildren
 
-export const MetricContent: FC<MetricContentProps> = ({ children, className }) => {
+export const MetricContent = ({ children, className }: MetricContentProps) => {
   return (
     <div className={cn('flex items-start font-kk-topo', className)} data-testid="MetricContent">
       {children}

--- a/src/components/Metric/MetricTitle.tsx
+++ b/src/components/Metric/MetricTitle.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { Paragraph } from '@/components/Typography'
 import { cn } from '@/lib/utils'
@@ -12,7 +12,7 @@ interface MetricTitleProps extends CommonComponentProps {
   infoIconProps?: Omit<InfoIconButtonProps, 'info'>
 }
 
-export const MetricTitle: FC<MetricTitleProps> = ({ title, info, className = '', infoIconProps }) => {
+export const MetricTitle = ({ title, info, className = '', infoIconProps }: MetricTitleProps) => {
   return (
     <div data-testid="MetricTitle" className={cn('flex w-full items-start gap-2', className)}>
       <Paragraph className="text-v3-bg-accent-0 text-sm md:text-base">{title}</Paragraph>

--- a/src/components/Modal/DisconnectWalletModal.tsx
+++ b/src/components/Modal/DisconnectWalletModal.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { Button } from '@/components/Button'
 import { Modal } from '@/components/Modal/Modal'
 import { Header, Paragraph, Span } from '@/components/Typography'
@@ -10,7 +8,7 @@ interface Props {
   onCancel: () => void
 }
 
-export const DisconnectWalletModal: FC<Props> = ({ onClose, onConfirm, onCancel }) => (
+export const DisconnectWalletModal = ({ onClose, onConfirm, onCancel }: Props) => (
   <Modal onClose={onClose} data-testid="DisconnectWalletModal">
     <div className="px-[50px] pt-[42px] pb-[84px] flex justify-center flex-col items-center">
       <Header variant="h2">DISCONNECT WALLET</Header>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FC, ReactNode, useRef } from 'react'
+import { ReactNode, useRef } from 'react'
 import { createPortal } from 'react-dom'
 
 import { cn } from '@/lib/utils'
@@ -23,7 +23,7 @@ export interface ModalProps {
  * Modal component that wraps the content of the modal and provides a close button.
  * On mobile, the modal is always fullscreen.
  */
-export const Modal: FC<ModalProps> = ({
+export const Modal = ({
   children,
   onClose,
   className,
@@ -31,7 +31,7 @@ export const Modal: FC<ModalProps> = ({
   height = 'auto',
   closeButtonColor = 'white',
   'data-testid': dataTestId,
-}) => {
+}: ModalProps) => {
   const portalContainerRef = useRef<HTMLDivElement>(null)
   const containerStyle: React.CSSProperties = {}
 

--- a/src/components/NewPopover/index.tsx
+++ b/src/components/NewPopover/index.tsx
@@ -22,7 +22,7 @@ interface NewPopoverProps {
   align?: 'start' | 'center' | 'end'
 }
 
-export const NewPopover: React.FC<NewPopoverProps> = ({
+export const NewPopover = ({
   open,
   onOpenChange,
   anchor = <span />,
@@ -37,7 +37,7 @@ export const NewPopover: React.FC<NewPopoverProps> = ({
   alignOffset = -24,
   side = 'top',
   align = 'end',
-}) => {
+}: NewPopoverProps) => {
   // If anchorRef is provided, create a hidden span and move it to the anchorRef's position
   const hiddenAnchorRef = useRef<HTMLSpanElement>(null)
   const portalContainer = usePortalContainer()

--- a/src/components/StackableBanner/BannerContent.tsx
+++ b/src/components/StackableBanner/BannerContent.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { Button } from '@/components/Button'
 import { Header, Paragraph } from '@/components/Typography'
@@ -13,14 +13,14 @@ export interface BannerContentProps {
   className?: string
 }
 
-export const BannerContent: FC<BannerContentProps> = ({
+export const BannerContent = ({
   title,
   description,
   buttonText,
   buttonOnClick,
   rightContent,
   className = '',
-}) => {
+}: BannerContentProps) => {
   return (
     <div
       className={cn(

--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -1,4 +1,4 @@
-import { FC, JSX } from 'react'
+import { JSX } from 'react'
 
 import { cn } from '@/lib/utils'
 import { ProposalState } from '@/shared/types'
@@ -59,7 +59,7 @@ const getVariants = (proposalState?: ProposalState): (typeof VARIANTS)[keyof typ
   return VARIANTS[ProposalState.None]
 }
 
-export const Status: FC<Props> = ({ proposalState, className, ...rest }) => {
+export const Status = ({ proposalState, className, ...rest }: Props) => {
   const { label, classes } = getVariants(proposalState)
 
   return (

--- a/src/components/Table/components/TableBody.tsx
+++ b/src/components/Table/components/TableBody.tsx
@@ -1,10 +1,10 @@
-import { FC, TableHTMLAttributes } from 'react'
+import { TableHTMLAttributes } from 'react'
 
 import { cn } from '@/lib/utils'
 
 /**
  * Tailwind styled wrapper around `tbody` element
  */
-export const TableBody: FC<TableHTMLAttributes<HTMLTableSectionElement>> = ({ className, ...props }) => {
+export const TableBody = ({ className, ...props }: TableHTMLAttributes<HTMLTableSectionElement>) => {
   return <tbody className={cn('text-sm leading-5', className)} {...props} />
 }


### PR DESCRIPTION
## Summary
- Remove `FC` / `React.FC` type annotations, replacing with direct prop typing on function parameters
- Part of DAO-2223: changing `@typescript-eslint/no-restricted-types` from `warn` to `error`