### PR TITLE
DAO-1983: Dynamic block time — BTC vault readers (part 8/9)

### DIFF
--- a/src/shared/hooks/contracts/btc-vault/useReadPermissionsManager.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadPermissionsManager.ts
@@ -1,7 +1,6 @@
 import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
 
 import { getAbi, type PermissionsManagerAbi } from '@/lib/abis/btc-vault'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { permissionsManager } from '@/lib/contracts'
 
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
@@ -24,7 +23,6 @@ export const useReadPermissionsManager = <TFunctionName extends PermissionsManag
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/btc-vault/useReadPermissionsManagerForMultipleArgs.test.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadPermissionsManagerForMultipleArgs.test.ts
@@ -2,7 +2,6 @@ import { renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, Mock, vi } from 'vitest'
 import { useReadContracts } from 'wagmi'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { permissionsManager } from '@/lib/contracts'
 
 import { useReadPermissionsManagerForMultipleArgs } from './useReadPermissionsManagerForMultipleArgs'
@@ -81,7 +80,6 @@ describe('useReadPermissionsManagerForMultipleArgs', () => {
         ],
         query: {
           retry: true,
-          refetchInterval: AVERAGE_BLOCKTIME,
         },
       }),
     )

--- a/src/shared/hooks/contracts/btc-vault/useReadPermissionsManagerForMultipleArgs.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadPermissionsManagerForMultipleArgs.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import { UseReadContractReturnType, useReadContracts } from 'wagmi'
 
 import { getAbi, type PermissionsManagerAbi } from '@/lib/abis/btc-vault'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { permissionsManager } from '@/lib/contracts'
 
 import { UseReadContractForMultipleArgsConfig, ViewPureFunctionName } from '../types'
@@ -34,7 +33,6 @@ export const useReadPermissionsManagerForMultipleArgs = <
     })),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/btc-vault/useReadRbtcBuffer.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadRbtcBuffer.ts
@@ -4,7 +4,6 @@ import { UseReadContractParameters } from 'wagmi'
 
 import { BufferAbi } from '@/lib/abis/btc-vault'
 import { getAbi } from '@/lib/abis/btc-vault'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { buffer } from '@/lib/contracts'
 
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
@@ -24,7 +23,6 @@ export const useReadRbtcBuffer = <TFunctionName extends BufferFunctionName>(
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/btc-vault/useReadRbtcVault.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadRbtcVault.ts
@@ -1,7 +1,6 @@
 import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
 
 import { getAbi, type RBTCAsyncVaultAbi } from '@/lib/abis/btc-vault'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { rbtcVault } from '@/lib/contracts'
 
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
@@ -24,7 +23,6 @@ export const useReadRbtcVault = <TFunctionName extends RbtcAsyncVaultFunctionNam
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/btc-vault/useReadRbtcVaultBatch.test.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadRbtcVaultBatch.test.ts
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, it, Mock, vi } from 'vitest'
 import { useReadContracts } from 'wagmi'
 
 import { getAbi } from '@/lib/abis/btc-vault'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { rbtcVault } from '@/lib/contracts'
 
 import { useReadRbtcVaultBatch } from './useReadRbtcVaultBatch'
@@ -65,7 +64,6 @@ describe('useReadRbtcVaultBatch', () => {
         ],
         query: expect.objectContaining({
           retry: true,
-          refetchInterval: AVERAGE_BLOCKTIME,
         }),
       }),
     )
@@ -95,7 +93,6 @@ describe('useReadRbtcVaultBatch', () => {
         ],
         query: expect.objectContaining({
           retry: true,
-          refetchInterval: AVERAGE_BLOCKTIME,
         }),
       }),
     )
@@ -140,7 +137,6 @@ describe('useReadRbtcVaultBatch', () => {
         query: expect.objectContaining({
           enabled: false,
           retry: true,
-          refetchInterval: AVERAGE_BLOCKTIME,
         }),
       }),
     )

--- a/src/shared/hooks/contracts/btc-vault/useReadRbtcVaultBatch.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadRbtcVaultBatch.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import { UseReadContractReturnType, useReadContracts } from 'wagmi'
 
 import { getAbi, type RBTCAsyncVaultAbi } from '@/lib/abis/btc-vault'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { rbtcVault } from '@/lib/contracts'
 
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
@@ -67,7 +66,6 @@ export function useReadRbtcVaultBatch<T extends readonly AnyRbtcVaultConfig[]>(
     contracts,
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/btc-vault/useReadRbtcVaultForMultipleArgs.test.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadRbtcVaultForMultipleArgs.test.ts
@@ -2,7 +2,6 @@ import { renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, Mock, vi } from 'vitest'
 import { useReadContracts } from 'wagmi'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { rbtcVault } from '@/lib/contracts'
 
 import { useReadRbtcVaultForMultipleArgs } from './useReadRbtcVaultForMultipleArgs'
@@ -72,7 +71,6 @@ describe('useReadRbtcVaultForMultipleArgs', () => {
         ],
         query: {
           retry: true,
-          refetchInterval: AVERAGE_BLOCKTIME,
         },
       }),
     )

--- a/src/shared/hooks/contracts/btc-vault/useReadRbtcVaultForMultipleArgs.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadRbtcVaultForMultipleArgs.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import { UseReadContractReturnType, useReadContracts } from 'wagmi'
 
 import { getAbi, type RBTCAsyncVaultAbi } from '@/lib/abis/btc-vault'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { rbtcVault } from '@/lib/contracts'
 
 import { UseReadContractForMultipleArgsConfig, ViewPureFunctionName } from '../types'
@@ -32,7 +31,6 @@ export const useReadRbtcVaultForMultipleArgs = <TFunctionName extends RbtcAsyncV
     })),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/btc-vault/useReadSyntheticYield.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadSyntheticYield.ts
@@ -1,7 +1,6 @@
 import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
 
 import { getAbi, SyntheticYieldAbi } from '@/lib/abis/btc-vault'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { syntheticYield } from '@/lib/contracts'
 
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
@@ -24,7 +23,6 @@ export const useReadSyntheticYield = <TFunctionName extends SyntheticYieldFuncti
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })


### PR DESCRIPTION
## Why this exists

BTC vault integration landed on `main` after the original block‑time spike was written. Those readers followed the older pattern: import a global “average block time” constant and pass it as `refetchInterval`. Once that constant is removed in favor of dynamic block time, these hooks must **stop referencing it** and instead rely on the same React Query defaults as the rest of the app.

This keeps vault UIs **consistent with other on‑chain reads**: refresh roughly once per block, not on an arbitrary timer copied from legacy code.

## What you should verify

- Vault‑related screens update after deposits, withdrawals, or epoch changes without manual refresh.
- Unit expectations around wagmi query options still match the intended behavior (defaults apply unless overridden).

## How it fits the larger effort

Fund‑manager flows and one API‑backed history query are finished in the last part, including an explicit “do not poll on an interval” choice where a REST history endpoint should not track block time.
