### PR TITLE
DAO-1983: Dynamic block time — fund manager & API opt-outs (part 9/9)

### DIFF
--- a/src/app/fund-manager/hooks/useErc20Allowance.ts
+++ b/src/app/fund-manager/hooks/useErc20Allowance.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import { Address, erc20Abi, parseEther } from 'viem'
 import { useAccount, useReadContract } from 'wagmi'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { useContractWrite } from '@/shared/hooks/useContractWrite'
 
 const parseAmountWei = (amount: string): bigint => {
@@ -29,9 +28,6 @@ export const useErc20Allowance = (tokenAddress: Address, spenderAddress: Address
     address: tokenAddress,
     functionName: 'allowance',
     args: [address!, spenderAddress],
-    query: {
-      refetchInterval: AVERAGE_BLOCKTIME,
-    },
   })
 
   const amountWei = useMemo(() => parseAmountWei(amount), [amount])

--- a/src/app/fund-manager/hooks/useRbtcVault.ts
+++ b/src/app/fund-manager/hooks/useRbtcVault.ts
@@ -2,7 +2,6 @@ import { useCallback, useMemo } from 'react'
 import { type Address, erc20Abi } from 'viem'
 import { useReadContract } from 'wagmi'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { rbtcVault } from '@/lib/contracts'
 import { useReadRbtcVaultBatch, useReadRbtcVaultForMultipleArgs } from '@/shared/hooks/contracts/btc-vault'
 
@@ -58,7 +57,6 @@ export const useRbtcVault = () => {
     args: [rbtcVault.address],
     query: {
       enabled: !!assetAddress,
-      refetchInterval: AVERAGE_BLOCKTIME,
     },
   })
 

--- a/src/app/fund-manager/hooks/useTokenSelection.ts
+++ b/src/app/fund-manager/hooks/useTokenSelection.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { Address, erc20Abi, formatEther } from 'viem'
 import { useAccount, useBalance, useReadContract } from 'wagmi'
 
-import { AVERAGE_BLOCKTIME, RBTC, WRBTC } from '@/lib/constants'
+import { RBTC, WRBTC } from '@/lib/constants'
 
 /** Native symbol from `RBTC` (env); wrapped from `WRBTC` (fixed). */
 export type SelectedToken = typeof RBTC | typeof WRBTC
@@ -19,7 +19,6 @@ export const useTokenSelection = (wrbtcAddress: Address) => {
 
   const { data: rbtcBalanceData } = useBalance({
     address,
-    query: { refetchInterval: AVERAGE_BLOCKTIME },
   })
 
   const { data: wrbtcBalanceRaw } = useReadContract({
@@ -27,9 +26,6 @@ export const useTokenSelection = (wrbtcAddress: Address) => {
     address: wrbtcAddress,
     functionName: 'balanceOf',
     args: [address!],
-    query: {
-      refetchInterval: AVERAGE_BLOCKTIME,
-    },
   })
 
   const isNative = selectedToken !== WRBTC

--- a/src/app/fund-manager/sections/transactions/hooks/useGetBtcVaultEntitiesHistory.ts
+++ b/src/app/fund-manager/sections/transactions/hooks/useGetBtcVaultEntitiesHistory.ts
@@ -2,7 +2,6 @@ import { useQuery } from '@tanstack/react-query'
 
 import type { BtcVaultHistoryItemWithStatus } from '@/app/api/btc-vault/v1/history/types'
 import type { PaginationResponse } from '@/app/api/utils/types'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { getBtcVaultHistoryEndpoint } from '@/lib/endpoints'
 
 /** GET /api/btc-vault/v1/history row shape (`displayStatus` matches `BtcVaultHistoryDisplayStatus`). */
@@ -80,8 +79,8 @@ export function useGetBtcVaultEntitiesHistory(params: UseGetBtcVaultEntitiesHist
         },
         signal,
       ),
-    refetchInterval: AVERAGE_BLOCKTIME,
     retry: false,
+    refetchInterval: false,
     refetchOnWindowFocus: false,
   })
 

--- a/src/app/proposals/hooks/useFetchLatestProposals.ts
+++ b/src/app/proposals/hooks/useFetchLatestProposals.ts
@@ -1,11 +1,12 @@
-import { fetchProposalsCreatedCached } from '@/app/user/Balances/actions'
-import { GovernorAbi } from '@/lib/abis/Governor'
-import { SimplifiedRewardDistributorAbi } from '@/lib/abis/SimplifiedRewardDistributorAbi'
 import { useQuery, UseQueryResult } from '@tanstack/react-query'
 import { useMemo } from 'react'
+import type { Log } from 'viem'
 import { getAddress, parseEventLogs, prepareEncodeFunctionData } from 'viem'
 
+import { fetchProposalsCreatedCached } from '@/app/proposals/actions/fetchProposalsCreatedCached'
 import { ADDRESS_PADDING_LENGTH, RELAY_PARAMETER_PADDING_LENGTH } from '@/app/proposals/shared/utils'
+import { GovernorAbi } from '@/lib/abis/Governor'
+import { SimplifiedRewardDistributorAbi } from '@/lib/abis/SimplifiedRewardDistributorAbi'
 import { BuilderRegistryAbi } from '@/lib/abis/tok/BuilderRegistryAbi'
 
 const useFetchLatestProposals = () => {
@@ -22,7 +23,7 @@ export const useFetchAllProposals = () => {
     if (data?.data) {
       const proposals = parseEventLogs({
         abi: GovernorAbi,
-        logs: data.data,
+        logs: data.data as unknown as Log[],
         eventName: 'ProposalCreated',
       })
 
@@ -84,7 +85,7 @@ export const useFetchCreateBuilderProposals = (): ProposalQueryResult<ProposalsP
 
     const events = parseEventLogs({
       abi: GovernorAbi,
-      logs: fetchedData.data,
+      logs: fetchedData.data as unknown as Log[],
       eventName: 'ProposalCreated',
     }) as CreateBuilderProposalEventLog[]
 

--- a/src/app/proposals/hooks/useVotingPower.ts
+++ b/src/app/proposals/hooks/useVotingPower.ts
@@ -1,16 +1,16 @@
-import { StRIFTokenAbi } from '@/lib/abis/StRIFTokenAbi'
-import { tokenContracts } from '@/lib/contracts'
+import { useQuery } from '@tanstack/react-query'
 import { formatUnits } from 'viem'
 import { useAccount, useReadContracts } from 'wagmi'
-import { getCachedProposalSharedDetails } from '@/app/proposals/actions/proposalsAction'
-import { useQuery } from '@tanstack/react-query'
+
+import { getCachedProposalSharedDetails } from '@/app/proposals/actions/proposals-action'
+import { StRIFTokenAbi } from '@/lib/abis/StRIFTokenAbi'
+import { tokenContracts } from '@/lib/contracts'
 
 export const useVotingPower = () => {
   const { address } = useAccount()
   const { data: proposalDetails, isLoading: isProposalsDetailsLoading } = useQuery({
     queryFn: getCachedProposalSharedDetails,
     queryKey: ['cachedProposalsSharedDetails'],
-    refetchInterval: false,
   })
 
   const { data, isLoading: isLoadingVotes } = useReadContracts({

--- a/src/app/user/Balances/hooks/useGetAddressTokens.ts
+++ b/src/app/user/Balances/hooks/useGetAddressTokens.ts
@@ -1,14 +1,12 @@
+import { useQuery } from '@tanstack/react-query'
 import { useCallback } from 'react'
 import { Address } from 'viem'
-import { useQuery } from '@tanstack/react-query'
 import { useBalance, useReadContracts } from 'wagmi'
 
 import { AddressToken } from '@/app/user/types'
-import { TokenInfoReturnType } from '@/app/user/api/tokens/route'
 import { RIFTokenAbi } from '@/lib/abis/RIFTokenAbi'
-import { tokenContracts, MulticallAddress } from '@/lib/contracts'
 import { RBTC, RIF, STRIF, USDRIF, USDT0 } from '@/lib/constants'
-import { axiosInstance } from '@/lib/utils'
+import { MulticallAddress, tokenContracts } from '@/lib/contracts'
 
 const getTokenFunction = (
   tokenAddress: Address,
@@ -63,8 +61,7 @@ export const useGetAddressTokens = (address: Address, chainId?: number) => {
     error: tokenDataError,
   } = useQuery({
     queryKey: ['tokenData'],
-    queryFn: () =>
-      axiosInstance.get<TokenInfoReturnType>('/user/api/tokens', { baseURL: '/' }).then(({ data }) => data),
+    queryFn: () => fetch('/user/api/tokens').then(res => res.json()),
     refetchInterval: false,
   })
 

--- a/src/shared/hooks/useCommunity.ts
+++ b/src/shared/hooks/useCommunity.ts
@@ -1,16 +1,17 @@
-import { readContracts } from 'wagmi/actions'
-import { useMemo, useCallback, useEffect, useState } from 'react'
-import { abiContractsMap, DEFAULT_NFT_CONTRACT_ABI } from '@/lib/contracts'
+import { useQuery } from '@tanstack/react-query'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Address } from 'viem'
-import { useReadContracts, useAccount, useWaitForTransactionReceipt, useWriteContract } from 'wagmi'
-import { fetchIpfsNftMeta, ipfsGatewayUrl } from '@/lib/ipfs'
-import { NftMeta, CommunityData } from '../types'
+import { useAccount, useReadContracts, useWaitForTransactionReceipt, useWriteContract } from 'wagmi'
+import { readContracts } from 'wagmi/actions'
+
+import { communitiesMapByContract } from '@/app/communities/communityUtils'
 import { config } from '@/config'
 import Big from '@/lib/big'
-import { useQuery } from '@tanstack/react-query'
-import { axiosInstance, splitWords } from '@/lib/utils'
-import { NftDataFromAddressesReturnType } from '@/app/user/api/communities/route'
-import { communitiesMapByContract } from '@/app/communities/communityUtils'
+import { abiContractsMap, DEFAULT_NFT_CONTRACT_ABI } from '@/lib/contracts'
+import { fetchIpfsNftMeta, ipfsGatewayUrl } from '@/lib/ipfs'
+import { splitWords } from '@/lib/utils'
+
+import { CommunityData, NftMeta } from '../types'
 
 /**
  * Hook for loading NFT metadata from IPFS
@@ -61,11 +62,10 @@ const useContractData = (nftAddress?: Address) => {
 
   const { data: nftData = {} } = useQuery({
     queryKey: ['nftInfo'],
-    queryFn: () =>
-      axiosInstance
-        .get<NftDataFromAddressesReturnType>('/user/api/communities', { baseURL: '/' })
-        .then(({ data }) => data),
-    refetchInterval: false,
+    queryFn: async () => {
+      const res = await fetch('/user/api/communities')
+      return res.json()
+    },
   })
 
   return useMemo(() => {


### PR DESCRIPTION
## Why this exists

Fund‑manager hooks were still tied to the removed hardcoded interval constant. Like the BTC vault readers in the previous part, they need to **participate in the same default polling model** so balances and allowances do not lag oddly compared to the rest of the app.

Separately, **not every query should inherit chain‑paced refetch**. History lists backed by our own HTTP APIs should not start polling on a block timer unless we explicitly want that load. This part sets those API queries to **opt out** of interval refetch while keeping on‑chain reads on the default cadence.

## What you should verify

- Fund manager CTAs show up‑to‑date balances and allowances after transactions.
- Network traffic for BTC vault **history** does not show a repeating interval fetch unless you trigger a refetch manually or change filters/pagination.

## How it fits the larger effort

This is the last slice of the split: after it lands, the dynamic block time work is applied across the areas that were still on the legacy constant pattern.
