### PR TITLE
DAO-1983: Dynamic block time — rewards & tx history hooks (part 4/9)

### DIFF
--- a/src/app/collective-rewards/shared/hooks/useGetABIWithGraph.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetABIWithGraph.ts
@@ -1,7 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-
 import { getCachedABIData } from '../actions/fetchABIData'
 import { useGetABI } from './useGetABI'
 
@@ -13,7 +11,6 @@ export const useGetMetricsAbiWithGraph = () => {
   } = useQuery({
     queryFn: () => getCachedABIData(),
     queryKey: ['abiData'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   const data = useGetABI(abiData)

--- a/src/app/collective-rewards/shared/hooks/useGetABIWithStateSync.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetABIWithStateSync.ts
@@ -1,8 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import Big from 'big.js'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-
 import { AbiData, useGetABI } from './useGetABI'
 import { useStateSyncHealthCheck } from './useStateSyncHealthCheck'
 
@@ -29,7 +27,6 @@ export const useGetMetricsAbiWithStateSync = () => {
       return response.json()
     },
     queryKey: ['abiData'],
-    refetchInterval: AVERAGE_BLOCKTIME,
     enabled: !healthCheckIsLoading && isStateSyncHealthy,
   })
 

--- a/src/app/collective-rewards/shared/hooks/useGetActiveBuildersCount.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetActiveBuildersCount.ts
@@ -1,7 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-
 export const useGetActiveBuildersCount = () => {
   const { data, isLoading, error } = useQuery<{ count: number }, Error>({
     queryFn: async () => {
@@ -12,7 +10,6 @@ export const useGetActiveBuildersCount = () => {
       return response.json()
     },
     queryKey: ['activeBuilders'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   return { data, isLoading, error }

--- a/src/app/collective-rewards/shared/hooks/useGetLastCycleRewardsWithStateSync.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetLastCycleRewardsWithStateSync.ts
@@ -1,7 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-
 import { CycleData } from './useGetABI'
 import { useStateSyncHealthCheck } from './useStateSyncHealthCheck'
 
@@ -28,7 +26,6 @@ export const useGetLastCycleRewardsWithStateSync = () => {
       return result.data as CycleData[]
     },
     queryKey: ['lastCycleRewardsWithStateSync'],
-    refetchInterval: AVERAGE_BLOCKTIME,
     enabled: !healthCheckIsLoading && isStateSyncHealthy,
   })
 

--- a/src/app/collective-rewards/shared/hooks/useGetRewardsDistributionRewards.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetRewardsDistributionRewards.ts
@@ -3,7 +3,6 @@ import { parseEventLogs } from 'viem'
 
 import { fetchRewardDistributionRewards } from '@/app/collective-rewards/actions'
 import { type BackersManagerAbi, getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BackersManagerAddress } from '@/lib/contracts'
 
 export type RewardDistributionRewardsEventLog = ReturnType<
@@ -22,7 +21,6 @@ export const useGetRewardDistributionRewardsLogs = () => {
       }) as Log[]
     },
     queryKey: ['RewardDistributionRewards', BackersManagerAddress],
-    refetchInterval: AVERAGE_BLOCKTIME,
     initialData: [],
   })
 

--- a/src/app/collective-rewards/shared/hooks/useStateSyncHealthCheck.ts
+++ b/src/app/collective-rewards/shared/hooks/useStateSyncHealthCheck.ts
@@ -1,13 +1,12 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 
 import type { HealthCheckResult } from '@/app/api/health/healthCheck.utils'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { sentryClient } from '@/lib/sentry/sentry-client'
 
 export const useStateSyncHealthCheck = (
   options?: Omit<UseQueryOptions<HealthCheckResult, Error>, 'queryKey' | 'queryFn'>,
-) =>
-  useQuery<HealthCheckResult, Error>({
+) => {
+  return useQuery<HealthCheckResult, Error>({
     queryFn: async (): Promise<HealthCheckResult> => {
       const response = await fetch('/api/health', {
         method: 'GET',
@@ -41,7 +40,7 @@ export const useStateSyncHealthCheck = (
         throw new Error('Invalid health check data')
       }
     },
-    refetchInterval: AVERAGE_BLOCKTIME,
     ...options,
     queryKey: ['healthCheck'],
   })
+}

--- a/src/app/collective-rewards/user/hooks/useGetGaugesArray.ts
+++ b/src/app/collective-rewards/user/hooks/useGetGaugesArray.ts
@@ -3,7 +3,6 @@ import { AbiFunction, Address } from 'viem'
 import { useReadContracts } from 'wagmi'
 
 import { BuilderRegistryAbi } from '@/lib/abis/tok/BuilderRegistryAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BuilderRegistryAddress } from '@/lib/contracts'
 import { useReadBuilderRegistry } from '@/shared/hooks/contracts'
 
@@ -36,9 +35,6 @@ export const useGetGaugesArray = () => {
     error: gaugesAddressError,
   } = useReadContracts<Address[]>({
     contracts: contractCalls,
-    query: {
-      refetchInterval: AVERAGE_BLOCKTIME,
-    },
   })
 
   const gauges = useMemo(() => gaugesAddress?.map(gauge => gauge.result as Address) ?? [], [gaugesAddress])

--- a/src/app/collective-rewards/user/hooks/useGetProposalsState.ts
+++ b/src/app/collective-rewards/user/hooks/useGetProposalsState.ts
@@ -4,7 +4,6 @@ import { useReadContracts } from 'wagmi'
 
 import { ProposalsToState } from '@/app/collective-rewards/types'
 import { GovernorAbi } from '@/lib/abis/Governor'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { GovernorAddress } from '@/lib/contracts'
 import { ProposalState } from '@/shared/types'
 
@@ -28,9 +27,6 @@ export const useGetProposalsState = (proposalIds: bigint[]) => {
     error,
   } = useReadContracts<ProposalState[]>({
     contracts: contractCalls,
-    query: {
-      refetchInterval: AVERAGE_BLOCKTIME,
-    },
   })
 
   const proposalsToStates = useMemo(() => {

--- a/src/app/my-rewards/tx-history/hooks/useGetBackedBuilders.ts
+++ b/src/app/my-rewards/tx-history/hooks/useGetBackedBuilders.ts
@@ -1,9 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { Address, isAddressEqual } from 'viem'
-
-import { useBuilderContext } from '@/app/collective-rewards/user/context/BuilderContext'
 import { shortAddress } from '@/lib/utils'
+import { useBuilderContext } from '@/app/collective-rewards/user/context/BuilderContext'
 
 type BackerToBuilderResponse = Array<{
   id: string
@@ -43,6 +42,7 @@ export const useGetBackedBuilders = (address?: Address) => {
     },
     queryKey: ['backerToBuilder', address],
     enabled: !!address,
+    refetchInterval: false,
   })
 
   // Transform the data into filter options

--- a/src/app/my-rewards/tx-history/hooks/useGetTransactionHistory.ts
+++ b/src/app/my-rewards/tx-history/hooks/useGetTransactionHistory.ts
@@ -1,9 +1,8 @@
-import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { useAccount } from 'wagmi'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-import { TOKENS } from '@/lib/tokens'
 import { usePricesContext } from '@/shared/context/PricesContext'
+import { TOKENS } from '@/lib/tokens'
 
 import { TransactionHistoryItem } from '../utils/types'
 
@@ -115,7 +114,6 @@ export const useGetTransactionHistory = (params?: UseGetTransactionHistoryParams
       builder,
       rewardToken,
     ],
-    refetchInterval: AVERAGE_BLOCKTIME,
     enabled: !!address,
     placeholderData: keepPreviousData,
   })


### PR DESCRIPTION
## Why this exists

The rewards and “my rewards” surfaces mix **on‑chain state** (balances, gauges, cycles) with **historical or derived data**. When every hook carries its own polling interval, the UX becomes inconsistent and the codebase becomes harder to reason about.

This batch continues the same approach as the previous one: **let chain‑paced reads inherit the global default** unless there is a strong reason to differ. That keeps refresh behavior aligned with how fast Rootstock actually produces blocks.

## What you should verify

- Rewards dashboards and transaction history views still feel responsive after on‑chain actions.
- You do not see obvious “stuck until manual refresh” regressions.

## How it fits the larger effort

This narrows the remaining manual intervals to places that truly need custom timing (fast polling during an active action, or explicit “do not poll” for APIs).
