### PR TITLE
DAO-1983 (C1/6): Blockscout average block time helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ CLAUDE.md
 .workflow/plans/
 .workflow/reviews/
 .workflow/qa-reports/
+
+# Local git worktrees
+.worktrees/

--- a/src/shared/context/BlockTimeContext/computeAverageBlockTime.test.ts
+++ b/src/shared/context/BlockTimeContext/computeAverageBlockTime.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { computeAverageBlockTime } from './computeAverageBlockTime'
+
+const FALLBACK_BLOCK_TIME_MS = 25_000
+
+describe('computeAverageBlockTime', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should fall back to 25s when Blockscout is unreachable', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'))
+
+    const result = await computeAverageBlockTime()
+
+    expect(result).toBe(FALLBACK_BLOCK_TIME_MS)
+  })
+
+  it('should fall back to 25s when API returns invalid data', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ average_block_time: null }), { status: 200 }),
+    )
+
+    const result = await computeAverageBlockTime()
+
+    expect(result).toBe(FALLBACK_BLOCK_TIME_MS)
+  })
+})

--- a/src/shared/context/BlockTimeContext/computeAverageBlockTime.ts
+++ b/src/shared/context/BlockTimeContext/computeAverageBlockTime.ts
@@ -1,0 +1,35 @@
+const BLOCKSCOUT_STATS_URL = 'https://rootstock.blockscout.com/api/v2/stats'
+const FALLBACK_BLOCK_TIME_MS = 25_000
+
+interface BlockscoutStatsResponse {
+  average_block_time: number
+}
+
+/**
+ * Fetches the average Rootstock block time from the Blockscout stats API.
+ * Falls back to 25s if the API is unreachable or returns unexpected data.
+ *
+ * @returns Average block time in milliseconds
+ */
+export async function computeAverageBlockTime(): Promise<number> {
+  try {
+    const response = await fetch(BLOCKSCOUT_STATS_URL, { signal: AbortSignal.timeout(10_000) })
+
+    if (!response.ok) {
+      console.error(`[BlockTime] Blockscout API returned ${response.status}`)
+      return FALLBACK_BLOCK_TIME_MS
+    }
+
+    const data: BlockscoutStatsResponse = await response.json()
+    const blockTimeMs = data.average_block_time
+
+    if (typeof blockTimeMs !== 'number' || blockTimeMs <= 0) {
+      console.error('[BlockTime] Unexpected average_block_time value:', blockTimeMs)
+      return FALLBACK_BLOCK_TIME_MS
+    }
+    return Math.round(blockTimeMs)
+  } catch (error) {
+    console.error('[BlockTime] Failed to fetch block time from Blockscout:', error)
+    return FALLBACK_BLOCK_TIME_MS
+  }
+}

--- a/src/shared/context/BlockTimeContext/index.ts
+++ b/src/shared/context/BlockTimeContext/index.ts
@@ -1,0 +1,1 @@
+export { computeAverageBlockTime } from './computeAverageBlockTime'


### PR DESCRIPTION
## Why

Rootstock’s block time is not a fixed constant you can hardcode: merge-mining with Bitcoin means the **average gap between blocks drifts**. Downstream work will use a **measured** average (from Blockscout’s public stats API) so polling and “blocks × seconds” math match reality instead of legacy guesses.

This PR only adds the **fetch helper and tests**. Nothing in the React tree calls it yet, so behavior is unchanged.

## What to check

- Fallback when Blockscout is unreachable or returns bad data.
- No runtime or bundle impact beyond the new module.

## Stack

**DAO-1983 Strategy C (6 PRs).** Merge **C1 → C2 → … → C6** into `main` in order (rebase the next PR onto `main` after each merge if your workflow prefers a single moving base).
