### PR TITLE
DAO-2223 Remove FC type annotations (part 11)

### DIFF
--- a/src/components/Table/components/TableCell.tsx
+++ b/src/components/Table/components/TableCell.tsx
@@ -1,10 +1,10 @@
-import { FC, TableHTMLAttributes } from 'react'
+import { TableHTMLAttributes } from 'react'
 
 import { cn } from '@/lib/utils'
 
 /**
  * Tailwind styled wrapper around `td` element
  */
-export const TableCell: FC<TableHTMLAttributes<HTMLTableCellElement>> = ({ className, ...props }) => {
+export const TableCell = ({ className, ...props }: TableHTMLAttributes<HTMLTableCellElement>) => {
   return <td className={cn('p-3 border-b', className)} {...props} />
 }

--- a/src/components/Table/components/TableCore.tsx
+++ b/src/components/Table/components/TableCore.tsx
@@ -1,11 +1,11 @@
-import { FC, TableHTMLAttributes } from 'react'
+import { TableHTMLAttributes } from 'react'
 
 import { cn } from '@/lib/utils'
 
 /**
  * Tailwind styled wrapper around `table` element
  */
-export const TableCore: FC<TableHTMLAttributes<HTMLTableElement>> = ({ className, children, ...props }) => {
+export const TableCore = ({ className, children, ...props }: TableHTMLAttributes<HTMLTableElement>) => {
   return (
     <div className={cn('w-full overflow-auto', className)} {...props}>
       <table className="w-full h-auto border-collapse">{children}</table>

--- a/src/components/Table/components/TableHead.tsx
+++ b/src/components/Table/components/TableHead.tsx
@@ -1,11 +1,11 @@
-import { FC, TableHTMLAttributes } from 'react'
+import { TableHTMLAttributes } from 'react'
 
 import { cn } from '@/lib/utils'
 
 /**
  * Tailwind styled wrapper around `thead` element
  */
-export const TableHead: FC<TableHTMLAttributes<HTMLTableSectionElement>> = ({ className, ...props }) => {
+export const TableHead = ({ className, ...props }: TableHTMLAttributes<HTMLTableSectionElement>) => {
   return (
     <thead className={cn('capitalize text-xs leading-4 [&_td]:py-3 bg-foreground', className)} {...props} />
   )

--- a/src/components/Table/components/TableRow.tsx
+++ b/src/components/Table/components/TableRow.tsx
@@ -1,8 +1,8 @@
-import { FC, TableHTMLAttributes } from 'react'
+import { TableHTMLAttributes } from 'react'
 
 /**
  * Tailwind styled wrapper around `tr` element
  */
-export const TableRow: FC<TableHTMLAttributes<HTMLTableRowElement>> = ({ className, ...props }) => {
+export const TableRow = ({ className, ...props }: TableHTMLAttributes<HTMLTableRowElement>) => {
   return <tr className={className} {...props} />
 }

--- a/src/components/TableNew/TableHeaderCell.tsx
+++ b/src/components/TableNew/TableHeaderCell.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { cn } from '@/lib/utils'
 
 import { CommonComponentProps } from '../commonProps'
@@ -8,12 +6,7 @@ interface TableHeaderCellProps extends CommonComponentProps<HTMLTableCellElement
   contentClassName?: string
 }
 
-export const TableHeaderCell: FC<TableHeaderCellProps> = ({
-  children,
-  className,
-  onClick,
-  contentClassName,
-}) => {
+export const TableHeaderCell = ({ children, className, onClick, contentClassName }: TableHeaderCellProps) => {
   return (
     <th
       className={cn(

--- a/src/components/TableNew/TableHeaderNode.tsx
+++ b/src/components/TableNew/TableHeaderNode.tsx
@@ -1,11 +1,9 @@
-import { FC } from 'react'
-
 import { cn } from '@/lib/utils'
 
 import { CommonComponentProps } from '../commonProps'
 
 export interface TableHeaderNodeProps extends CommonComponentProps {}
 
-export const TableHeaderNode: FC<TableHeaderNodeProps> = ({ children, className }) => {
+export const TableHeaderNode = ({ children, className }: TableHeaderNodeProps) => {
   return <div className={cn('flex flex-col items-start gap-1 cursor-[inherit]', className)}>{children}</div>
 }

--- a/src/components/TableNew/TablePager.tsx
+++ b/src/components/TableNew/TablePager.tsx
@@ -32,18 +32,23 @@ export interface TablePagerProps extends CommonComponentProps {
   renderPagerCount?: (ctx: TablePagerCountContext) => ReactNode
 }
 
-const PagerCount: React.FC<{
+const PagerCount = ({
+  start,
+  end,
+  total,
+  itemName,
+}: {
   start: number
   end: number
   total: number
   itemName: string
-}> = ({ start, end, total, itemName }) => (
+}) => (
   <Paragraph
     variant="body-xs"
     className="text-v3-bg-accent-0 select-none first-letter:uppercase"
     data-testid="table-pager-count"
   >
-    {itemName} {start} – {end} out of {total}
+    {itemName} {start}– {end}out of {total}
   </Paragraph>
 )
 type NextPageHandler = (props: {
@@ -90,7 +95,7 @@ const getDefaultRange = (pageSize: number, totalItems: number) => ({
  * @param mode - The mode of the pager (cyclic or expandable)
  * @param className - The className to apply to the pager
  */
-export const TablePager: React.FC<TablePagerProps> = ({
+export const TablePager = ({
   pageSize,
   totalItems = 0,
   pagedItemName,
@@ -98,7 +103,7 @@ export const TablePager: React.FC<TablePagerProps> = ({
   mode,
   renderPagerCount,
   className,
-}) => {
+}: TablePagerProps) => {
   if (!isMode(mode)) {
     throw new Error(`Invalid mode: ${mode}`)
   }

--- a/src/components/Typography/Header.tsx
+++ b/src/components/Typography/Header.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { EmphaseVariants, HeaderVariants, HtmlTypographyTag } from './types'
 import { BaseTypography, BaseTypographyProps } from './Typography'
 
@@ -41,7 +39,7 @@ export interface HeaderProps extends Omit<BaseTypographyProps<HtmlTypographyTag>
  * - h4: font-size: 16px; font-family: font-rootstock-sans - **Figma: Header/H4**
  * - h5: font-size: 12px; font-family: font-rootstock-sans - **Figma: Header/H5**
  */
-export const Header: FC<HeaderProps> = ({ variant = 'h1', children, 'data-testid': dataTestId, ...rest }) => (
+export const Header = ({ variant = 'h1', children, 'data-testid': dataTestId, ...rest }: HeaderProps) => (
   <BaseTypography as={elementByVariant[variant]} variant={variant} data-testid={dataTestId} {...rest}>
     {children}
   </BaseTypography>

--- a/src/components/Typography/Paragraph.tsx
+++ b/src/components/Typography/Paragraph.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { BodyVariants } from './types'
 import { BaseTypography, BaseTypographyProps } from './Typography'
 
@@ -26,12 +24,7 @@ interface Props extends Omit<BaseTypographyProps<'p'>, 'as'> {
  *
  * All variants support the `bold` prop for bold text.
  */
-export const Paragraph: FC<Props> = ({
-  variant = 'body',
-  children,
-  'data-testid': dataTestId = '',
-  ...rest
-}) => (
+export const Paragraph = ({ variant = 'body', children, 'data-testid': dataTestId = '', ...rest }: Props) => (
   <BaseTypography as="p" variant={variant} data-testid={`Paragraph${dataTestId}`} {...rest}>
     {children}
   </BaseTypography>

--- a/src/components/Typography/Span.tsx
+++ b/src/components/Typography/Span.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { BodyVariants, EmphaseVariants, HeaderVariants, TagVariants } from './types'
 import { BaseTypography, BaseTypographyProps } from './Typography'
 
@@ -46,7 +44,7 @@ interface Props extends Omit<BaseTypographyProps<'span'>, 'as'> {
  *
  * All variants support the `bold`, `caps`, and `html` props.
  */
-export const Span: FC<Props> = ({ variant = 'body', children, ...rest }) => (
+export const Span = ({ variant = 'body', children, ...rest }: Props) => (
   <BaseTypography as="span" variant={variant} {...rest}>
     {children}
   </BaseTypography>


### PR DESCRIPTION
## Summary
- Remove `FC` / `React.FC` type annotations, replacing with direct prop typing on function parameters
- Part of DAO-2223: changing `@typescript-eslint/no-restricted-types` from `warn` to `error`