### PR TITLE
DAO-1983: Dynamic block time — vault, delegation, countdown (part 6/9)

### DIFF
--- a/src/app/user/Delegation/hooks/useGetDelegates.ts
+++ b/src/app/user/Delegation/hooks/useGetDelegates.ts
@@ -2,7 +2,6 @@ import { Address } from 'viem'
 import { useReadContract } from 'wagmi'
 
 import { StRIFTokenAbi } from '@/lib/abis/StRIFTokenAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { tokenContracts } from '@/lib/contracts'
 
 const stRifContract = {
@@ -20,9 +19,6 @@ export const useGetDelegates = (address: Address | undefined) => {
       ...stRifContract,
       functionName: 'delegates',
       args: [address],
-      query: {
-        refetchInterval: AVERAGE_BLOCKTIME,
-      },
     },
   )
 

--- a/src/app/vault/history/hooks/useGetVaultHistory.ts
+++ b/src/app/vault/history/hooks/useGetVaultHistory.ts
@@ -1,8 +1,6 @@
-import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { useAccount } from 'wagmi'
-
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 
 import { fetchVaultHistory, VaultHistoryResponse } from '../utils/api'
 import { VaultHistoryItemAPI } from '../utils/types'
@@ -58,7 +56,6 @@ export const useGetVaultHistory = (params?: UseGetVaultHistoryParams) => {
       sortDirection,
       type.length > 0 ? [...type].sort().join(',') : '',
     ],
-    refetchInterval: AVERAGE_BLOCKTIME,
     enabled: !!address,
   })
 

--- a/src/app/vault/hooks/useVaultDepositLimiter.ts
+++ b/src/app/vault/hooks/useVaultDepositLimiter.ts
@@ -1,8 +1,7 @@
 import { useMemo } from 'react'
-import { useAccount, useReadContracts } from 'wagmi'
+import { useReadContracts, useAccount } from 'wagmi'
 
 import { VaultDepositLimiterAbi } from '@/lib/abis/VaultDepositLimiterAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 
 import { useVaultDepositLimiterAddress } from './useVaultDepositLimiterAddress'
 
@@ -62,7 +61,6 @@ export function useVaultDepositLimiter() {
   } = useReadContracts({
     contracts,
     query: {
-      refetchInterval: AVERAGE_BLOCKTIME, // Refetch every minute
       enabled: !!depositLimiterAddress, // Only run when we have the address
     },
   })

--- a/src/app/vault/hooks/useVaultDepositLimiterAddress.ts
+++ b/src/app/vault/hooks/useVaultDepositLimiterAddress.ts
@@ -1,7 +1,6 @@
-import { Address } from 'viem'
 import { useReadContract } from 'wagmi'
-
 import { vault } from '@/lib/contracts'
+import { Address } from 'viem'
 
 /**
  * Hook to read the deposit limiter address from the vault contract
@@ -17,7 +16,7 @@ export function useVaultDepositLimiterAddress() {
     abi: vault.abi,
     functionName: 'depositLimiter',
     query: {
-      // No refetch interval since this value doesn't change
+      refetchInterval: false,
       staleTime: Infinity,
       gcTime: Infinity,
     },

--- a/src/components/Countdown/Countdown.stories.tsx
+++ b/src/components/Countdown/Countdown.stories.tsx
@@ -3,6 +3,7 @@ import { Countdown } from './Countdown'
 import { TimeSource } from './types'
 import Big from '@/lib/big'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { BlockTimeProvider } from '@/shared/context/BlockTimeContext'
 
 const queryClient = new QueryClient()
 
@@ -16,7 +17,9 @@ const meta: Meta<typeof Countdown> = {
   decorators: [
     Story => (
       <QueryClientProvider client={queryClient}>
-        <Story />
+        <BlockTimeProvider>
+          <Story />
+        </BlockTimeProvider>
       </QueryClientProvider>
     ),
   ],

--- a/src/components/Countdown/Countdown.tsx
+++ b/src/components/Countdown/Countdown.tsx
@@ -1,22 +1,29 @@
+'use client'
+
 import moment from 'moment'
 import { useBlockNumber } from 'wagmi'
 
 import { Paragraph } from '@/components/Typography'
-import Big from '@/lib/big'
-import { DEFAULT_NUMBER_OF_SECONDS_PER_BLOCK } from '@/lib/constants'
 import { cn } from '@/lib/utils'
+import { useBlockTime } from '@/shared/context/BlockTimeContext'
+import Big from '@/lib/big'
 
 import { CountdownProps, TimeSource } from './types'
 
 /**
  * Calculates the time remaining in seconds
  */
-const calculateTimeRemaining = (end: Big, currentTime: Big, timeSource: TimeSource): number => {
+const calculateTimeRemaining = (
+  end: Big,
+  currentTime: Big,
+  timeSource: TimeSource,
+  secondsPerBlock: number,
+): number => {
   const remaining = end.minus(currentTime)
   if (remaining.lte(0)) return 0
 
   if (timeSource === 'blocks') {
-    return remaining.mul(DEFAULT_NUMBER_OF_SECONDS_PER_BLOCK).toNumber()
+    return remaining.mul(secondsPerBlock).toNumber()
   } else {
     return remaining.toNumber()
   }
@@ -104,6 +111,7 @@ export function Countdown({
   className,
   colorDirection = 'normal',
 }: CountdownProps) {
+  const { secondsPerBlock } = useBlockTime()
   const { data: currentBlockNumber } = useBlockNumber()
 
   // Calculate current time based on timeSource
@@ -114,7 +122,7 @@ export function Countdown({
         : Big(0)
       : Big(Math.floor(Date.now() / 1000))
 
-  const timeRemainingSec = calculateTimeRemaining(end, currentTime, timeSource)
+  const timeRemainingSec = calculateTimeRemaining(end, currentTime, timeSource, secondsPerBlock)
   const ratio = calculateRatio(end, currentTime, referenceStart)
 
   // Color coding is automatically disabled if ratio cannot be calculated (no referenceStart)

--- a/src/shared/hooks/contracts/collective-rewards/useReadBackersManager.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadBackersManager.ts
@@ -1,9 +1,6 @@
-import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
-
 import { type BackersManagerAbi, getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BackersManagerAddress } from '@/lib/contracts'
-
+import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
 
 type BackersManagerFunctionName = ViewPureFunctionName<BackersManagerAbi>
@@ -24,7 +21,6 @@ export const useReadBackersManager = <TFunctionName extends BackersManagerFuncti
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/collective-rewards/useReadBuilderRegistry.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadBuilderRegistry.ts
@@ -1,9 +1,6 @@
-import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
-
 import { type BuilderRegistryAbi, getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BuilderRegistryAddress } from '@/lib/contracts'
-
+import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
 
 type BuilderRegistryFunctionName = ViewPureFunctionName<BuilderRegistryAbi>
@@ -24,7 +21,6 @@ export const useReadBuilderRegistry = <TFunctionName extends BuilderRegistryFunc
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/collective-rewards/useReadBuilderRegistryForMultipleArgs.test.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadBuilderRegistryForMultipleArgs.test.ts
@@ -1,12 +1,10 @@
 import { getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BuilderRegistryAddress } from '@/lib/contracts'
 import { renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, Mock, vi } from 'vitest'
 import { useReadContracts } from 'wagmi'
 import { useReadBuilderRegistryForMultipleArgs } from './useReadBuilderRegistryForMultipleArgs'
 
-// Mock wagmi's useReadContracts
 vi.mock('wagmi', () => ({
   useReadContracts: vi.fn(),
 }))
@@ -59,7 +57,6 @@ describe('useReadBuilderRegistries hook', () => {
         ],
         query: {
           retry: true,
-          refetchInterval: AVERAGE_BLOCKTIME,
         },
       }),
     )

--- a/src/shared/hooks/contracts/collective-rewards/useReadBuilderRegistryForMultipleArgs.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadBuilderRegistryForMultipleArgs.ts
@@ -1,10 +1,7 @@
+import { getAbi, type BuilderRegistryAbi } from '@/lib/abis/tok'
+import { BuilderRegistryAddress } from '@/lib/contracts'
 import { useMemo } from 'react'
 import { UseReadContractParameters, UseReadContractReturnType, useReadContracts } from 'wagmi'
-
-import { type BuilderRegistryAbi, getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-import { BuilderRegistryAddress } from '@/lib/contracts'
-
 import { UseReadContractForMultipleArgsConfig, ViewPureFunctionName } from '../types'
 
 type BuilderRegistryFunctionName = ViewPureFunctionName<BuilderRegistryAbi>
@@ -33,7 +30,6 @@ export const useReadBuilderRegistryForMultipleArgs = <TFunctionName extends Buil
     })),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })


### PR DESCRIPTION
## Why this exists

Vault and delegation flows combine **high‑value financial state** with **timers** shown to users. A countdown that assumes the wrong seconds‑per‑block will drift badly over multi‑day periods; vault previews that lag the chain undermine trust.

This batch aligns those surfaces with the same block‑time‑aware approach: **use real average block time where time is computed from blocks**, and stop hardcoding refresh intervals on reads that should follow chain pace.

## What you should verify

- Vault balances and limits reflect recent transactions within a reasonable time.
- Countdowns tied to block deltas look plausible compared to explorer timestamps (small drift is OK; large systematic drift is not).

## How it fits the larger effort

Remaining shared contract reader hooks are handled in the next batch; fund‑manager and BTC vault areas follow after that.
