### PR TITLE
DAO-1983: Dynamic block time — Blockscout fetch helper (part 1/9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ CLAUDE.md
 .workflow/plans/
 .workflow/reviews/
 .workflow/qa-reports/
+
+# Local git worktrees
+.worktrees/

--- a/src/shared/context/BlockTimeContext/computeAverageBlockTime.test.ts
+++ b/src/shared/context/BlockTimeContext/computeAverageBlockTime.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { computeAverageBlockTime } from './computeAverageBlockTime'
+
+const FALLBACK_BLOCK_TIME_MS = 25_000
+
+describe('computeAverageBlockTime', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should fall back to 25s when Blockscout is unreachable', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'))
+
+    const result = await computeAverageBlockTime()
+
+    expect(result).toBe(FALLBACK_BLOCK_TIME_MS)
+  })
+
+  it('should fall back to 25s when API returns invalid data', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ average_block_time: null }), { status: 200 }),
+    )
+
+    const result = await computeAverageBlockTime()
+
+    expect(result).toBe(FALLBACK_BLOCK_TIME_MS)
+  })
+})

--- a/src/shared/context/BlockTimeContext/computeAverageBlockTime.ts
+++ b/src/shared/context/BlockTimeContext/computeAverageBlockTime.ts
@@ -1,0 +1,35 @@
+const BLOCKSCOUT_STATS_URL = 'https://rootstock.blockscout.com/api/v2/stats'
+const FALLBACK_BLOCK_TIME_MS = 25_000
+
+interface BlockscoutStatsResponse {
+  average_block_time: number
+}
+
+/**
+ * Fetches the average Rootstock block time from the Blockscout stats API.
+ * Falls back to 25s if the API is unreachable or returns unexpected data.
+ *
+ * @returns Average block time in milliseconds
+ */
+export async function computeAverageBlockTime(): Promise<number> {
+  try {
+    const response = await fetch(BLOCKSCOUT_STATS_URL, { signal: AbortSignal.timeout(10_000) })
+
+    if (!response.ok) {
+      console.error(`[BlockTime] Blockscout API returned ${response.status}`)
+      return FALLBACK_BLOCK_TIME_MS
+    }
+
+    const data: BlockscoutStatsResponse = await response.json()
+    const blockTimeMs = data.average_block_time
+
+    if (typeof blockTimeMs !== 'number' || blockTimeMs <= 0) {
+      console.error('[BlockTime] Unexpected average_block_time value:', blockTimeMs)
+      return FALLBACK_BLOCK_TIME_MS
+    }
+    return Math.round(blockTimeMs)
+  } catch (error) {
+    console.error('[BlockTime] Failed to fetch block time from Blockscout:', error)
+    return FALLBACK_BLOCK_TIME_MS
+  }
+}

--- a/src/shared/context/BlockTimeContext/index.ts
+++ b/src/shared/context/BlockTimeContext/index.ts
@@ -1,0 +1,1 @@
+export { computeAverageBlockTime } from './computeAverageBlockTime'


### PR DESCRIPTION
## Why this exists

The app historically assumed Rootstock behaves like a chain with a fixed block interval. In practice Rootstock is merge-mined with Bitcoin, so **average time between blocks drifts** (roughly high‑20s seconds, not a neat constant). Any feature that hardcodes “one block = X seconds” or “refresh every minute” will be **wrong for countdowns** and **stale for on‑chain reads**.

This change introduces a **small, testable building block** that asks Blockscout’s public stats API for the chain’s reported **average block time** and falls back to a safe default if the network call fails. Nothing in the React tree uses it yet; later PRs wire it into providers and query defaults.

## What you should verify

- The fetch helper behaves sensibly when Blockscout is slow or returns bad data (fallback path).
- No user‑visible behavior changes yet.

## How it fits the larger effort

Later parts mount a provider, set React Query defaults from this value, and remove duplicated polling constants across the app so **one source of truth** drives refresh cadence and time‑in‑block estimates.
