### PR TITLE
DAO-1983: Dynamic block time — shared proposal & reward readers (part 7/9)

### DIFF
--- a/src/shared/hooks/contracts/collective-rewards/useReadCycleTimeKeeper.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadCycleTimeKeeper.ts
@@ -1,9 +1,6 @@
-import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
-
 import { type CycleTimeKeeperAbi, getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BackersManagerAddress } from '@/lib/contracts'
-
+import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
 
 type CycleTimeKeeperFunctionName = ViewPureFunctionName<CycleTimeKeeperAbi>
@@ -24,7 +21,6 @@ export const useReadCycleTimeKeeper = <TFunctionName extends CycleTimeKeeperFunc
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/collective-rewards/useReadGauges.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadGauges.ts
@@ -2,8 +2,7 @@ import { useMemo } from 'react'
 import { Abi } from 'viem'
 import { UseReadContractParameters, UseReadContractReturnType, useReadContracts } from 'wagmi'
 
-import { type GaugeAbi, getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
+import { getAbi, type GaugeAbi } from '@/lib/abis/tok'
 
 import { UseReadContractsConfig, ViewPureFunctionName } from '../types'
 
@@ -34,7 +33,6 @@ export const useReadGauges = <TFunctionName extends GaugeFunctionName>(
     })),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/collective-rewards/useReadRewardDistributor.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadRewardDistributor.ts
@@ -1,9 +1,6 @@
-import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
-
 import { getAbi, type RewardDistributorAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { RewardDistributorAddress } from '@/lib/contracts'
-
+import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
 
 type RewardDistributorFunctionName = ViewPureFunctionName<RewardDistributorAbi>
@@ -24,7 +21,6 @@ export const useReadRewardDistributor = <TFunctionName extends RewardDistributor
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/useCommunity.ts
+++ b/src/shared/hooks/useCommunity.ts
@@ -1,17 +1,16 @@
-import { useQuery } from '@tanstack/react-query'
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Address } from 'viem'
-import { useAccount, useReadContracts, useWaitForTransactionReceipt, useWriteContract } from 'wagmi'
 import { readContracts } from 'wagmi/actions'
-
-import { communitiesMapByContract } from '@/app/communities/communityUtils'
+import { useMemo, useCallback, useEffect, useState } from 'react'
+import { abiContractsMap, DEFAULT_NFT_CONTRACT_ABI } from '@/lib/contracts'
+import { Address } from 'viem'
+import { useReadContracts, useAccount, useWaitForTransactionReceipt, useWriteContract } from 'wagmi'
+import { fetchIpfsNftMeta, ipfsGatewayUrl } from '@/lib/ipfs'
+import { NftMeta, CommunityData } from '../types'
 import { config } from '@/config'
 import Big from '@/lib/big'
-import { abiContractsMap, DEFAULT_NFT_CONTRACT_ABI } from '@/lib/contracts'
-import { fetchIpfsNftMeta, ipfsGatewayUrl } from '@/lib/ipfs'
-import { splitWords } from '@/lib/utils'
-
-import { CommunityData, NftMeta } from '../types'
+import { useQuery } from '@tanstack/react-query'
+import { axiosInstance, splitWords } from '@/lib/utils'
+import { NftDataFromAddressesReturnType } from '@/app/user/api/communities/route'
+import { communitiesMapByContract } from '@/app/communities/communityUtils'
 
 /**
  * Hook for loading NFT metadata from IPFS
@@ -62,10 +61,11 @@ const useContractData = (nftAddress?: Address) => {
 
   const { data: nftData = {} } = useQuery({
     queryKey: ['nftInfo'],
-    queryFn: async () => {
-      const res = await fetch('/user/api/communities')
-      return res.json()
-    },
+    queryFn: () =>
+      axiosInstance
+        .get<NftDataFromAddressesReturnType>('/user/api/communities', { baseURL: '/' })
+        .then(({ data }) => data),
+    refetchInterval: false,
   })
 
   return useMemo(() => {

--- a/src/shared/hooks/useDiscourseTopic.ts
+++ b/src/shared/hooks/useDiscourseTopic.ts
@@ -1,12 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
-
 import { extractTopicIdFromDiscourseUrl } from '@/lib/discourse'
 import type { DiscourseTopicResponse } from '@/shared/types/discourse'
 
 interface UseDiscourseTopicOptions {
   enabled?: boolean
   staleTime?: number
-  refetchInterval?: number
+  refetchInterval?: number | false
 }
 
 /**
@@ -27,7 +26,7 @@ export function useDiscourseTopic(
   discourseUrl: string | null | undefined,
   options: UseDiscourseTopicOptions = {},
 ) {
-  const { enabled = true, staleTime = 5 * 60 * 1000, refetchInterval } = options
+  const { enabled = true, staleTime = 5 * 60 * 1000, refetchInterval = false } = options
 
   return useQuery<DiscourseTopicResponse, Error>({
     queryKey: ['discourse-topic', discourseUrl],

--- a/src/shared/hooks/useExecuteProposal.ts
+++ b/src/shared/hooks/useExecuteProposal.ts
@@ -1,10 +1,9 @@
 import { useMemo } from 'react'
 import { useReadContract, useWriteContract } from 'wagmi'
-
+import { GovernorAddress } from '@/lib/contracts'
 import { GovernorAbi } from '@/lib/abis/Governor'
 import { TimelockControllerAbi } from '@/lib/abis/TimelockController'
 import Big from '@/lib/big'
-import { GovernorAddress } from '@/lib/contracts'
 
 const DAO_DEFAULT_PARAMS = {
   abi: GovernorAbi,
@@ -34,6 +33,7 @@ export const useExecuteProposal = (proposalId: string) => {
   const { data: timelockAddress } = useReadContract({
     ...DAO_DEFAULT_PARAMS,
     functionName: 'timelock',
+    query: { refetchInterval: false },
   })
 
   const { data: minDelay } = useReadContract({
@@ -42,7 +42,8 @@ export const useExecuteProposal = (proposalId: string) => {
     functionName: 'getMinDelay',
     query: {
       enabled: !!timelockAddress,
-      staleTime: 60000, // Timelock delay rarely changes
+      refetchInterval: false,
+      staleTime: 60000,
     },
   })
 
@@ -50,7 +51,7 @@ export const useExecuteProposal = (proposalId: string) => {
 
   // Memoized calculations
   const proposalQueuedTime = useMemo(() => {
-    if (!proposalEta || !minDelay) return
+    if (!proposalEta || !minDelay) return undefined
     return Big(proposalEta.toString()).minus(minDelay.toString())
   }, [proposalEta, minDelay])
 

--- a/src/shared/hooks/useGetExternalDelegatedAmount.ts
+++ b/src/shared/hooks/useGetExternalDelegatedAmount.ts
@@ -4,7 +4,7 @@ import { useAccount, useReadContract } from 'wagmi'
 
 import { useGetDelegates } from '@/app/user/Delegation/hooks/useGetDelegates'
 import { StRIFTokenAbi } from '@/lib/abis/StRIFTokenAbi'
-import { AVERAGE_BLOCKTIME, STRIF_ADDRESS } from '@/lib/constants'
+import { STRIF_ADDRESS } from '@/lib/constants'
 import { getEnsDomainName } from '@/lib/rns'
 
 /**
@@ -35,7 +35,7 @@ export const useGetExternalDelegatedAmount = (address: Address | undefined) => {
     refetch: refetchDelegate,
   } = useGetDelegates(address)
 
-  const [delegateeRns, setDelegateeRns] = useState<string | undefined>()
+  const [delegateeRns, setDelegateeRns] = useState<string | undefined>(undefined)
 
   useEffect(() => {
     if (delegateeAddress) {
@@ -52,9 +52,6 @@ export const useGetExternalDelegatedAmount = (address: Address | undefined) => {
       address: STRIF_ADDRESS,
       functionName: 'getVotes',
       args: [ownAddress],
-      query: {
-        refetchInterval: AVERAGE_BLOCKTIME,
-      },
     },
   )
 
@@ -64,9 +61,6 @@ export const useGetExternalDelegatedAmount = (address: Address | undefined) => {
       address: STRIF_ADDRESS,
       functionName: 'getVotes',
       args: [delegateeAddress],
-      query: {
-        refetchInterval: AVERAGE_BLOCKTIME,
-      },
     },
   )
 
@@ -80,9 +74,6 @@ export const useGetExternalDelegatedAmount = (address: Address | undefined) => {
       address: STRIF_ADDRESS,
       functionName: 'balanceOf',
       args: [ownAddress],
-      query: {
-        refetchInterval: AVERAGE_BLOCKTIME,
-      },
     },
   )
 
@@ -103,8 +94,10 @@ export const useGetExternalDelegatedAmount = (address: Address | undefined) => {
     amountDelegatedToMe = votingPower || 0n
   }
 
-  if (didIDelegateToMyself && votingPower && balance && votingPower > balance) {
-    amountDelegatedToMe = votingPower - balance
+  if (didIDelegateToMyself && votingPower && balance) {
+    if (votingPower > balance) {
+      amountDelegatedToMe = votingPower - balance
+    }
   }
 
   const refetch = () => {

--- a/src/shared/hooks/usePagination.ts
+++ b/src/shared/hooks/usePagination.ts
@@ -1,7 +1,5 @@
-import { useQuery, UseQueryResult } from '@tanstack/react-query'
 import { useCallback, useMemo, useState } from 'react'
-
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
+import { useQuery, UseQueryResult } from '@tanstack/react-query'
 
 interface UsePaginatedQueryOptions<T> {
   queryKey: string[]
@@ -30,7 +28,6 @@ export function usePagination<T>({
     queryKey,
     queryFn,
     refetchOnWindowFocus: false,
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   const allItems = useMemo(() => (Array.isArray(data) ? data : []), [data])

--- a/src/shared/hooks/useProposalState.ts
+++ b/src/shared/hooks/useProposalState.ts
@@ -1,8 +1,7 @@
-import { Address } from 'viem'
 import { useReadContract } from 'wagmi'
-
-import { GovernorAbi } from '@/lib/abis/Governor'
 import { GovernorAddress } from '@/lib/contracts'
+import { Address } from 'viem'
+import { GovernorAbi } from '@/lib/abis/Governor'
 
 enum ProposalState {
   Pending,
@@ -23,7 +22,7 @@ export const useProposalState = (proposalId: string, shouldRefetch = true) => {
     functionName: 'state',
     args: [BigInt(proposalId)],
     query: {
-      ...(shouldRefetch && { refetchInterval: 5000 }),
+      refetchInterval: shouldRefetch ? 5000 : false,
     },
   })
 

--- a/src/shared/hooks/useVoteOnProposal.ts
+++ b/src/shared/hooks/useVoteOnProposal.ts
@@ -1,11 +1,10 @@
-import { useState } from 'react'
-import { Address } from 'viem'
-import { useAccount, useReadContract, useWaitForTransactionReceipt, useWriteContract } from 'wagmi'
-
 import { GovernorAbi } from '@/lib/abis/Governor'
 import { GovernorAddress } from '@/lib/contracts'
+import { Address } from 'viem'
+import { useAccount, useReadContract, useWaitForTransactionReceipt, useWriteContract } from 'wagmi'
 import { useProposalState } from '@/shared/hooks/useProposalState'
-import { Vote, VOTES_MAP_REVERSE } from '@/shared/types'
+import { useState } from 'react'
+import { VOTES_MAP_REVERSE, Vote } from '@/shared/types'
 
 const DEFAULT_DAO = {
   address: GovernorAddress as Address,
@@ -14,7 +13,7 @@ const DEFAULT_DAO = {
 
 export const useVoteOnProposal = (proposalId: string, shouldRefetch = true) => {
   const { address } = useAccount()
-  const [txHash, setTxHash] = useState<`0x${string}` | undefined>()
+  const [txHash, setTxHash] = useState<`0x${string}` | undefined>(undefined)
 
   // First read the proposal to see if it's active
   const { proposalState, proposalStateHuman } = useProposalState(proposalId)
@@ -27,7 +26,7 @@ export const useVoteOnProposal = (proposalId: string, shouldRefetch = true) => {
     functionName: 'hasVoted',
     args: [BigInt(proposalId), address as Address],
     query: {
-      ...(shouldRefetch && { refetchInterval: 5000 }),
+      refetchInterval: shouldRefetch ? 5000 : false,
     },
   })
 


### PR DESCRIPTION
## Why this exists

A number of shared hooks centralize proposal lifecycle reads and collective‑rewards contract reads. If these oscillate between “no polling”, “slow polling”, and “copy‑pasted polling”, the app feels inconsistent and bugs hide in the differences.

This batch standardizes them on the **default query behavior** established earlier: on‑chain reads should generally move with the chain unless a hook has a deliberate exception (for example temporary fast polling while waiting for a user’s transaction).

## What you should verify

- Proposal state transitions still propagate to the UI during active voting periods.
- No obvious regression in hooks used by multiple screens (shared behavior should remain predictable).

## How it fits the larger effort

Specialized areas (BTC vault readers and fund manager) are handled in the final two parts, including explicit opt‑outs for HTTP/API style queries that should not inherit chain‑paced refetch.
