### PR TITLE
DAO-1983: Dynamic block time — collective rewards hooks (part 3/9)

### DIFF
--- a/src/app/collective-rewards/allocations/hooks/useGetVotingPower.ts
+++ b/src/app/collective-rewards/allocations/hooks/useGetVotingPower.ts
@@ -1,8 +1,8 @@
 import { useAccount, useReadContract } from 'wagmi'
 
 import { StRIFTokenAbi } from '@/lib/abis/StRIFTokenAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { tokenContracts } from '@/lib/contracts'
+
 export const useGetVotingPower = () => {
   const { address } = useAccount()
   const { data, isLoading, error } = useReadContract({
@@ -10,9 +10,6 @@ export const useGetVotingPower = () => {
     address: tokenContracts.stRIF,
     functionName: 'balanceOf',
     args: [address!],
-    query: {
-      refetchInterval: AVERAGE_BLOCKTIME,
-    },
   })
   return {
     data,

--- a/src/app/collective-rewards/components/ActiveBackers/ActiveBackers.tsx
+++ b/src/app/collective-rewards/components/ActiveBackers/ActiveBackers.tsx
@@ -1,9 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-
-import { useHandleErrors } from '../../utils'
 import { CountMetric } from '../CountMetric'
+import { useHandleErrors } from '../../utils'
 
 export const ActiveBackers = () => {
   const { data, isLoading, error } = useQuery<{ count: number }, Error>({
@@ -15,7 +13,6 @@ export const ActiveBackers = () => {
       return response.json()
     },
     queryKey: ['activeBackers'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   useHandleErrors({ error, title: 'Error loading active backers' })

--- a/src/app/collective-rewards/metrics/hooks/useIntervalTimestamp.ts
+++ b/src/app/collective-rewards/metrics/hooks/useIntervalTimestamp.ts
@@ -1,18 +1,19 @@
 import { DateTime } from 'luxon'
 import { useEffect, useState } from 'react'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
+import { useBlockTime } from '@/shared/context/BlockTimeContext'
 
 export const useIntervalTimestamp = () => {
+  const { averageBlockTimeMs } = useBlockTime()
   const [timestamp, setTimestamp] = useState(BigInt(DateTime.now().toUnixInteger()))
 
   useEffect(() => {
     const interval = setInterval(() => {
       setTimestamp(BigInt(DateTime.now().toUnixInteger()))
-    }, AVERAGE_BLOCKTIME)
+    }, averageBlockTimeMs)
 
     return () => clearInterval(interval)
-  }, [])
+  }, [averageBlockTimeMs])
 
   return timestamp
 }

--- a/src/app/collective-rewards/rewards/backers/hooks/useGetBackerStakingHistory.ts
+++ b/src/app/collective-rewards/rewards/backers/hooks/useGetBackerStakingHistory.ts
@@ -1,8 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { Address } from 'viem'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-
 import { fetchBackerStakingHistory } from '../actions/fetchBackerStakingHistory'
 
 export interface BackerStakingHistory {
@@ -32,7 +30,6 @@ export const useGetBackerStakingHistoryWithStateSync = (backer: Address) => {
       return response.json()
     },
     queryKey: ['backerStakingHistory', backer],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   return {
@@ -46,7 +43,6 @@ export const useGetBackerStakingHistoryWithGraph = (backer: Address) => {
   const { data, isLoading, error } = useQuery({
     queryFn: () => fetchBackerStakingHistory(backer),
     queryKey: ['backerStakingHistory', backer],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   return {

--- a/src/app/collective-rewards/rewards/builders/hooks/useGetBuilderRewardsClaimedLogs.ts
+++ b/src/app/collective-rewards/rewards/builders/hooks/useGetBuilderRewardsClaimedLogs.ts
@@ -3,7 +3,6 @@ import { Address, getAddress, parseEventLogs } from 'viem'
 
 import { fetchBuilderRewardsClaimed } from '@/app/collective-rewards/actions'
 import { GaugeAbi } from '@/lib/abis/tok/GaugeAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 
 type BuilderRewardsClaimedEventLog = ReturnType<
   typeof parseEventLogs<typeof GaugeAbi, true, 'BuilderRewardsClaimed'>
@@ -30,7 +29,6 @@ export const useGetBuilderRewardsClaimedLogs = (gauge: Address) => {
       }, {})
     },
     queryKey: ['builderRewardsClaimedLogs', gauge],
-    refetchInterval: AVERAGE_BLOCKTIME,
     initialData: {},
   })
 

--- a/src/app/collective-rewards/rewards/hooks/useGetChartBackingData.tsx
+++ b/src/app/collective-rewards/rewards/hooks/useGetChartBackingData.tsx
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { DailyAllocationItem } from '@/app/collective-rewards/types'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 
 export const useGetChartBackingData = () => {
   const { data, isLoading, error } = useQuery<DailyAllocationItem[], Error>({
@@ -23,7 +22,6 @@ export const useGetChartBackingData = () => {
       return result.data as DailyAllocationItem[]
     },
     queryKey: ['backingChartData'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   return {

--- a/src/app/collective-rewards/rewards/hooks/useGetChartRewardsData.tsx
+++ b/src/app/collective-rewards/rewards/hooks/useGetChartRewardsData.tsx
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { CycleRewardsItem } from '@/app/collective-rewards/types'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 
 export const useGetChartRewardsData = () => {
   const { data, isLoading, error } = useQuery<CycleRewardsItem[], Error>({
@@ -23,7 +22,6 @@ export const useGetChartRewardsData = () => {
       return result.data as CycleRewardsItem[]
     },
     queryKey: ['rewardsChartData'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   return {

--- a/src/app/collective-rewards/rewards/hooks/useGetGaugesEvents.ts
+++ b/src/app/collective-rewards/rewards/hooks/useGetGaugesEvents.ts
@@ -1,13 +1,12 @@
-import { useQuery } from '@tanstack/react-query'
 import { AbiEvent, Address, parseEventLogs } from 'viem'
-
 import {
   fetchBackerRewardsClaimed,
   fetchBuilderRewardsClaimed,
   fetchGaugeNotifyRewardLogs,
 } from '@/app/collective-rewards/actions'
+import { useQuery } from '@tanstack/react-query'
+
 import { GaugeAbi } from '@/lib/abis/tok/GaugeAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 
 type EventEntry = Extract<(typeof GaugeAbi)[number], AbiEvent>
 type EventName = Extract<
@@ -38,7 +37,6 @@ export const useGetGaugesEvents = <T extends EventName>(gauges: Address[], event
       }, {})
     },
     queryKey: ['useGetGaugesEvents', eventName, gauges],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   return {

--- a/src/app/collective-rewards/rewards/hooks/useGetNotifyRewardLogs.ts
+++ b/src/app/collective-rewards/rewards/hooks/useGetNotifyRewardLogs.ts
@@ -1,10 +1,9 @@
-import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { Address, getAddress, isAddressEqual, parseEventLogs } from 'viem'
 
 import { fetchGaugeNotifyRewardLogs } from '@/app/collective-rewards/actions'
 import { GaugeAbi } from '@/lib/abis/tok/GaugeAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 
 export type GaugeNotifyRewardEventLog = ReturnType<
   typeof parseEventLogs<typeof GaugeAbi, true, 'NotifyReward'>
@@ -32,7 +31,6 @@ export const useGetGaugeNotifyRewardLogs = (
       })
     },
     queryKey: ['notifyRewardLogs', gauge],
-    refetchInterval: AVERAGE_BLOCKTIME,
     initialData: [],
   })
 

--- a/src/app/collective-rewards/rewards/hooks/useGetRewardDistributionFinishedLogs.ts
+++ b/src/app/collective-rewards/rewards/hooks/useGetRewardDistributionFinishedLogs.ts
@@ -3,7 +3,6 @@ import { parseEventLogs } from 'viem'
 
 import { fetchRewardDistributionFinished } from '@/app/collective-rewards/actions'
 import { type BackersManagerAbi, getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BackersManagerAddress } from '@/lib/contracts'
 
 export type RewardDistributionFinishedEventLog = ReturnType<
@@ -22,7 +21,6 @@ export const useGetRewardDistributionFinishedLogs = () => {
       })
     },
     queryKey: ['RewardDistributionFinished', BackersManagerAddress],
-    refetchInterval: AVERAGE_BLOCKTIME,
     initialData: [],
   })
 


### PR DESCRIPTION
## Why this exists

After the provider sets a sensible default polling interval for on‑chain data, **individual hooks should not repeat the same interval** everywhere. Duplication makes it easy for one screen to refresh at a different rate than another for no good reason, and it hides which reads are truly “chain paced” versus “static” or “API paced.”

This batch updates collective‑rewards–related hooks to **inherit the default** instead of importing a shared constant. Behavior intent: on‑chain values move with the chain; less boilerplate in each hook.

## What you should verify

- Collective rewards screens still update within a reasonable window after a transaction confirms (no need to manually refresh).
- No new noisy polling against backend HTTP routes from these hooks.

## How it fits the larger effort

This is one of several focused batches that migrate the codebase without a single huge diff. The next batches cover adjacent feature areas using the same pattern.
