### PR TITLE
DAO-2226 When 1 feeTier from available ones doesn't have liquidity "auto" fails

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -67,7 +67,7 @@ jobs:
           echo "Fork block: $FORK_BLOCK"
           # Start Anvil fork in background for swap execution tests
           # Fork is required for testing swap execution (write operations) without spending real funds
-          anvil --fork-url $ROOTSTOCK_RPC_URL --chain-id 31337 --fork-block-number $FORK_BLOCK --timeout 120000 > /tmp/anvil.log 2>&1 &
+          anvil --fork-url $ROOTSTOCK_RPC_URL --chain-id 31337 --fork-block-number $FORK_BLOCK --timeout 120000 --gas-limit 500000000 > /tmp/anvil.log 2>&1 &
           echo $! > /tmp/anvil.pid
           # Wait for fork to be ready (with timeout)
           timeout=30

--- a/docs/FORK_SETUP.md
+++ b/docs/FORK_SETUP.md
@@ -23,6 +23,60 @@ This guide uses [Foundry's Anvil](https://getfoundry.sh/guides/forking-mainnet-w
 
 **Solution**: Use `testnet` environment for Vault testing, `fork` environment for swap testing.
 
+## Swaps, Multicall3, and why Anvil gas limits matter
+
+This section is for anyone new to the repo **or** to Ethereum JSON-RPC. It explains how the app loads swap quotes on a fork and why `npm run fork:anvil` uses the flags it does.
+
+### Background: reading contracts without sending a transaction
+
+To show “you will receive X” for a swap, the app must **ask the chain** what Uniswap’s **Quoter** contract would return. Those asks are **read-only**: they do not move funds. Over HTTP, the usual JSON-RPC method is **`eth_call`**: “simulate this contract call at the latest block and return the result.”
+
+Each `eth_call` has a **gas budget** (how much EVM work the node allows for that simulation). If the simulation needs more gas than allowed, the node returns an error such as **`EVM error OutOfGas`** (often with JSON-RPC code **`-32603`**). That is **not** the same as “no liquidity”—it means the **node refused to finish the simulation**.
+
+### Why there are many reads for one swap (Auto fee tier)
+
+Uniswap V3 splits the same token pair into **separate pools** by **fee tier** (e.g. 0.01%, 0.05%, 0.3%, 1%). In **Auto** mode the app does not know in advance which pool has the best price, so it **probes every standard tier** by calling the Quoter once per tier (four reads for a single-hop pair).
+
+Doing four separate `eth_call`s to the public RPC works but is **slow** (four round trips). The app instead batches those reads.
+
+### What Multicall3 is (in one paragraph)
+
+**Multicall3** is a small, widely deployed **helper contract** (address `0xcA11…` on many chains, including Rootstock mainnet). Its popular entrypoint is **`aggregate3`**: you pass a list of `(target, callData, allowFailure)` entries. The contract **runs each inner call in one EVM execution**. From the **RPC client’s perspective**, that is still **one** outer `eth_call` to Multicall3—not four `eth_call`s to the Quoter.
+
+Libraries like **viem** expose this as `publicClient.multicall({ contracts: [...] })`. The Uniswap swap provider (`src/lib/swap/providers/uniswap.ts`) uses that for **Auto** fee quoting, multihop fee combinations, and **available fee tier** probes (`getAvailableFeeTiers`).
+
+### Inner failures vs outer failures (important for debugging)
+
+With **`allowFailure: true`** (viem’s default here), if one Quoter call **reverts** (e.g. pool missing for that tier), Multicall3 **still returns**: you get a **per-item** `success` / `failure` in the result. That is expected.
+
+A different class of problem is when the **entire** outer `eth_call` to Multicall3 **fails** (whole batch **OutOfGas**, transport error, etc.). Then **viem throws** before you get per-tier results. On a **local Anvil fork**, heavy batched simulations hit this more often than on many **public** nodes, because **Anvil is not the same software** as the Rootstock RPC: same forked **state**, different **simulation rules and gas limits**.
+
+### Why `npm run fork:anvil` sets `--gas-limit 500000000`
+
+Anvil applies a **block gas limit** to simulations. The default is often **much lower** than what a large Multicall3 + Uniswap Quoter simulation needs. Raising the limit with **`--gas-limit 500000000`** gives `eth_call` headroom so **one batched** quote probe is less likely to fail with **outer** OutOfGas.
+
+**Restart Anvil** after changing this script so the new limit is in effect.
+
+**Note:** `anvil` does **not** allow **`--gas-limit`** and **`--disable-block-gas-limit`** together (it will exit with a CLI error). Pick one approach; we standardized on a **high explicit `--gas-limit`** for predictability.
+
+### What the app does when the outer multicall still fails (`multicallWithGasEnvelopeRetry`)
+
+If the **whole** Multicall3 `eth_call` fails with errors that look like **OutOfGas / RPC `-32603` / “EVM error”**, the code **retries once** with viem’s **`batchSize: 1`**. In viem’s multicall implementation, that threshold is based on **encoded calldata size**, so in practice it forces **smaller chunks** (often **one Quoter read per outer `eth_call`**). You get **more** RPC round trips, but quotes still work on strict environments.
+
+This helper lives in:
+
+- `src/lib/swap/multicallWithGasEnvelopeRetry.ts`
+
+It is used for **Uniswap quoter batching** and for **`getTokenDecimalsBatch`** in `src/lib/swap/utils.ts` (decimals for multiple tokens in **one** multicall, with **deduplicated** addresses).
+
+### CI uses the same Anvil gas limit as local dev
+
+GitHub Actions starts Anvil for fork tests with the **same** `--gas-limit 500000000` as `package.json` → `fork:anvil`, so CI does not fail quotes that pass locally only because of a higher block gas limit.
+
+### How to inspect RPC traffic yourself
+
+Use your browser’s **Developer Tools → Network** tab (filter by **Fetch/XHR**) while the app talks to `http://127.0.0.1:8545`. Each JSON-RPC request is typically one HTTP POST; look for **`eth_call`** in the payload. A successful **batched** Multicall3 quote is usually **one** `eth_call` to the multicall contract, not one per fee tier.
+
 ## ⚠️ Important: Add Fork Network to MetaMask First
 
 **Yes, you need to add the fork network to MetaMask** to connect your wallet to the local Anvil fork.
@@ -36,6 +90,8 @@ This guide uses [Foundry's Anvil](https://getfoundry.sh/guides/forking-mainnet-w
    ```
 
    Keep this terminal running! Anvil must be active for MetaMask to connect.
+
+   The script sets **`--gas-limit 500000000`** so batched Multicall3 quote simulations are less likely to hit outer `OutOfGas` on Anvil. See [Swaps, Multicall3, and why Anvil gas limits matter](#swaps-multicall3-and-why-anvil-gas-limits-matter). **Restart Anvil** after changing fork flags.
 
 2. **Open MetaMask** and click the network dropdown (usually shows "Ethereum Mainnet" or similar)
 3. **Click "Add Network"** or "Add a network manually"

--- a/docs/SWAP_ARCHITECTURE.md
+++ b/docs/SWAP_ARCHITECTURE.md
@@ -1,312 +1,321 @@
-# Swap feature — architecture and onboarding guide
+# How swapping works in this app
 
-This document explains how token swapping works in this repository: user journey, supported assets, state, quoting, on-chain execution, and where to read code. It is written for junior engineers, QA, and product owners who need a reliable mental model without reading the whole codebase first.
+You can swap **three tokens only**: USDT0, USDRIF, and RIF. The app asks the chain how much you would get (a **quote**), then helps you approve and sign, then runs the trade on **Uniswap V3** on Rootstock.
 
-**Branch / baseline:** Documentation was authored on branch `dao-2217` (created from `origin/dao-2226`). Swap logic lives primarily under `src/lib/swap/`, `src/shared/stores/swap/`, `src/app/user/Swap/`, and `src/app/api/swap/`.
+Most code for this lives in:
 
----
+- `src/lib/swap/` — math, paths, quotes, and transaction data
+- `src/shared/stores/swap/` — what the screen remembers and the React hooks that talk to the chain
+- `src/app/user/Swap/` — the swap popup and its three steps
+- `src/app/api/swap/` — an HTTP endpoint that can get a quote (same idea as inside the popup)
 
-## 1. What swapping does (one paragraph)
-
-The app lets users trade between **three fixed tokens** (USDT0, USDRIF, RIF) on Rootstock using **Uniswap V3** infrastructure: **QuoterV2** estimates output or required input, and the **Universal Router** executes a **V3 exact-in swap**. For **USDRIF ↔ RIF** there is **no direct pool in the routing table**, so the product uses a **two-hop path through USDT0**. Approvals use **Permit2**: the user first approves the ERC-20 to Permit2, then signs an EIP-712 **spending cap**, and finally sends **one transaction** that runs **PERMIT2_PERMIT + V3_SWAP_EXACT_IN** on the Universal Router.
-
----
-
-## 2. Supported tokens and pairs
-
-| Symbol  | Role in product | Notes |
-|---------|-----------------|--------|
-| **USDT0** | Primary stable routing asset | Bridge token for USDRIF ↔ RIF |
-| **USDRIF** | Dollar-pegged RIF derivative | Pairs directly with USDT0 |
-| **RIF**   | Native/governance-oriented asset | Reaches USDRIF via USDT0 multihop |
-
-Canonical lists in code:
-
-- `SWAP_FLOW_TOKEN_SYMBOLS` and `SWAP_TOKEN_ADDRESSES` in `src/lib/swap/constants.ts` — addresses come from `tokenContracts` / env (`NEXT_PUBLIC_*_ADDRESS`).
-- UI token metadata (decimals, names) in `src/shared/stores/swap/useSwapTokens.ts`.
-
-**Important:** Other DEX names appear in constants (`ICECREAMSWAP`, `OPENOCEAN`) for future or historical wiring, but **quotes and execution in this branch use Uniswap only** (`uniswapProvider`).
+*This file was added on branch `dao-2217` (from `origin/dao-2226`).*
 
 ---
 
-## 3. End-to-end user flow (UI)
+## 1. The big picture
 
-The swap UI is a **modal wizard** (`SwappingFlow`), opened from the vault area (`VaultActions` renders `SwappingFlow` when the user opens swap).
+**What the user does**
+
+1. Pick how much to send or how much they want to receive.
+2. The app shows an estimate from **QuoterV2** (a read-only contract that simulates the swap).
+3. If needed, they approve the token for **Permit2** (a helper contract Uniswap uses).
+4. They sign a **spending cap** in the wallet (no gas for this step — it is just a signature).
+5. They confirm **one** on-chain transaction. The **Universal Router** runs the permit step and then the **V3_SWAP_EXACT_IN** swap in the same transaction.
+
+**USDRIF and RIF**
+
+There is no single pool that swaps USDRIF and RIF directly in our route list. So the app always routes that pair through **USDT0**: for example USDRIF → USDT0 → RIF (two steps on the path, called **multihop**).
+
+---
+
+## 2. The three tokens
+
+| Token   | Plain meaning |
+|---------|----------------|
+| **USDT0** | Stable value token; also used as the “middle” hop between USDRIF and RIF. |
+| **USDRIF** | A dollar-linked RIF-related token; swaps straight against USDT0. |
+| **RIF**   | The main RIF token; to reach USDRIF the path goes through USDT0. |
+
+Where the addresses and symbols are set:
+
+- `src/lib/swap/constants.ts` — `SWAP_TOKEN_ADDRESSES`, `SWAP_FLOW_TOKEN_SYMBOLS`
+- `src/shared/stores/swap/useSwapTokens.ts` — names and decimals for the UI
+
+You may see other exchange names in constants (for example IceCream, OpenOcean). **Right now only Uniswap is wired up** for real quotes and swaps (`uniswapProvider`).
+
+---
+
+## 3. The three steps in the popup
+
+The swap screen is a **modal** (`SwappingFlow`). It opens from the vault actions area when the user chooses swap.
 
 ```mermaid
 flowchart LR
-  subgraph step1 [Step 1 - Select amount]
-    A[Pick tokens + amount] --> B[Quote via Uniswap]
-    B --> C{ERC20 allowance to Permit2?}
-    C -->|No| D[Approve unlimited to Permit2]
+  subgraph step1 [Step 1]
+    A[Amount and tokens] --> B[Get quote]
+    B --> C{Token approved for Permit2?}
+    C -->|No| D[Approve]
     C -->|Yes| E[Continue]
     D --> E
   end
-  subgraph step2 [Step 2 - Permit]
-    F[Sign Permit2 spending cap] --> G[EIP-712 off-chain]
+  subgraph step2 [Step 2]
+    F[Sign spending cap]
   end
-  subgraph step3 [Step 3 - Confirm]
-    H[Choose slippage] --> I[Compute min out]
-    I --> J[Universal Router execute]
+  subgraph step3 [Step 3]
+    G[Pick slippage] --> H[Confirm swap tx]
   end
   step1 --> step2 --> step3
 ```
 
-| Step | File | User-visible purpose |
-|------|------|---------------------|
-| 1 | `SwapStepOne.tsx` | Enter **exact-in** or **exact-out** amount, pick fee tier (Auto or fixed), optional % of balance, flip tokens, continue or **Approve & Continue** |
-| 2 | `SwapStepTwo.tsx` | **Sign spending cap** (Permit2 + Universal Router); auto-skips if prior signature still covers amount |
-| 3 | `SwapStepThree.tsx` | Review from/to, pick **slippage**, see **minimum received**, confirm **one on-chain tx** |
+| Step | Code file | What the user sees |
+|------|-----------|-------------------|
+| 1 | `SwapStepOne.tsx` | Type **amount in** or **amount out**, pick pool fee (**Auto** or a fixed tier), optional % of balance, flip direction, then **Continue** or **Approve & Continue**. |
+| 2 | `SwapStepTwo.tsx` | **Sign spending cap** so the router can spend the exact amount. If an old signature still covers the amount, this step can skip ahead. |
+| 3 | `SwapStepThree.tsx` | Check summary, pick **slippage**, see **minimum you receive**, press **Confirm swap**. |
 
-Supporting UI:
+Other pieces:
 
-- `SwappingFlow.tsx` — modal shell, progress bar, step routing, resets `useSwapStore` on close.
-- `SwapSteps.tsx` — step labels (SELECT AMOUNT → REQUEST ALLOWANCE → CONFIRM SWAP).
-- `SwapInputComponent.tsx` — amount input, token dropdown, USD hint, balance line.
-- `SwapStepWarning.tsx` / `LowLiquidityWarning` — standardized warning styling; low-liquidity copy from `low-liquidity-warning.ts`.
-- `useSwapSmartDefault.ts` — on modal open, if user has no USDT0, prefers USDRIF or RIF as “From” (`smart-default-direction.ts`).
-
----
-
-## 4. Architecture layers
-
-| Layer | Responsibility |
-|-------|----------------|
-| **UI (Swap steps)** | Collects intent, drives wagmi txs/signing, shows warnings |
-| **Zustand (`useSwapStore`)** | Tokens, typed amount, mode, fee tier selection, permit payload, swap tx lifecycle |
-| **Hooks (`shared/stores/swap/hooks.ts`)** | Quotes (React Query), allowance, permit signing, swap execution |
-| **`src/lib/swap`** | Route resolution, Uniswap path encoding, Quoter calls, Universal Router calldata, Permit2 helpers |
-| **API `GET /api/swap/quote`** | Server-side quote using same provider stack (integrators, tests, or future clients) |
-| **On-chain** | ERC20 `approve` → Permit2; `UniversalRouter.execute` with bundled permit + swap |
-
-**Dual quote paths (good to know for QA):**
-
-- **In-modal quotes** call `uniswapProvider` **directly from the browser** via `useSwapInput` (same logic as server, but no HTTP hop).
-- **`useSwapQuote`** + **`/api/swap/quote`** exist for **HTTP/React Query** consumers; the live wizard does **not** depend on `useSwapQuote`.
+- `SwappingFlow.tsx` — popup frame, progress bar, which step is shown; clears swap state when closed.
+- `SwapSteps.tsx` — the labels: SELECT AMOUNT → REQUEST ALLOWANCE → CONFIRM SWAP.
+- `SwapInputComponent.tsx` — amount box, token picker, balance, USD hint.
+- `SwapStepWarning.tsx` / `LowLiquidityWarning` — warning layout and the low-liquidity message.
+- `useSwapSmartDefault.ts` + `smart-default-direction.ts` — when the popup opens, if the user has no USDT0, the app may default “From” to USDRIF or RIF so they do not have to fix tokens first.
 
 ---
 
-## 5. Routing: when swaps are one-hop vs multihop
+## 4. How the code is split (layers)
 
-`resolveSwapRoute(tokenIn, tokenOut)` in `src/lib/swap/routes.ts` returns an ordered list of token addresses:
+Think of it as layers from the screen down to the chain:
 
-- **Default:** `[tokenIn, tokenOut]` (single hop).
-- **USDRIF ↔ RIF:** `[USDRIF, USDT0, RIF]` or `[RIF, USDT0, USDRIF]` depending on direction.
+| Layer | Job |
+|-------|-----|
+| Swap step components | Buttons, inputs, warnings; start wallet actions. |
+| **`useSwapStore` (Zustand)** | Which tokens, typed amount, fee choice, permit data, swap transaction state. **Live quote numbers are not stored here** — they come from React Query in the hooks. |
+| **`hooks.ts`** | Fetches quotes, checks allowance, signs permit, sends the swap transaction. |
+| **`src/lib/swap`** | Builds the route, talks to **QuoterV2**, builds **Universal Router** calldata, Permit2 helpers. |
+| **`GET /api/swap/quote`** | Same quote logic on the server (tests, other callers, or future features). |
+| Chain | `approve` on the token; `execute` on the Universal Router. |
 
-Helpers:
+**Two ways to get a quote (easy to mix up)**
 
-- **`isMultihopRoute`** — `tokens.length > 2`.
-- **`getSwapRouteCacheKey`** — stable string for React Query keys.
-
-**Why it exists:** Uniswap V3 quotes and swaps need a **path** of `(token, fee, token, fee, …)`. The resolver fixes topology so Quoter and execution always agree on intermediates.
-
----
-
-## 6. Fee tiers vs slippage (frequent confusion)
-
-- **Fee tier (pool fee):** Uniswap V3 splits liquidity into pools with fees **100, 500, 3000, 10000** (basis points of the trade, i.e. 0.01%–1%). **Auto** mode asks the Quoter for many combinations and picks the economically best result. **Manual** tier on a multihop route uses the **same** uint24 fee on **every** hop (uniform path).
-- **Slippage (Step 3):** User-selected protection on **minimum output** (`amountOutMinimum`) for the **V3_SWAP_EXACT_IN** command. It is **not** the pool fee.
+- **Inside the popup:** `useSwapInput` calls `uniswapProvider` **in the browser** (no HTTP round trip).
+- **HTTP:** `useSwapQuote` calls **`/api/swap/quote`**. The popup does **not** use `useSwapQuote`.
 
 ---
 
-## 7. Permit2 and Universal Router
+## 5. Route: one hop or two hops
 
-1. **ERC-20 `approve(token, Permit2, MAX)`** — one-time per token (Step 1). Implemented in `useTokenAllowance` via standard `approve` (ABI reused from `RIFTokenAbi` for ERC20).
-2. **`signTypedData` PermitSingle** — authorizes Universal Router to pull **exactly** the signed amount from Permit2 (Step 2). Built with `createSecurePermit` in `src/lib/swap/permit2.ts`; nonce read from Permit2 `allowance(owner, token, spender)`.
-3. **`execute(commands, inputs)`** on Universal Router — `getPermitSwapEncodedData` encodes **`0x0a` (PERMIT2_PERMIT) + `0x00` (V3_SWAP_EXACT_IN)** with the V3 path bytes (`src/lib/swap/providers/uniswap.ts`).
+`resolveSwapRoute` in `src/lib/swap/routes.ts` returns the ordered list of token addresses.
 
-If execution fails with **AllowanceExpired** (`0xd81b2f2e`), the user must return to Step 2 and sign again (handled in `useSwapExecution`).
+- **Most pairs:** two tokens only — one hop.
+- **USDRIF ↔ RIF:** three tokens — always through USDT0.
 
----
+Small helpers:
 
-## 8. Reference: main functions and types
+- `isMultihopRoute` — true when there are more than two tokens in the list.
+- `getSwapRouteCacheKey` — a string key so React Query does not reuse the wrong cached quote when the pair changes.
 
-Below: **what it does**, **why it exists**, **role in swapping**.
-
-### 8.1 `src/lib/swap/constants.ts`
-
-| Export | Role |
-|--------|------|
-| `SWAP_TOKEN_ADDRESSES` | Central map of swap-eligible token addresses |
-| `SWAP_FLOW_TOKEN_SYMBOLS` | The three symbols exposed in the UI |
-| `ROUTER_ADDRESSES` / `POOL_ADDRESSES` | Env-backed contract addresses for quoting and hints |
-| `SWAP_PROVIDERS` | Provider name union (`uniswap`, etc.) |
-| `UNISWAP_FEE_TIERS` | `[100, 500, 3000, 10000]` |
-| `feeTierToPercent` | Display helper (tier / 10_000) |
-
-### 8.2 `src/lib/swap/routes.ts`
-
-| Function | Why |
-|----------|-----|
-| `resolveSwapRoute` | Deterministic path for Quoter + execution (incl. USDRIF–RIF via USDT0) |
-| `isMultihopRoute` | Branches quoting/encoding logic |
-| `getSwapRouteCacheKey` | Invalidates React Query when pair topology changes |
-
-### 8.3 `src/lib/swap/utils.ts`
-
-| Function | Why |
-|----------|-----|
-| `scaleAmount` | Human string → `bigint` via `viem` `parseUnits` (API route) |
-| `isValidAmount` | Positive decimal guard for API |
-| `getTokenDecimals` | On-chain `decimals()` read (single token) |
-| `getTokenDecimalsBatch` | Multicall decimals for API (one round-trip, deduped addresses) |
-| `calculatePriceImpact` | **Utility** comparing effective vs spot price; used in tests / future UI, not wired into the current swap modal quote display |
-
-### 8.4 `src/lib/swap/multicallWithGasEnvelopeRetry.ts`
-
-| Function | Why |
-|----------|-----|
-| `multicallWithGasEnvelopeRetry` | Some RPCs reject large `aggregate3` calls; retries with smaller batches |
-| `isLikelyOuterMulticallRpcFailure` | Classifies outer RPC failures vs per-call reverts |
-
-### 8.5 `src/lib/swap/providers/uniswap.ts` (core provider)
-
-**Path encoding**
-
-| Function | Role |
-|----------|------|
-| `encodeFeeUint24Hex` | Packs uint24 fee into path bytes |
-| `encodeUniformFeeSwapPath` | Same fee every hop |
-| `encodePerHopFeeSwapPath` | Distinct fee per hop (Auto multihop search) |
-
-**Quoting**
-
-| Function | Role |
-|----------|------|
-| `getUniswapQuote` / `getUniswapExactOutputQuote` | Main entry: resolve route, single-hop vs multihop, Auto vs explicit tier |
-| `getBestQuoteFromAllTiers` / `getBestExactOutputFromAllTiers` | Multicall all single-hop tiers, pick best |
-| `getBestMultihopQuoteExactIn` / `…ExactOut` | Cartesian product of tier combinations (up to 3 hops policy) |
-| `cartesianFeeCombinations` | Builds fee lists for multihop probes |
-
-**Execution helpers**
-
-| Function | Role |
-|----------|------|
-| `getSwapEncodedData` | `V3_SWAP_EXACT_IN` only (no permit) — lower-level building block |
-| `getPermitSwapEncodedData` | **Production path**: permit + swap commands for Universal Router |
-| `getAvailableFeeTiers` | Probes which tiers return positive output (powers Step 1 fee buttons) |
-
-**Export**
-
-| Export | Role |
-|--------|------|
-| `uniswapProvider` | `SwapProvider` implementation (`getQuote`, `getQuoteExactOutput`) |
-
-**Error handling:** Infrastructure errors propagate; Quoter reverts often become user-facing “no liquidity” messages (`swapQuoteNoLiquidityExplicitTier`).
-
-### 8.6 `src/lib/swap/permit2.ts`
-
-| Area | Role |
-|------|------|
-| Types (`PermitSingle`, `PermitDetails`, …) | Match Uniswap Permit2 EIP-712 layout |
-| `validateSpender`, `validateAmount`, `validateExpiration`, `validateNonce`, `validateChainId`, `validateToken` | Defense-in-depth before signing |
-| `validatePermitParams` | Aggregates validation for tooling/tests |
-| `createPermitSingle` | Builds struct + deadlines |
-| `createPermit2Domain` / `createTypedDataForPermit` | Wallet `signTypedData` input |
-| `createSecurePermit` | **Used in app** — validates then returns permit + typed data |
-| `validateSignatureFormat` | Basic hex length / `v` checks |
-
-### 8.7 `src/lib/swap/providers/index.ts`
-
-Defines **`SwapProvider`**, **`SwapQuote`**, **`QuoteParams`**, **`QuoteExactOutputParams`** — shared interface if additional DEX adapters are added later.
-
-### 8.8 `src/shared/stores/swap/useSwapStore.ts`
-
-Zustand actions: token pair, `mode` + `typedAmount`, fee tier, permit blobs, swap/approval tx hashes, `reset` on modal close. **Quotes and allowances are not stored here** (React Query / wagmi).
-
-### 8.9 `src/shared/stores/swap/hooks.ts`
-
-| Hook | Role |
-|------|------|
-| `useSwapInput` | Debounced quoting, exact-in/out switching, `availableFeeTiers`, quote staleness (~30s), syncs `poolFee` from quote |
-| `useTokenSelection` | Thin wrapper over store + `useSwapTokens` |
-| `useTokenAllowance` | Reads allowance to Permit2; `approve` unlimited to Permit2 |
-| `usePermitSigning` | Fetches Permit2 nonce, `createSecurePermit`, `signTypedData` |
-| `useSwapExecution` | `getPermitSwapEncodedData` + `execute` on Universal Router |
-
-Helper **`normalizeQuoteResult`** maps provider response into **`QuoteResult`** (bigint fields for UI math).
-
-### 8.10 `src/app/api/swap/quote/route.ts`
-
-| Piece | Role |
-|-------|------|
-| `GET` | Validates addresses/amount, batch-reads decimals, calls `uniswapProvider.getQuote`, returns `{ quotes }` |
-| `revalidate = 30` | Next.js cache hint aligned with quote TTL |
-
-### 8.11 `src/shared/hooks/useSwapQuote.ts`
-
-React Query wrapper around **`/api/swap/quote`**. Useful for **non-modal** consumers; swap modal uses **`useSwapInput`** instead.
-
-### 8.12 User swap utilities
-
-| Module | Role |
-|--------|------|
-| `smart-default-direction.ts` | `getSmartDefaultSwapDirection` — balance-based default pair |
-| `low-liquidity-warning.ts` | `shouldShowLowLiquidityWarning` — USD-based or stable-to-stable heuristic, >5% loss warning |
+**Why:** Uniswap V3 needs a **path**: token, fee, token, fee, … The resolver makes sure the quote step and the send-transaction step use the **same** path.
 
 ---
 
-## 9. Environment variables (operations)
+## 6. Pool fee vs slippage (not the same thing)
 
-Swap-related **public** env vars (see `src/lib/constants.ts`):
+**Pool fee (fee tier)**
+
+Uniswap splits liquidity into pools with different trading fees. Our app uses the standard tiers **100, 500, 3000, 10000** (think of them as **0.01%**, **0.05%**, **0.3%**, **1%** of the trade).
+
+- **Auto:** the app asks for many combinations and picks the best outcome.
+- **Manual tier on a multihop path:** the **same** fee tier is used on **every** hop (uniform path).
+
+**Slippage (step 3)**
+
+The user picks how much worse than the quote they still accept (for example 0.5%). The app turns that into a **minimum output** amount for the swap command. That is **slippage**, not the pool fee.
+
+---
+
+## 7. Permit2 and Universal Router (short version)
+
+1. **Approve** — Step 1 may send an ERC-20 `approve` so **Permit2** is allowed to move the token (`useTokenAllowance`). The app often approves the maximum once so the user is not asked again and again.
+2. **Sign** — Step 2 builds a **PermitSingle** message and the user signs it (`createSecurePermit` in `permit2.ts`). This says how much the **Universal Router** may pull via Permit2.
+3. **Swap** — Step 3 sends one transaction to **Universal Router** `execute`. The payload bundles **PERMIT2_PERMIT** then **V3_SWAP_EXACT_IN** (`getPermitSwapEncodedData` in `uniswap.ts`).
+
+If the wallet error mentions **AllowanceExpired** (or code `0xd81b2f2e`), the signed cap expired or is wrong — go back to Step 2 and sign again (`useSwapExecution` handles that message).
+
+---
+
+## 8. What each main piece of code does
+
+Short notes: **what** / **why it matters for swapping**.
+
+### `src/lib/swap/constants.ts`
+
+| Name | What it does |
+|------|----------------|
+| `SWAP_TOKEN_ADDRESSES` | Addresses for the three swap tokens. |
+| `SWAP_FLOW_TOKEN_SYMBOLS` | The three symbols shown in the UI. |
+| `ROUTER_ADDRESSES`, `POOL_ADDRESSES` | Contract addresses from env. |
+| `UNISWAP_FEE_TIERS` | The four fee numbers the app tries. |
+| `feeTierToPercent` | Turns a tier into a percent string for display. |
+
+### `src/lib/swap/routes.ts`
+
+| Function | What it does |
+|----------|----------------|
+| `resolveSwapRoute` | Picks the token list for the path (adds USDT0 between USDRIF and RIF when needed). |
+| `isMultihopRoute` | True if the path has more than one hop. |
+| `getSwapRouteCacheKey` | Cache key for quotes when the route changes. |
+
+### `src/lib/swap/utils.ts`
+
+| Function | What it does |
+|----------|----------------|
+| `scaleAmount` | Turns a typed string amount into chain units (`bigint`) for the API. |
+| `isValidAmount` | Rejects empty or non-positive amounts for the API. |
+| `getTokenDecimals` | Reads `decimals()` from one token contract. |
+| `getTokenDecimalsBatch` | Reads decimals for several tokens in one multicall (used by the quote API). |
+| `calculatePriceImpact` | Helper for comparing price vs a reference; **not** shown in the swap modal today (tests / future use). |
+
+### `src/lib/swap/multicallWithGasEnvelopeRetry.ts`
+
+| Function | What it does |
+|----------|----------------|
+| `multicallWithGasEnvelopeRetry` | Batches many read calls; if the RPC rejects the big batch (gas limit), retries with smaller batches. |
+| `isLikelyOuterMulticallRpcFailure` | Helps tell “whole batch failed” from “one pool call reverted”. |
+
+### `src/lib/swap/providers/uniswap.ts`
+
+**Building paths**
+
+| Function | What it does |
+|----------|----------------|
+| `encodeUniformFeeSwapPath` | Path bytes with one fee for every hop. |
+| `encodePerHopFeeSwapPath` | Path bytes when each hop can have its own fee. |
+
+**Quotes**
+
+| Function | What it does |
+|----------|----------------|
+| `getUniswapQuote` / `getUniswapExactOutputQuote` | Main quote entry: picks route, single vs multihop, Auto vs fixed fee. |
+| `getBestQuoteFromAllTiers` / `getBestExactOutputFromAllTiers` | Single hop: try all four fees, pick best. |
+| `getBestMultihopQuoteExactIn` / `…ExactOut` | Multihop: try fee combinations, pick best. |
+| `cartesianFeeCombinations` | Builds the list of fee combinations to try. |
+
+**Transactions**
+
+| Function | What it does |
+|----------|----------------|
+| `getSwapEncodedData` | Swap command only (no permit) — building block. |
+| `getPermitSwapEncodedData` | What production uses: permit + swap for the Universal Router. |
+| `getAvailableFeeTiers` | Finds which fee tiers return a real quote (powers the fee buttons on step 1). |
+
+**Export:** `uniswapProvider` — object with `getQuote` and `getQuoteExactOutput`.
+
+### `src/lib/swap/permit2.ts`
+
+Types and helpers for the EIP-712 permit (must match Permit2 on chain). Important pieces:
+
+- `createSecurePermit` — builds safe permit data for the wallet to sign (used in the app).
+- `validateSpender`, `validateAmount`, `validateExpiration`, `validateNonce`, etc. — safety checks before signing.
+
+### `src/lib/swap/providers/index.ts`
+
+Shared TypeScript types for a “provider” (`SwapQuote`, `QuoteParams`, …) so another DEX could be added later with the same shape.
+
+### `src/shared/stores/swap/useSwapStore.ts`
+
+Zustand store: tokens in/out, input mode, amounts typed, fee tier choice, permit + signature, swap tx hash and errors, reset on close.
+
+### `src/shared/stores/swap/hooks.ts`
+
+| Hook | What it does |
+|------|----------------|
+| `useSwapInput` | Debounced quotes, exact-in vs exact-out, fee tier list, marks quote “old” after ~30s, copies fee from quote into store for execution. |
+| `useTokenSelection` | Token in/out and metadata. |
+| `useTokenAllowance` | Read allowance to Permit2; send `approve` if needed. |
+| `usePermitSigning` | Read nonce, build permit, call `signTypedData`. |
+| `useSwapExecution` | Build router calldata and send `execute`. |
+
+`normalizeQuoteResult` turns the provider response into a `QuoteResult` the UI can use (bigints).
+
+### `src/app/api/swap/quote/route.ts`
+
+`GET` handler: checks inputs, reads decimals, calls `uniswapProvider.getQuote`, returns JSON. Cached for about 30 seconds (`revalidate`).
+
+### `src/shared/hooks/useSwapQuote.ts`
+
+Fetches `/api/swap/quote` with React Query. **The swap popup does not use this**; the popup uses `useSwapInput` instead.
+
+### `src/app/user/Swap/utils/`
+
+| File | What it does |
+|------|----------------|
+| `smart-default-direction.ts` | Picks default “From” / “To” from balances when the modal opens. |
+| `low-liquidity-warning.ts` | Decides whether to show the “not enough liquidity” style warning (uses USD prices when possible). |
+
+---
+
+## 9. Environment variables
+
+Public env keys used for swap-related addresses (full list in `src/lib/constants.ts`):
 
 - Token addresses: `NEXT_PUBLIC_USDT0_ADDRESS`, `NEXT_PUBLIC_USDRIF_ADDRESS`, `NEXT_PUBLIC_RIF_ADDRESS`, …
-- DEX: `NEXT_PUBLIC_UNISWAP_UNIVERSAL_ROUTER_ADDRESS`, `NEXT_PUBLIC_UNISWAP_QUOTER_V2_ADDRESS`
-- Permit2: `NEXT_PUBLIC_PERMIT2_ADDRESS` (Rootstock may differ from mainnet canonical)
+- Uniswap: `NEXT_PUBLIC_UNISWAP_UNIVERSAL_ROUTER_ADDRESS`, `NEXT_PUBLIC_UNISWAP_QUOTER_V2_ADDRESS`
+- Permit2: `NEXT_PUBLIC_PERMIT2_ADDRESS`
 - Pool hint: `NEXT_PUBLIC_USDT0_USDRIF_POOL_ADDRESS`
-- Chain: `NEXT_PUBLIC_CHAIN_ID`, `NEXT_PUBLIC_ENV`, etc.
+- Chain / app mode: `NEXT_PUBLIC_CHAIN_ID`, `NEXT_PUBLIC_ENV`, …
 
-Local / fork setup may be documented in `docs/FORK_SETUP.md` (general chain tooling).
+For running a local chain or fork, see `docs/FORK_SETUP.md`.
 
 ---
 
-## 10. Tests as executable spec
+## 10. Tests (where behavior is spelled out)
 
-| Area | Test file |
-|------|-----------|
-| Uniswap provider / path / quotes | `src/lib/swap/providers/uniswap.test.ts` |
+| Topic | File |
+|-------|------|
+| Uniswap quotes and paths | `src/lib/swap/providers/uniswap.test.ts` |
 | Routes | `src/lib/swap/routes.test.ts` |
 | Utils | `src/lib/swap/utils.test.ts` |
-| Multicall retry | grep / future — logic in `multicallWithGasEnvelopeRetry.ts` |
 | Quote API | `src/app/api/swap/quote/route.test.ts` |
-| Store | `src/shared/stores/swap/useSwapStore.test.ts` |
-| `useSwapInput` / quote hook | `src/shared/hooks/useSwapQuote.test.tsx`, `useSwapQuote` |
+| Swap store | `src/shared/stores/swap/useSwapStore.test.ts` |
+| `useSwapQuote` hook | `src/shared/hooks/useSwapQuote.test.tsx` |
 | Step 1 UI | `src/app/user/Swap/Steps/SwapStepOne.test.tsx` |
 | Smart default | `src/app/user/Swap/hooks/useSwapSmartDefault.test.ts` |
-| Low liquidity | `src/app/user/Swap/utils/low-liquidity-warning.test.ts` |
+| Low liquidity warning | `src/app/user/Swap/utils/low-liquidity-warning.test.ts` |
 
-Running tests (from repo root): use the project’s usual command (e.g. `npm test` / `npx vitest`) as defined in `package.json`.
-
----
-
-## 11. Further reading (external)
-
-- [Uniswap V3 Core concepts](https://docs.uniswap.org/concepts/protocol/concentrated-liquidity) — pools, price ranges, fees  
-- [Uniswap V3 Swap Router / Universal Router](https://docs.uniswap.org/contracts/universal-router/overview) — command encoding  
-- [Permit2 overview](https://docs.uniswap.org/contracts/permit2/overview) — signature-based allowances  
-- [QuoterV2](https://docs.uniswap.org/contracts/v3/reference/periphery/lens/QuoterV2) — `quoteExactInput` / `quoteExactOutput` and multihop paths  
+Run tests with whatever script is in `package.json` (often `npm test` or Vitest).
 
 ---
 
-## 12. Quick file map
+## 11. Deeper reading (official docs)
+
+- [Uniswap V3 — concentrated liquidity](https://docs.uniswap.org/concepts/protocol/concentrated-liquidity) — how pools work  
+- [Universal Router](https://docs.uniswap.org/contracts/universal-router/overview) — command encoding  
+- [Permit2](https://docs.uniswap.org/contracts/permit2/overview) — signature allowances  
+- [QuoterV2](https://docs.uniswap.org/contracts/v3/reference/periphery/lens/QuoterV2) — quote functions and paths  
+
+---
+
+## 12. Folder cheat sheet
 
 ```
 src/lib/swap/
-  constants.ts          # Token + router constants, fee tiers
-  types.ts              # SwapQuoteMode
-  utils.ts              # Amount/decimals helpers
-  routes.ts             # USDRIF↔RIF via USDT0
-  permit2.ts            # EIP-712 permit helpers
+  constants.ts          # Tokens, fees, router addresses
+  types.ts              # exactIn / exactOut mode type
+  utils.ts              # Amounts and decimals helpers
+  routes.ts             # When to use USDT0 between USDRIF and RIF
+  permit2.ts            # Permit signing helpers
   multicallWithGasEnvelopeRetry.ts
-  providers/uniswap.ts  # Quoter + Universal Router encoding
+  providers/uniswap.ts  # Quotes and router payload
 src/shared/stores/swap/
-  useSwapStore.ts       # Zustand UI state
-  useSwapTokens.ts      # Static token metadata
-  hooks.ts              # Quote, allowance, permit, execution
-src/app/user/Swap/      # Modal, steps, warnings, smart default
-src/app/api/swap/quote/ # HTTP quote API
+  useSwapStore.ts       # UI state
+  useSwapTokens.ts      # Token info for the UI
+  hooks.ts              # Quotes, allowance, permit, swap tx
+src/app/user/Swap/      # Modal and steps
+src/app/api/swap/quote/ # HTTP quote
 ```
 
 ---
 
-*For questions about chain forking or env profiles, start with `docs/FORK_SETUP.md`. For feature flags or app config, see `src/config/`.*
+*Fork and env setup: `docs/FORK_SETUP.md`. App config: `src/config/`.*

--- a/docs/SWAP_ARCHITECTURE.md
+++ b/docs/SWAP_ARCHITECTURE.md
@@ -1,0 +1,312 @@
+# Swap feature — architecture and onboarding guide
+
+This document explains how token swapping works in this repository: user journey, supported assets, state, quoting, on-chain execution, and where to read code. It is written for junior engineers, QA, and product owners who need a reliable mental model without reading the whole codebase first.
+
+**Branch / baseline:** Documentation was authored on branch `dao-2217` (created from `origin/dao-2226`). Swap logic lives primarily under `src/lib/swap/`, `src/shared/stores/swap/`, `src/app/user/Swap/`, and `src/app/api/swap/`.
+
+---
+
+## 1. What swapping does (one paragraph)
+
+The app lets users trade between **three fixed tokens** (USDT0, USDRIF, RIF) on Rootstock using **Uniswap V3** infrastructure: **QuoterV2** estimates output or required input, and the **Universal Router** executes a **V3 exact-in swap**. For **USDRIF ↔ RIF** there is **no direct pool in the routing table**, so the product uses a **two-hop path through USDT0**. Approvals use **Permit2**: the user first approves the ERC-20 to Permit2, then signs an EIP-712 **spending cap**, and finally sends **one transaction** that runs **PERMIT2_PERMIT + V3_SWAP_EXACT_IN** on the Universal Router.
+
+---
+
+## 2. Supported tokens and pairs
+
+| Symbol  | Role in product | Notes |
+|---------|-----------------|--------|
+| **USDT0** | Primary stable routing asset | Bridge token for USDRIF ↔ RIF |
+| **USDRIF** | Dollar-pegged RIF derivative | Pairs directly with USDT0 |
+| **RIF**   | Native/governance-oriented asset | Reaches USDRIF via USDT0 multihop |
+
+Canonical lists in code:
+
+- `SWAP_FLOW_TOKEN_SYMBOLS` and `SWAP_TOKEN_ADDRESSES` in `src/lib/swap/constants.ts` — addresses come from `tokenContracts` / env (`NEXT_PUBLIC_*_ADDRESS`).
+- UI token metadata (decimals, names) in `src/shared/stores/swap/useSwapTokens.ts`.
+
+**Important:** Other DEX names appear in constants (`ICECREAMSWAP`, `OPENOCEAN`) for future or historical wiring, but **quotes and execution in this branch use Uniswap only** (`uniswapProvider`).
+
+---
+
+## 3. End-to-end user flow (UI)
+
+The swap UI is a **modal wizard** (`SwappingFlow`), opened from the vault area (`VaultActions` renders `SwappingFlow` when the user opens swap).
+
+```mermaid
+flowchart LR
+  subgraph step1 [Step 1 - Select amount]
+    A[Pick tokens + amount] --> B[Quote via Uniswap]
+    B --> C{ERC20 allowance to Permit2?}
+    C -->|No| D[Approve unlimited to Permit2]
+    C -->|Yes| E[Continue]
+    D --> E
+  end
+  subgraph step2 [Step 2 - Permit]
+    F[Sign Permit2 spending cap] --> G[EIP-712 off-chain]
+  end
+  subgraph step3 [Step 3 - Confirm]
+    H[Choose slippage] --> I[Compute min out]
+    I --> J[Universal Router execute]
+  end
+  step1 --> step2 --> step3
+```
+
+| Step | File | User-visible purpose |
+|------|------|---------------------|
+| 1 | `SwapStepOne.tsx` | Enter **exact-in** or **exact-out** amount, pick fee tier (Auto or fixed), optional % of balance, flip tokens, continue or **Approve & Continue** |
+| 2 | `SwapStepTwo.tsx` | **Sign spending cap** (Permit2 + Universal Router); auto-skips if prior signature still covers amount |
+| 3 | `SwapStepThree.tsx` | Review from/to, pick **slippage**, see **minimum received**, confirm **one on-chain tx** |
+
+Supporting UI:
+
+- `SwappingFlow.tsx` — modal shell, progress bar, step routing, resets `useSwapStore` on close.
+- `SwapSteps.tsx` — step labels (SELECT AMOUNT → REQUEST ALLOWANCE → CONFIRM SWAP).
+- `SwapInputComponent.tsx` — amount input, token dropdown, USD hint, balance line.
+- `SwapStepWarning.tsx` / `LowLiquidityWarning` — standardized warning styling; low-liquidity copy from `low-liquidity-warning.ts`.
+- `useSwapSmartDefault.ts` — on modal open, if user has no USDT0, prefers USDRIF or RIF as “From” (`smart-default-direction.ts`).
+
+---
+
+## 4. Architecture layers
+
+| Layer | Responsibility |
+|-------|----------------|
+| **UI (Swap steps)** | Collects intent, drives wagmi txs/signing, shows warnings |
+| **Zustand (`useSwapStore`)** | Tokens, typed amount, mode, fee tier selection, permit payload, swap tx lifecycle |
+| **Hooks (`shared/stores/swap/hooks.ts`)** | Quotes (React Query), allowance, permit signing, swap execution |
+| **`src/lib/swap`** | Route resolution, Uniswap path encoding, Quoter calls, Universal Router calldata, Permit2 helpers |
+| **API `GET /api/swap/quote`** | Server-side quote using same provider stack (integrators, tests, or future clients) |
+| **On-chain** | ERC20 `approve` → Permit2; `UniversalRouter.execute` with bundled permit + swap |
+
+**Dual quote paths (good to know for QA):**
+
+- **In-modal quotes** call `uniswapProvider` **directly from the browser** via `useSwapInput` (same logic as server, but no HTTP hop).
+- **`useSwapQuote`** + **`/api/swap/quote`** exist for **HTTP/React Query** consumers; the live wizard does **not** depend on `useSwapQuote`.
+
+---
+
+## 5. Routing: when swaps are one-hop vs multihop
+
+`resolveSwapRoute(tokenIn, tokenOut)` in `src/lib/swap/routes.ts` returns an ordered list of token addresses:
+
+- **Default:** `[tokenIn, tokenOut]` (single hop).
+- **USDRIF ↔ RIF:** `[USDRIF, USDT0, RIF]` or `[RIF, USDT0, USDRIF]` depending on direction.
+
+Helpers:
+
+- **`isMultihopRoute`** — `tokens.length > 2`.
+- **`getSwapRouteCacheKey`** — stable string for React Query keys.
+
+**Why it exists:** Uniswap V3 quotes and swaps need a **path** of `(token, fee, token, fee, …)`. The resolver fixes topology so Quoter and execution always agree on intermediates.
+
+---
+
+## 6. Fee tiers vs slippage (frequent confusion)
+
+- **Fee tier (pool fee):** Uniswap V3 splits liquidity into pools with fees **100, 500, 3000, 10000** (basis points of the trade, i.e. 0.01%–1%). **Auto** mode asks the Quoter for many combinations and picks the economically best result. **Manual** tier on a multihop route uses the **same** uint24 fee on **every** hop (uniform path).
+- **Slippage (Step 3):** User-selected protection on **minimum output** (`amountOutMinimum`) for the **V3_SWAP_EXACT_IN** command. It is **not** the pool fee.
+
+---
+
+## 7. Permit2 and Universal Router
+
+1. **ERC-20 `approve(token, Permit2, MAX)`** — one-time per token (Step 1). Implemented in `useTokenAllowance` via standard `approve` (ABI reused from `RIFTokenAbi` for ERC20).
+2. **`signTypedData` PermitSingle** — authorizes Universal Router to pull **exactly** the signed amount from Permit2 (Step 2). Built with `createSecurePermit` in `src/lib/swap/permit2.ts`; nonce read from Permit2 `allowance(owner, token, spender)`.
+3. **`execute(commands, inputs)`** on Universal Router — `getPermitSwapEncodedData` encodes **`0x0a` (PERMIT2_PERMIT) + `0x00` (V3_SWAP_EXACT_IN)** with the V3 path bytes (`src/lib/swap/providers/uniswap.ts`).
+
+If execution fails with **AllowanceExpired** (`0xd81b2f2e`), the user must return to Step 2 and sign again (handled in `useSwapExecution`).
+
+---
+
+## 8. Reference: main functions and types
+
+Below: **what it does**, **why it exists**, **role in swapping**.
+
+### 8.1 `src/lib/swap/constants.ts`
+
+| Export | Role |
+|--------|------|
+| `SWAP_TOKEN_ADDRESSES` | Central map of swap-eligible token addresses |
+| `SWAP_FLOW_TOKEN_SYMBOLS` | The three symbols exposed in the UI |
+| `ROUTER_ADDRESSES` / `POOL_ADDRESSES` | Env-backed contract addresses for quoting and hints |
+| `SWAP_PROVIDERS` | Provider name union (`uniswap`, etc.) |
+| `UNISWAP_FEE_TIERS` | `[100, 500, 3000, 10000]` |
+| `feeTierToPercent` | Display helper (tier / 10_000) |
+
+### 8.2 `src/lib/swap/routes.ts`
+
+| Function | Why |
+|----------|-----|
+| `resolveSwapRoute` | Deterministic path for Quoter + execution (incl. USDRIF–RIF via USDT0) |
+| `isMultihopRoute` | Branches quoting/encoding logic |
+| `getSwapRouteCacheKey` | Invalidates React Query when pair topology changes |
+
+### 8.3 `src/lib/swap/utils.ts`
+
+| Function | Why |
+|----------|-----|
+| `scaleAmount` | Human string → `bigint` via `viem` `parseUnits` (API route) |
+| `isValidAmount` | Positive decimal guard for API |
+| `getTokenDecimals` | On-chain `decimals()` read (single token) |
+| `getTokenDecimalsBatch` | Multicall decimals for API (one round-trip, deduped addresses) |
+| `calculatePriceImpact` | **Utility** comparing effective vs spot price; used in tests / future UI, not wired into the current swap modal quote display |
+
+### 8.4 `src/lib/swap/multicallWithGasEnvelopeRetry.ts`
+
+| Function | Why |
+|----------|-----|
+| `multicallWithGasEnvelopeRetry` | Some RPCs reject large `aggregate3` calls; retries with smaller batches |
+| `isLikelyOuterMulticallRpcFailure` | Classifies outer RPC failures vs per-call reverts |
+
+### 8.5 `src/lib/swap/providers/uniswap.ts` (core provider)
+
+**Path encoding**
+
+| Function | Role |
+|----------|------|
+| `encodeFeeUint24Hex` | Packs uint24 fee into path bytes |
+| `encodeUniformFeeSwapPath` | Same fee every hop |
+| `encodePerHopFeeSwapPath` | Distinct fee per hop (Auto multihop search) |
+
+**Quoting**
+
+| Function | Role |
+|----------|------|
+| `getUniswapQuote` / `getUniswapExactOutputQuote` | Main entry: resolve route, single-hop vs multihop, Auto vs explicit tier |
+| `getBestQuoteFromAllTiers` / `getBestExactOutputFromAllTiers` | Multicall all single-hop tiers, pick best |
+| `getBestMultihopQuoteExactIn` / `…ExactOut` | Cartesian product of tier combinations (up to 3 hops policy) |
+| `cartesianFeeCombinations` | Builds fee lists for multihop probes |
+
+**Execution helpers**
+
+| Function | Role |
+|----------|------|
+| `getSwapEncodedData` | `V3_SWAP_EXACT_IN` only (no permit) — lower-level building block |
+| `getPermitSwapEncodedData` | **Production path**: permit + swap commands for Universal Router |
+| `getAvailableFeeTiers` | Probes which tiers return positive output (powers Step 1 fee buttons) |
+
+**Export**
+
+| Export | Role |
+|--------|------|
+| `uniswapProvider` | `SwapProvider` implementation (`getQuote`, `getQuoteExactOutput`) |
+
+**Error handling:** Infrastructure errors propagate; Quoter reverts often become user-facing “no liquidity” messages (`swapQuoteNoLiquidityExplicitTier`).
+
+### 8.6 `src/lib/swap/permit2.ts`
+
+| Area | Role |
+|------|------|
+| Types (`PermitSingle`, `PermitDetails`, …) | Match Uniswap Permit2 EIP-712 layout |
+| `validateSpender`, `validateAmount`, `validateExpiration`, `validateNonce`, `validateChainId`, `validateToken` | Defense-in-depth before signing |
+| `validatePermitParams` | Aggregates validation for tooling/tests |
+| `createPermitSingle` | Builds struct + deadlines |
+| `createPermit2Domain` / `createTypedDataForPermit` | Wallet `signTypedData` input |
+| `createSecurePermit` | **Used in app** — validates then returns permit + typed data |
+| `validateSignatureFormat` | Basic hex length / `v` checks |
+
+### 8.7 `src/lib/swap/providers/index.ts`
+
+Defines **`SwapProvider`**, **`SwapQuote`**, **`QuoteParams`**, **`QuoteExactOutputParams`** — shared interface if additional DEX adapters are added later.
+
+### 8.8 `src/shared/stores/swap/useSwapStore.ts`
+
+Zustand actions: token pair, `mode` + `typedAmount`, fee tier, permit blobs, swap/approval tx hashes, `reset` on modal close. **Quotes and allowances are not stored here** (React Query / wagmi).
+
+### 8.9 `src/shared/stores/swap/hooks.ts`
+
+| Hook | Role |
+|------|------|
+| `useSwapInput` | Debounced quoting, exact-in/out switching, `availableFeeTiers`, quote staleness (~30s), syncs `poolFee` from quote |
+| `useTokenSelection` | Thin wrapper over store + `useSwapTokens` |
+| `useTokenAllowance` | Reads allowance to Permit2; `approve` unlimited to Permit2 |
+| `usePermitSigning` | Fetches Permit2 nonce, `createSecurePermit`, `signTypedData` |
+| `useSwapExecution` | `getPermitSwapEncodedData` + `execute` on Universal Router |
+
+Helper **`normalizeQuoteResult`** maps provider response into **`QuoteResult`** (bigint fields for UI math).
+
+### 8.10 `src/app/api/swap/quote/route.ts`
+
+| Piece | Role |
+|-------|------|
+| `GET` | Validates addresses/amount, batch-reads decimals, calls `uniswapProvider.getQuote`, returns `{ quotes }` |
+| `revalidate = 30` | Next.js cache hint aligned with quote TTL |
+
+### 8.11 `src/shared/hooks/useSwapQuote.ts`
+
+React Query wrapper around **`/api/swap/quote`**. Useful for **non-modal** consumers; swap modal uses **`useSwapInput`** instead.
+
+### 8.12 User swap utilities
+
+| Module | Role |
+|--------|------|
+| `smart-default-direction.ts` | `getSmartDefaultSwapDirection` — balance-based default pair |
+| `low-liquidity-warning.ts` | `shouldShowLowLiquidityWarning` — USD-based or stable-to-stable heuristic, >5% loss warning |
+
+---
+
+## 9. Environment variables (operations)
+
+Swap-related **public** env vars (see `src/lib/constants.ts`):
+
+- Token addresses: `NEXT_PUBLIC_USDT0_ADDRESS`, `NEXT_PUBLIC_USDRIF_ADDRESS`, `NEXT_PUBLIC_RIF_ADDRESS`, …
+- DEX: `NEXT_PUBLIC_UNISWAP_UNIVERSAL_ROUTER_ADDRESS`, `NEXT_PUBLIC_UNISWAP_QUOTER_V2_ADDRESS`
+- Permit2: `NEXT_PUBLIC_PERMIT2_ADDRESS` (Rootstock may differ from mainnet canonical)
+- Pool hint: `NEXT_PUBLIC_USDT0_USDRIF_POOL_ADDRESS`
+- Chain: `NEXT_PUBLIC_CHAIN_ID`, `NEXT_PUBLIC_ENV`, etc.
+
+Local / fork setup may be documented in `docs/FORK_SETUP.md` (general chain tooling).
+
+---
+
+## 10. Tests as executable spec
+
+| Area | Test file |
+|------|-----------|
+| Uniswap provider / path / quotes | `src/lib/swap/providers/uniswap.test.ts` |
+| Routes | `src/lib/swap/routes.test.ts` |
+| Utils | `src/lib/swap/utils.test.ts` |
+| Multicall retry | grep / future — logic in `multicallWithGasEnvelopeRetry.ts` |
+| Quote API | `src/app/api/swap/quote/route.test.ts` |
+| Store | `src/shared/stores/swap/useSwapStore.test.ts` |
+| `useSwapInput` / quote hook | `src/shared/hooks/useSwapQuote.test.tsx`, `useSwapQuote` |
+| Step 1 UI | `src/app/user/Swap/Steps/SwapStepOne.test.tsx` |
+| Smart default | `src/app/user/Swap/hooks/useSwapSmartDefault.test.ts` |
+| Low liquidity | `src/app/user/Swap/utils/low-liquidity-warning.test.ts` |
+
+Running tests (from repo root): use the project’s usual command (e.g. `npm test` / `npx vitest`) as defined in `package.json`.
+
+---
+
+## 11. Further reading (external)
+
+- [Uniswap V3 Core concepts](https://docs.uniswap.org/concepts/protocol/concentrated-liquidity) — pools, price ranges, fees  
+- [Uniswap V3 Swap Router / Universal Router](https://docs.uniswap.org/contracts/universal-router/overview) — command encoding  
+- [Permit2 overview](https://docs.uniswap.org/contracts/permit2/overview) — signature-based allowances  
+- [QuoterV2](https://docs.uniswap.org/contracts/v3/reference/periphery/lens/QuoterV2) — `quoteExactInput` / `quoteExactOutput` and multihop paths  
+
+---
+
+## 12. Quick file map
+
+```
+src/lib/swap/
+  constants.ts          # Token + router constants, fee tiers
+  types.ts              # SwapQuoteMode
+  utils.ts              # Amount/decimals helpers
+  routes.ts             # USDRIF↔RIF via USDT0
+  permit2.ts            # EIP-712 permit helpers
+  multicallWithGasEnvelopeRetry.ts
+  providers/uniswap.ts  # Quoter + Universal Router encoding
+src/shared/stores/swap/
+  useSwapStore.ts       # Zustand UI state
+  useSwapTokens.ts      # Static token metadata
+  hooks.ts              # Quote, allowance, permit, execution
+src/app/user/Swap/      # Modal, steps, warnings, smart default
+src/app/api/swap/quote/ # HTTP quote API
+```
+
+---
+
+*For questions about chain forking or env profiles, start with `docs/FORK_SETUP.md`. For feature flags or app config, see `src/config/`.*

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "vitest",
     "build:start": "next build && next start",
     "fork:stop": "pkill -f anvil || true",
-    "fork:anvil": "sh -c 'anvil --fork-url \"$ROOTSTOCK_RPC_URL\" --chain-id 31337 --fork-block-number \"${RS_FORK_BLOCK_NUMBER:-8707257}\" --timeout 120000'",
+    "fork:anvil": "sh -c 'anvil --fork-url \"$ROOTSTOCK_RPC_URL\" --chain-id 31337 --fork-block-number \"${RS_FORK_BLOCK_NUMBER:-8707257}\" --timeout 120000 --gas-limit 500000000'",
     "postinstall": "prisma generate",
     "db:migrate:dao": "prisma migrate deploy",
     "db:studio": "prisma studio",

--- a/src/app/api/swap/quote/route.ts
+++ b/src/app/api/swap/quote/route.ts
@@ -59,7 +59,7 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    // Read decimals for both tokens in parallel
+    // Read decimals for both tokens in one multicall (deduped; same RPC envelope retry as Quoter batches)
     // getTokenDecimalsBatch returns map with normalized (checksummed) addresses as keys
     const decimalsMap = await getTokenDecimalsBatch([tokenIn, tokenOut])
     const tokenInDecimals = decimalsMap[getAddress(tokenIn)]

--- a/src/lib/swap/multicallWithGasEnvelopeRetry.ts
+++ b/src/lib/swap/multicallWithGasEnvelopeRetry.ts
@@ -1,0 +1,53 @@
+import { publicClient as appPublicClient } from '@/lib/viemPublicClient'
+
+export type AppPublicClient = typeof appPublicClient
+
+/** Row shape for viem `multicall` with default `allowFailure: true` (used after wrapper widens generics). */
+export interface MulticallAllowFailureRow {
+  status: 'success' | 'failure'
+  result?: unknown
+  error?: Error
+}
+
+function errorFingerprint(err: unknown): string {
+  if (!(err instanceof Error)) return ''
+  const ctor = err.constructor?.name ?? ''
+  return `${ctor} ${err.name} ${err.message}`.toLowerCase()
+}
+
+/**
+ * Detects failures of the whole `eth_call` into Multicall3 `aggregate3` (simulation gas / RPC),
+ * as opposed to per-call failures returned inside aggregate3 when `allowFailure` is true.
+ */
+export function isLikelyOuterMulticallRpcFailure(err: unknown): boolean {
+  const fp = errorFingerprint(err)
+  return (
+    fp.includes('outofgas') ||
+    fp.includes('out of gas') ||
+    fp.includes('-32603') ||
+    fp.includes('internal json-rpc error') ||
+    fp.includes('evm error') ||
+    fp.includes('caller gas limit') ||
+    fp.includes('call gas') ||
+    fp.includes('gas limit exceeded') ||
+    fp.includes('exceeds block gas limit')
+  )
+}
+
+/**
+ * Runs viem `multicall` over Quoter (or similar) calls. If the RPC rejects the batched
+ * `aggregate3` `eth_call` (common on strict `eth_call` gas envelopes), retries with
+ * `batchSize: 1` (viem measures batch in calldata bytes — one Quoter call per chunk).
+ */
+export async function multicallWithGasEnvelopeRetry(
+  client: AppPublicClient,
+  args: Parameters<AppPublicClient['multicall']>[0],
+): Promise<readonly MulticallAllowFailureRow[]> {
+  try {
+    return (await client.multicall(args)) as readonly MulticallAllowFailureRow[]
+  } catch (err) {
+    if (!isLikelyOuterMulticallRpcFailure(err)) throw err
+    if (args.batchSize === 1) throw err
+    return (await client.multicall({ ...args, batchSize: 1 })) as readonly MulticallAllowFailureRow[]
+  }
+}

--- a/src/lib/swap/multicallWithGasEnvelopeRetry.ts
+++ b/src/lib/swap/multicallWithGasEnvelopeRetry.ts
@@ -15,23 +15,46 @@ function errorFingerprint(err: unknown): string {
   return `${ctor} ${err.name} ${err.message}`.toLowerCase()
 }
 
+/** RPC / gas-envelope signals shared by strict chunk detection and (with one extra) thrown multicall errors. */
+const CHUNK_ENVELOPE_SUBSTRINGS = [
+  'outofgas',
+  'out of gas',
+  '-32603',
+  'internal json-rpc error',
+  'caller gas limit',
+  'call gas',
+  'gas limit exceeded',
+  'exceeds block gas limit',
+] as const
+
+function fingerprintMatchesChunkEnvelope(fp: string): boolean {
+  return CHUNK_ENVELOPE_SUBSTRINGS.some(s => fp.includes(s))
+}
+
 /**
  * Detects failures of the whole `eth_call` into Multicall3 `aggregate3` (simulation gas / RPC),
  * as opposed to per-call failures returned inside aggregate3 when `allowFailure` is true.
+ *
+ * Includes a bare `evm error` substring so thrown RPC errors still match; that substring is omitted
+ * when deciding whether an all-failure multicall *result* was a chunk envelope issue (quoter reverts
+ * often surface as "EVM error: execution reverted").
  */
 export function isLikelyOuterMulticallRpcFailure(err: unknown): boolean {
   const fp = errorFingerprint(err)
-  return (
-    fp.includes('outofgas') ||
-    fp.includes('out of gas') ||
-    fp.includes('-32603') ||
-    fp.includes('internal json-rpc error') ||
-    fp.includes('evm error') ||
-    fp.includes('caller gas limit') ||
-    fp.includes('call gas') ||
-    fp.includes('gas limit exceeded') ||
-    fp.includes('exceeds block gas limit')
-  )
+  return fingerprintMatchesChunkEnvelope(fp) || fp.includes('evm error')
+}
+
+/**
+ * viem maps a rejected `aggregate3` `readContract` to one failure row per call in that chunk, with
+ * the same underlying reason — it does not throw. Detect that so we still retry with smaller chunks.
+ */
+function allRowsFailedFromSameChunkRpc(results: readonly MulticallAllowFailureRow[]): boolean {
+  if (results.length === 0) return false
+  if (!results.every(r => r.status === 'failure')) return false
+  const e0 = results[0].error
+  if (!e0 || !fingerprintMatchesChunkEnvelope(errorFingerprint(e0))) return false
+  const fp0 = errorFingerprint(e0)
+  return results.every(r => r.error !== undefined && errorFingerprint(r.error) === fp0)
 }
 
 /**
@@ -43,11 +66,18 @@ export async function multicallWithGasEnvelopeRetry(
   client: AppPublicClient,
   args: Parameters<AppPublicClient['multicall']>[0],
 ): Promise<readonly MulticallAllowFailureRow[]> {
+  const run = (multicallArgs: Parameters<AppPublicClient['multicall']>[0]) =>
+    client.multicall(multicallArgs) as Promise<readonly MulticallAllowFailureRow[]>
+
   try {
-    return (await client.multicall(args)) as readonly MulticallAllowFailureRow[]
+    const first = await run(args)
+    if (args.batchSize !== 1 && allRowsFailedFromSameChunkRpc(first)) {
+      return await run({ ...args, batchSize: 1 })
+    }
+    return first
   } catch (err) {
     if (!isLikelyOuterMulticallRpcFailure(err)) throw err
     if (args.batchSize === 1) throw err
-    return (await client.multicall({ ...args, batchSize: 1 })) as readonly MulticallAllowFailureRow[]
+    return await run({ ...args, batchSize: 1 })
   }
 }

--- a/src/lib/swap/providers/uniswap.test.ts
+++ b/src/lib/swap/providers/uniswap.test.ts
@@ -18,6 +18,7 @@ import {
 } from './uniswap'
 import type { PermitSingle } from '../permit2'
 import { ROUTER_ADDRESSES, SWAP_TOKEN_ADDRESSES } from '../constants'
+import { multicallWithGasEnvelopeRetry } from '../multicallWithGasEnvelopeRetry'
 import { resolveSwapRoute } from '../routes'
 import { getTokenDecimalsBatch } from '../utils'
 import { UniswapQuoterV2Abi } from '@/lib/abis/UniswapQuoterV2Abi'
@@ -61,7 +62,7 @@ function getTwoHopFeeCombinations(): number[][] {
 
 async function getBestMultihopExactInputFromMulticall(routeTokens: readonly Address[], amountIn: bigint) {
   const hopCombos = getTwoHopFeeCombinations()
-  const multicall = await publicClient.multicall({
+  const multicall = await multicallWithGasEnvelopeRetry(publicClient, {
     contracts: hopCombos.map(hopFees => ({
       address: ROUTER_ADDRESSES.UNISWAP_QUOTER_V2,
       abi: UniswapQuoterV2Abi,

--- a/src/lib/swap/providers/uniswap.test.ts
+++ b/src/lib/swap/providers/uniswap.test.ts
@@ -4,6 +4,7 @@ import {
   encodeFunctionData,
   parseUnits,
   type AbiFunction,
+  getAddress,
   type Address,
   type Hex,
 } from 'viem'
@@ -18,7 +19,7 @@ import {
 import type { PermitSingle } from '../permit2'
 import { ROUTER_ADDRESSES, SWAP_TOKEN_ADDRESSES } from '../constants'
 import { resolveSwapRoute } from '../routes'
-import { getTokenDecimals } from '../utils'
+import { getTokenDecimalsBatch } from '../utils'
 import { UniswapQuoterV2Abi } from '@/lib/abis/UniswapQuoterV2Abi'
 import { tokenContracts } from '@/lib/contracts'
 import { RIF, UNISWAP_UNIVERSAL_ROUTER_ADDRESS } from '@/lib/constants'
@@ -165,9 +166,10 @@ describe('uniswap provider - integration tests', () => {
   beforeAll(async () => {
     if (hasRealAddresses) {
       try {
-        tokenInDecimals = await getTokenDecimals(realTokenIn)
-        tokenOutDecimals = await getTokenDecimals(realTokenOut)
-        rifDecimals = await getTokenDecimals(rifToken)
+        const decimalsMap = await getTokenDecimalsBatch([realTokenIn, realTokenOut, rifToken])
+        tokenInDecimals = decimalsMap[getAddress(realTokenIn)]!
+        tokenOutDecimals = decimalsMap[getAddress(realTokenOut)]!
+        rifDecimals = decimalsMap[getAddress(rifToken)]!
       } catch (error) {
         console.warn('Failed to fetch token decimals, some tests may be skipped:', error)
       }

--- a/src/lib/swap/providers/uniswap.ts
+++ b/src/lib/swap/providers/uniswap.ts
@@ -11,6 +11,7 @@ import {
   UNISWAP_FEE_TIERS,
   type UniswapFeeTier,
 } from '../constants'
+import { multicallWithGasEnvelopeRetry } from '../multicallWithGasEnvelopeRetry'
 import type { PermitSingle } from '../permit2'
 import { isMultihopRoute, resolveSwapRoute } from '../routes'
 import type { QuoteExactOutputParams, QuoteMode, QuoteParams, SwapProvider, SwapQuote } from './'
@@ -315,7 +316,7 @@ function buildMultihopExactOutputContractsAllFeePairs(tokens: readonly Address[]
 }
 
 /**
- * Batch-quote all fee tiers for exactIn via a single multicall RPC request.
+ * Batch-quote all fee tiers for exactIn via a single Multicall3 `aggregate3` RPC (viem `multicall`).
  * Returns the best quote (highest amountOut) or null if all tiers failed.
  */
 async function getBestQuoteFromAllTiers(
@@ -324,7 +325,7 @@ async function getBestQuoteFromAllTiers(
 ): Promise<SwapQuote | null> {
   const { tokenIn, tokenOut, amountIn, tokenOutDecimals } = params
 
-  const results = await publicClient.multicall({
+  const results = await multicallWithGasEnvelopeRetry(publicClient, {
     contracts: buildExactInputContracts(tokenIn, tokenOut, amountIn),
   })
 
@@ -350,7 +351,7 @@ async function getBestQuoteFromAllTiers(
 }
 
 /**
- * Batch-quote all fee tiers for exactOut via a single multicall RPC request.
+ * Batch-quote all fee tiers for exactOut via Multicall3 (same pattern as exact-in).
  * Returns the best quote (lowest amountIn) or null if all tiers failed.
  */
 async function getBestExactOutputFromAllTiers(
@@ -359,7 +360,7 @@ async function getBestExactOutputFromAllTiers(
 ): Promise<SwapQuote | null> {
   const { tokenIn, tokenOut, amountOut, tokenOutDecimals } = params
 
-  const results = await publicClient.multicall({
+  const results = await multicallWithGasEnvelopeRetry(publicClient, {
     contracts: buildExactOutputContracts(tokenIn, tokenOut, amountOut),
   })
 
@@ -464,7 +465,7 @@ async function getBestMultihopQuoteExactIn(
   providerName: SwapProvider['name'],
 ): Promise<SwapQuote | null> {
   const combos = cartesianFeeCombinations(tokens.length - 1)
-  const results = await publicClient.multicall({
+  const results = await multicallWithGasEnvelopeRetry(publicClient, {
     contracts: buildMultihopExactInputContractsAllFeePairs(tokens, params.amountIn),
   })
   const validQuotes: SwapQuote[] = []
@@ -494,7 +495,7 @@ async function getBestMultihopQuoteExactOut(
   providerName: SwapProvider['name'],
 ): Promise<SwapQuote | null> {
   const combos = cartesianFeeCombinations(tokens.length - 1)
-  const results = await publicClient.multicall({
+  const results = await multicallWithGasEnvelopeRetry(publicClient, {
     contracts: buildMultihopExactOutputContractsAllFeePairs(tokens, params.amountOut),
   })
   const validQuotes: SwapQuote[] = []
@@ -822,7 +823,7 @@ export async function getAvailableFeeTiers(
   const testAmount = oneFullTokenRaw > maxProbeRaw ? maxProbeRaw : oneFullTokenRaw
 
   if (isMultihopRoute(route)) {
-    const results = await publicClient.multicall({
+    const results = await multicallWithGasEnvelopeRetry(publicClient, {
       contracts: buildMultihopUniformFeeExactInputContracts(route.tokens, testAmount),
     })
 
@@ -836,7 +837,7 @@ export async function getAvailableFeeTiers(
       .filter((fee): fee is UniswapFeeTier => fee !== null)
   }
 
-  const results = await publicClient.multicall({
+  const results = await multicallWithGasEnvelopeRetry(publicClient, {
     contracts: buildExactInputContracts(tokenIn, tokenOut, testAmount),
   })
 

--- a/src/lib/swap/utils.test.ts
+++ b/src/lib/swap/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { Address } from 'viem'
+import { Address, getAddress } from 'viem'
 import Big from '@/lib/big'
 import {
   scaleAmount,
@@ -356,26 +356,28 @@ describe('swap/utils', () => {
       const result = await getTokenDecimalsBatch([mockTokenAddress1, mockTokenAddress2, mockTokenAddress3])
 
       expect(result).toEqual({
-        [mockTokenAddress1]: 18,
-        [mockTokenAddress2]: 6,
-        [mockTokenAddress3]: 8,
+        [getAddress(mockTokenAddress1)]: 18,
+        [getAddress(mockTokenAddress2)]: 6,
+        [getAddress(mockTokenAddress3)]: 8,
       })
-      expect(mockedPublicClient.multicall).toHaveBeenCalledWith({
-        contracts: expect.arrayContaining([
-          expect.objectContaining({
-            address: mockTokenAddress1,
-            functionName: 'decimals',
-          }),
-          expect.objectContaining({
-            address: mockTokenAddress2,
-            functionName: 'decimals',
-          }),
-          expect.objectContaining({
-            address: mockTokenAddress3,
-            functionName: 'decimals',
-          }),
-        ]),
-      })
+      expect(mockedPublicClient.multicall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          contracts: expect.arrayContaining([
+            expect.objectContaining({
+              address: getAddress(mockTokenAddress1),
+              functionName: 'decimals',
+            }),
+            expect.objectContaining({
+              address: getAddress(mockTokenAddress2),
+              functionName: 'decimals',
+            }),
+            expect.objectContaining({
+              address: getAddress(mockTokenAddress3),
+              functionName: 'decimals',
+            }),
+          ]),
+        }),
+      )
     })
 
     it('should handle single token', async () => {
@@ -384,7 +386,29 @@ describe('swap/utils', () => {
       const result = await getTokenDecimalsBatch([mockTokenAddress1])
 
       expect(result).toEqual({
-        [mockTokenAddress1]: 18,
+        [getAddress(mockTokenAddress1)]: 18,
+      })
+    })
+
+    it('deduplicates addresses so each token is read once per multicall', async () => {
+      mockedPublicClient.multicall.mockResolvedValueOnce([
+        { status: 'success', result: 18 },
+        { status: 'success', result: 6 },
+      ] as any)
+
+      const result = await getTokenDecimalsBatch([mockTokenAddress1, mockTokenAddress1, mockTokenAddress2])
+
+      expect(mockedPublicClient.multicall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          contracts: [
+            expect.objectContaining({ address: getAddress(mockTokenAddress1) }),
+            expect.objectContaining({ address: getAddress(mockTokenAddress2) }),
+          ],
+        }),
+      )
+      expect(result).toEqual({
+        [getAddress(mockTokenAddress1)]: 18,
+        [getAddress(mockTokenAddress2)]: 6,
       })
     })
 
@@ -418,12 +442,11 @@ describe('swap/utils', () => {
       )
     })
 
-    it('should handle empty array', async () => {
-      mockedPublicClient.multicall.mockResolvedValueOnce([])
-
+    it('should handle empty array without RPC', async () => {
       const result = await getTokenDecimalsBatch([])
 
       expect(result).toEqual({})
+      expect(mockedPublicClient.multicall).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/lib/swap/utils.ts
+++ b/src/lib/swap/utils.ts
@@ -3,6 +3,8 @@ import { Address, getAddress, parseUnits } from 'viem'
 import Big from '@/lib/big'
 import { publicClient } from '@/lib/viemPublicClient'
 
+import { multicallWithGasEnvelopeRetry } from './multicallWithGasEnvelopeRetry'
+
 /**
  * Minimal ERC20 ABI for reading decimals
  */
@@ -128,31 +130,39 @@ export async function getTokenDecimals(tokenAddress: Address): Promise<number> {
 }
 
 /**
- * Read decimals from multiple token contracts in parallel
- * @param tokenAddresses - Array of token addresses
- * @returns Record mapping token addresses to their decimals
+ * Read decimals from multiple token contracts in one multicall (one RPC round-trip per viem chunk).
+ * Duplicate addresses are de-duplicated so each token is read at most once.
  */
 export async function getTokenDecimalsBatch(tokenAddresses: Address[]): Promise<Record<Address, number>> {
-  // Normalize all addresses to ensure proper checksumming and use as keys
   const normalizedAddresses = tokenAddresses.map(addr => getAddress(addr))
 
+  if (normalizedAddresses.length === 0) {
+    return {}
+  }
+
+  const uniqueInOrder: Address[] = []
+  const seen = new Set<Address>()
+  for (const a of normalizedAddresses) {
+    if (!seen.has(a)) {
+      seen.add(a)
+      uniqueInOrder.push(a)
+    }
+  }
+
   try {
-    // Use multicall for efficiency
-    const results = await publicClient.multicall({
-      contracts: normalizedAddresses.map(address => ({
+    const results = await multicallWithGasEnvelopeRetry(publicClient, {
+      contracts: uniqueInOrder.map(address => ({
         address,
         abi: ERC20_DECIMALS_ABI,
-        functionName: 'decimals',
+        functionName: 'decimals' as const,
       })),
     })
 
-    // Process results and handle failures
-    // Use normalized addresses as keys for consistent lookups
-    const decimalsMap: Record<Address, number> = {}
-    const failedAddresses: Address[] = []
+    const byAddress: Partial<Record<Address, number>> = {}
+    const failedUnique: Address[] = []
 
     results.forEach((result, index) => {
-      const normalizedAddress = normalizedAddresses[index]
+      const addr = uniqueInOrder[index]
 
       if (
         result.status === 'success' &&
@@ -160,27 +170,31 @@ export async function getTokenDecimalsBatch(tokenAddresses: Address[]): Promise<
         result.result >= 0 &&
         result.result <= 255
       ) {
-        decimalsMap[normalizedAddress] = result.result
+        byAddress[addr] = result.result
       } else {
-        failedAddresses.push(normalizedAddress)
-        // Log failure reason for debugging
+        failedUnique.push(addr)
         if (result.status === 'failure' && result.error) {
           console.warn(
-            `Failed to read decimals for ${normalizedAddress}:`,
+            `Failed to read decimals for ${addr}:`,
             result.error instanceof Error ? result.error.message : result.error,
           )
         }
       }
     })
 
-    // Check if we got decimals for all addresses
+    const decimalsMap: Record<Address, number> = {}
+    for (const addr of normalizedAddresses) {
+      const d = byAddress[addr]
+      if (typeof d === 'number') {
+        decimalsMap[addr] = d
+      }
+    }
+
     const missingAddresses = normalizedAddresses.filter(addr => typeof decimalsMap[addr] !== 'number')
 
     if (missingAddresses.length > 0) {
       const errorDetails =
-        failedAddresses.length > 0
-          ? ` RPC multicall returned failures for: ${failedAddresses.join(', ')}`
-          : ''
+        failedUnique.length > 0 ? ` RPC multicall returned failures for: ${failedUnique.join(', ')}` : ''
       throw new Error(`Failed to read decimals for tokens: ${missingAddresses.join(', ')}${errorDetails}`)
     }
 


### PR DESCRIPTION
## Why this exists

The swap stack talks to Rootstock through normal JSON-RPC `eth_call`. When we ask Uniswap V3 for quotes across several fee tiers, we do not fire one HTTP request per contract call if we can avoid it: we batch those reads through **Multicall3**, so a single `eth_call` runs many small view calls inside one on-chain aggregate. That is the usual pattern on public RPCs and keeps latency and load down.

**The problem:** that outer `eth_call` is still one EVM execution with a **single gas budget** (the block gas limit the node applies to the call). A batch that is fine on a forgiving public endpoint can fail on **Anvil** or other strict setups with an **Out of gas** style error for the *whole* multicall. From the app’s perspective that looks like the entire quote path failed, even though each inner quoter read might succeed if sent separately. So fork-based development and CI can disagree with “it works on mainnet RPC” without any change to pool math or business logic.

**What we changed conceptually**

1. **Graceful degradation on outer failures** — If the batched multicall fails in a way that matches this class of RPC / envelope errors, we **retry once** with a smaller multicall shape (effectively one inner call per batch chunk) so the same logic still runs, just with more round trips when the node is tight on gas.

2. **Same idea for token decimals** — Decimals are also read on-chain; batching and the same retry path keeps behavior consistent and avoids redundant calls (duplicate addresses are collapsed).

3. **Align fork and CI with real gas headroom** — Local fork and the workflow that starts Anvil use a **higher block gas limit** so developers and CI are not randomly blocked by default limits that do not match how public RPCs behave. This does not remove the need for the retry; it reduces noise when comparing fork vs production.

4. **Documentation** — There is a short, onboarding-oriented explanation of Multicall3, why one fat `eth_call` can fail as a unit, and how to inspect RPC traffic in the browser when debugging. No extra tooling is required for that.

Together, this is about **robustness and parity**: quotes and decimals should behave predictably whether you are on a public RPC, a local fork, or CI, without giving up batching when the environment allows it.
