### PR TITLE
DAO-2223 Remove FC type annotations (part 12)

### DIFF
--- a/src/components/containers/ActionMetricsContainer.tsx
+++ b/src/components/containers/ActionMetricsContainer.tsx
@@ -1,12 +1,10 @@
-import { FC } from 'react'
-
 import { cn } from '@/lib/utils'
 
 import { CommonComponentProps } from '../commonProps'
 
 type ActionMetricsContainerProps = CommonComponentProps
 
-export const ActionMetricsContainer: FC<ActionMetricsContainerProps> = ({ className = '', children }) => {
+export const ActionMetricsContainer = ({ className = '', children }: ActionMetricsContainerProps) => {
   return (
     <div
       data-testid={'ActionsMetrics'}

--- a/src/components/containers/ActionsContainer.tsx
+++ b/src/components/containers/ActionsContainer.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { cn } from '@/lib/utils'
 
@@ -9,12 +9,12 @@ interface ActionsContainerProps extends CommonComponentProps {
   containerClassName?: string
 }
 
-export const ActionsContainer: FC<ActionsContainerProps> = ({
+export const ActionsContainer = ({
   title,
   children,
   className = '',
   containerClassName = '',
-}) => {
+}: ActionsContainerProps) => {
   return (
     <div
       data-testid="ActionsContainer"

--- a/src/components/containers/InfoContainer.tsx
+++ b/src/components/containers/InfoContainer.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { cn } from '@/lib/utils'
 
 import { CommonComponentProps } from '../commonProps'
@@ -8,7 +6,7 @@ type InfoContainer = CommonComponentProps & {
   title?: string
 }
 
-export const InfoContainer: FC<InfoContainer> = ({ children, className = '', title }) => {
+export const InfoContainer = ({ children, className = '', title }: InfoContainer) => {
   return (
     <div
       className={cn('flex flex-col items-start gap-2 self-stretch p-6 pt-10 rounded-sm', className)}

--- a/src/components/containers/MetricsContainer.tsx
+++ b/src/components/containers/MetricsContainer.tsx
@@ -1,12 +1,10 @@
-import { FC } from 'react'
-
 import { cn } from '@/lib/utils'
 
 import { CommonComponentProps } from '../commonProps'
 
 type MetricsContainerProps = CommonComponentProps
 
-export const MetricsContainer: FC<MetricsContainerProps> = ({ className = '', children }) => {
+export const MetricsContainer = ({ className = '', children }: MetricsContainerProps) => {
   return (
     <div
       data-testid={'MetricsContainer'}

--- a/src/components/loading-components/CardPlaceholder.tsx
+++ b/src/components/loading-components/CardPlaceholder.tsx
@@ -1,6 +1,5 @@
 import { motion, Variants } from 'framer-motion'
 import Image from 'next/image'
-import { FC } from 'react'
 
 /**
  * This "shimmer" animation simply moves the background gradient
@@ -19,7 +18,7 @@ const shimmerVariants: Variants = {
   },
 }
 
-export const CardPlaceholder: FC = () => (
+export const CardPlaceholder = () => (
   <div className="rounded-sm bg-input-bg w-[300px] pb-4" data-testid="CommunityCardPlaceholder">
     {/* Image placeholder */}
     <div className="relative w-full h-[300px] mb-5">

--- a/src/shared/context/FeatureFlag/FeatureFlagContext.test.tsx
+++ b/src/shared/context/FeatureFlag/FeatureFlagContext.test.tsx
@@ -59,9 +59,13 @@ const mockGetEnvFlags = vi.mocked(flagUtils.getEnvFlags)
 const mockIsFeatureFlag = vi.mocked(flagUtils.isFeatureFlag)
 
 // Wrapper component for testing hooks
-const Wrapper: FC<{ children: ReactNode }> = ({ children }) => (
-  <FeatureFlagProvider>{children}</FeatureFlagProvider>
-)
+const Wrapper = (
+  {
+    children
+  }: {
+    children: ReactNode;
+  }
+) => (<FeatureFlagProvider>{children}</FeatureFlagProvider>)
 
 type FakeFeatureFlags = Record<
   FakeFeature,

--- a/src/shared/context/FeatureFlag/FeatureFlagContext.tsx
+++ b/src/shared/context/FeatureFlag/FeatureFlagContext.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, FC, ReactNode, useContext, useEffect, useState } from 'react'
+import { createContext, ReactNode, useContext, useEffect, useState } from 'react'
 
 import { Feature, getFeatures, USER_FLAGS_FEATURE } from '@/config/features.conf'
 
@@ -76,7 +76,7 @@ const combineUserFlags = (userFlags: Partial<FeatureFlags>): FeatureFlags => {
   }
 }
 
-export const FeatureFlagProvider: FC<{ children: ReactNode }> = ({ children }) => {
+export const FeatureFlagProvider = ({ children }: { children: ReactNode }) => {
   const [flags, setFlags] = useState<FeatureFlags>(() => getEnvFlags())
 
   useEffect(() => {

--- a/src/shared/context/FeatureFlag/withFeatureFlag.tsx
+++ b/src/shared/context/FeatureFlag/withFeatureFlag.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { ComponentType, FC } from 'react'
+import { ComponentType } from 'react'
 
 import { useFeatureFlags } from './FeatureFlagContext'
 import { DEFAULT_CONFIG, FeatureHandleConfig } from './withServerFeatureFlag'
@@ -15,7 +15,7 @@ export const withFeatureFlag = <P extends object>(
     ...config,
   }
 
-  const WithFeatureFlag: FC<P> = props => {
+  const WithFeatureFlag = (props: P) => {
     const { flags } = useFeatureFlags()
     const router = useRouter()
 

--- a/src/shared/context/FeatureFlag/withServerFeatureFlag.tsx
+++ b/src/shared/context/FeatureFlag/withServerFeatureFlag.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
-import type { ComponentType, FC } from 'react'
+import type { ComponentType } from 'react'
 
 import { type FeatureFlag, getEnvFlag } from './flags.utils'
 
@@ -9,7 +9,7 @@ export interface FeatureHandleConfig {
   redirectTo?: string
 }
 
-const DefaultFallback: FC = () => <></>
+const DefaultFallback = () => <></>
 
 export const DEFAULT_CONFIG: Partial<FeatureHandleConfig> = {
   fallback: <DefaultFallback />,
@@ -24,7 +24,7 @@ export const withServerFeatureFlag = <P extends object>(
     ...config,
   }
 
-  const WithServerFeatureFlag: FC<P> = props => {
+  const WithServerFeatureFlag = (props: P) => {
     if (!(getEnvFlag(feature) ?? false)) {
       if (redirectTo) {
         redirect(redirectTo)

--- a/src/shared/context/PricesContext.tsx
+++ b/src/shared/context/PricesContext.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, FC, ReactNode, useContext, useMemo } from 'react'
+import { ComponentType, createContext, ReactNode, useContext, useMemo } from 'react'
 
 import { useGetSpecificPrices } from '@/app/user/Balances/hooks/useGetSpecificPrices'
 import { GetPricesResult } from '@/app/user/types'
@@ -27,7 +27,7 @@ const PricesContextProvider = ({ children }: Props) => {
 
 export const usePricesContext = () => useContext(PricesContext)
 
-export const withPricesContextProvider = <P extends object>(Component: FC<P>) => {
+export const withPricesContextProvider = <P extends object>(Component: ComponentType<P>) => {
   return function WrapperComponent(props: P) {
     return (
       <PricesContextProvider>


### PR DESCRIPTION
## Summary
- Remove `FC` / `React.FC` type annotations, replacing with direct prop typing on function parameters
- Part of DAO-2223: changing `@typescript-eslint/no-restricted-types` from `warn` to `error`