### PR TITLE
DAO-1983: Dynamic block time — provider & query defaults (part 2/9)

### DIFF
--- a/src/app/providers/ContextProviders.tsx
+++ b/src/app/providers/ContextProviders.tsx
@@ -11,6 +11,7 @@ import { GlobalErrorBoundary } from '@/components/ErrorPage/GlobalErrorBoundary'
 import { currentEnvChain, wagmiAdapter, wagmiAdapterConfig } from '@/config'
 import { REOWN_METADATA_URL, REOWN_PROJECT_ID } from '@/lib/constants'
 import { useChunkErrorHandler } from '@/lib/hooks/useChunkErrorHandler'
+import { BlockTimeProvider } from '@/shared/context/BlockTimeContext'
 import { FeatureFlagProvider } from '@/shared/context/FeatureFlag'
 import { ConnectWalletProvider } from '@/shared/walletConnection/connection/ConnectWalletProvider'
 
@@ -90,21 +91,23 @@ export const ContextProviders = ({ children, initialState }: Props) => {
         <FeatureFlagProvider>
           <WagmiProvider config={wagmiAdapterConfig} initialState={initialState}>
             <QueryClientProvider client={queryClient}>
-              <ConnectWalletProvider>
-                <BuilderContextProviderWithPrices>
-                  <BoosterProvider>
-                    <AllocationsContextProvider>
-                      <BalancesProvider>
-                        <TooltipProvider>
-                          <ReviewProposalProvider>
-                            <NavigationGuardProvider>{children}</NavigationGuardProvider>
-                          </ReviewProposalProvider>
-                        </TooltipProvider>
-                      </BalancesProvider>
-                    </AllocationsContextProvider>
-                  </BoosterProvider>
-                </BuilderContextProviderWithPrices>
-              </ConnectWalletProvider>
+              <BlockTimeProvider>
+                <ConnectWalletProvider>
+                  <BuilderContextProviderWithPrices>
+                    <BoosterProvider>
+                      <AllocationsContextProvider>
+                        <BalancesProvider>
+                          <TooltipProvider>
+                            <ReviewProposalProvider>
+                              <NavigationGuardProvider>{children}</NavigationGuardProvider>
+                            </ReviewProposalProvider>
+                          </TooltipProvider>
+                        </BalancesProvider>
+                      </AllocationsContextProvider>
+                    </BoosterProvider>
+                  </BuilderContextProviderWithPrices>
+                </ConnectWalletProvider>
+              </BlockTimeProvider>
             </QueryClientProvider>
           </WagmiProvider>
         </FeatureFlagProvider>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -89,7 +89,6 @@ export const DEPOSITOR_ROLE = '0x013e1f410e70025de956b8838ba99c3a9a9f7eb3e6d6780
 // keccak256('WHITELISTED_USER_ROLE') — mirrors Roles.sol (internal constant, no on-chain getter)
 export const WHITELISTED_USER_ROLE = '0x013e1f410e70025de956b8838ba99c3a9a9f7eb3e6d678062363333c8abd7ea0'
 
-export const AVERAGE_BLOCKTIME = 60_000
 export const CACHE_REVALIDATE_SECONDS = 20
 
 export const RIF = 'RIF'
@@ -111,7 +110,6 @@ export const GRANT_TOKEN_LIMITS = {
 export const RNS_REGISTRY_ADDRESS = process.env.NEXT_PUBLIC_RNS_REGISTRY_ADDRESS as Address
 
 export const NODE_URL = process.env.NEXT_PUBLIC_NODE_URL
-export const DEFAULT_NUMBER_OF_SECONDS_PER_BLOCK = 25
 
 export const GOOGLE_TAG_ID = 'GTM-PTL6VZMT'
 

--- a/src/shared/context/BlockTimeContext/BlockTimeContext.test.tsx
+++ b/src/shared/context/BlockTimeContext/BlockTimeContext.test.tsx
@@ -1,0 +1,46 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { type ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { BlockTimeProvider, useBlockTime } from './BlockTimeContext'
+
+vi.mock('./computeAverageBlockTime', () => ({
+  computeAverageBlockTime: vi.fn().mockResolvedValue(29_000),
+}))
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <BlockTimeProvider>{children}</BlockTimeProvider>
+      </QueryClientProvider>
+    )
+  }
+}
+
+describe('BlockTimeContext', () => {
+  it('should provide fetched block time values', async () => {
+    const { result } = renderHook(() => useBlockTime(), { wrapper: createWrapper() })
+
+    await waitFor(() => {
+      expect(result.current.averageBlockTimeMs).toBe(29_000)
+    })
+
+    expect(result.current.secondsPerBlock).toBe(29)
+  })
+
+  it('should throw when used outside BlockTimeProvider', () => {
+    const queryClient = new QueryClient()
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    expect(() => {
+      renderHook(() => useBlockTime(), { wrapper })
+    }).toThrow('useBlockTime must be used within a BlockTimeProvider')
+  })
+})

--- a/src/shared/context/BlockTimeContext/BlockTimeContext.tsx
+++ b/src/shared/context/BlockTimeContext/BlockTimeContext.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { createContext, ReactNode, useContext, useEffect, useMemo } from 'react'
+
+import { computeAverageBlockTime } from './computeAverageBlockTime'
+
+const FALLBACK_BLOCK_TIME_MS = 25_000
+const ONE_HOUR_MS = 3_600_000
+
+interface BlockTimeContextType {
+  averageBlockTimeMs: number
+  secondsPerBlock: number
+}
+
+const BlockTimeContext = createContext<BlockTimeContextType | null>(null)
+
+interface Props {
+  children: ReactNode
+}
+
+/**
+ * Fetches the average Rootstock block time from Blockscout (server action, cached 1h)
+ * and provides it to the component tree via context. Also sets the fetched value
+ * as the default `refetchInterval` on the QueryClient, so all queries poll at
+ * block time by default — individual hooks only need to override when they want
+ * a different interval or opt out with `refetchInterval: false`.
+ */
+export const BlockTimeProvider = ({ children }: Props) => {
+  const queryClient = useQueryClient()
+  const { data: averageBlockTimeMs = FALLBACK_BLOCK_TIME_MS } = useQuery({
+    queryKey: ['averageBlockTime'],
+    queryFn: computeAverageBlockTime,
+    staleTime: ONE_HOUR_MS,
+    refetchInterval: ONE_HOUR_MS,
+  })
+
+  // Propagate fetched block time as the default refetchInterval for all queries
+  useEffect(() => {
+    queryClient.setDefaultOptions({
+      queries: {
+        ...queryClient.getDefaultOptions().queries,
+        refetchInterval: averageBlockTimeMs,
+      },
+    })
+  }, [averageBlockTimeMs, queryClient])
+
+  const value = useMemo<BlockTimeContextType>(
+    () => ({
+      averageBlockTimeMs,
+      secondsPerBlock: averageBlockTimeMs / 1000,
+    }),
+    [averageBlockTimeMs],
+  )
+
+  return <BlockTimeContext.Provider value={value}>{children}</BlockTimeContext.Provider>
+}
+
+/**
+ * Returns the current average Rootstock block time, fetched from Blockscout and
+ * cached for 1 hour. Falls back to 25s if the fetch fails.
+ *
+ * Most hooks don't need this — `refetchInterval` is set as a QueryClient default.
+ * Use this hook only when you need the block time value directly (e.g. for
+ * `setInterval`, `staleTime`, or block-to-time conversions).
+ *
+ * @returns averageBlockTimeMs — block time in milliseconds
+ * @returns secondsPerBlock — block time in seconds (for time calculations)
+ *
+ * @example
+ * ```ts
+ * const { secondsPerBlock } = useBlockTime()
+ * const seconds = remainingBlocks * secondsPerBlock
+ * ```
+ */
+export const useBlockTime = (): BlockTimeContextType => {
+  const context = useContext(BlockTimeContext)
+  if (context === null) {
+    throw new Error('useBlockTime must be used within a BlockTimeProvider')
+  }
+  return context
+}

--- a/src/shared/context/BlockTimeContext/index.ts
+++ b/src/shared/context/BlockTimeContext/index.ts
@@ -1,1 +1,2 @@
+export { BlockTimeProvider, useBlockTime } from './BlockTimeContext'
 export { computeAverageBlockTime } from './computeAverageBlockTime'


### PR DESCRIPTION
## Why this exists

Once we know the chain’s average block time, we can stop treating polling as an arbitrary magic number. Before this work, many hooks repeated the same `refetchInterval`, and some UI (for example countdowns) multiplied “blocks remaining” by a **guess** that did not match real Rootstock block production.

This part **mounts a provider** that:

- Fetches the average block time (with caching so we do not hammer Blockscout).
- Publishes the value through React context for the few places that need the number directly.
- Sets React Query’s **default** `refetchInterval` so ordinary on‑chain reads naturally track “about once per block” instead of a slower hardcoded cadence.

It also **removes obsolete constants** that encoded the old assumptions, so new code is less likely to reintroduce the same drift.

## What you should verify

- The app still boots with providers in a sensible order (query client must exist before we adjust its defaults).
- Nothing throws when Blockscout is unavailable (fallback should keep the app usable).

## How it fits the larger effort

Follow‑up PRs remove per‑hook `refetchInterval` duplication and add **explicit opt‑outs** where data is not chain‑paced (backend APIs, immutable configuration reads, etc.).
