### PR TITLE
DAO-2223 Change no-restricted-types from warn to error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -129,7 +129,7 @@ const config = [
         },
       ],
       '@typescript-eslint/no-restricted-types': [
-        'warn',
+        'error',
         {
           types: {
             FC: {


### PR DESCRIPTION
## Summary
- Change `@typescript-eslint/no-restricted-types` severity from `warn` to `error` in `eslint.config.mjs`
- Merge **after** all DAO-2223 part PRs that remove FC type annotations