### PR TITLE
DAO-2235 Add static HTTP response headers

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -20,6 +20,36 @@ if (process.env.NODE_ENV !== 'production') {
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
+  poweredByHeader: false,
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=(), payment=(), usb=()',
+          },
+        ],
+      },
+    ]
+  },
   experimental: {
     serverSourceMaps: true,
   },


### PR DESCRIPTION
## Summary
- Add 5 standard HTTP security response headers (HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy) via `headers()` in `next.config.mjs`
- Suppress `x-powered-by: Next.js` header via `poweredByHeader: false`