### PR TITLE
DAO-1983 (C3/6): Migrate hooks — collective rewards & fund (batch 1)

### DIFF
--- a/src/app/collective-rewards/allocations/hooks/useGetVotingPower.ts
+++ b/src/app/collective-rewards/allocations/hooks/useGetVotingPower.ts
@@ -1,8 +1,8 @@
 import { useAccount, useReadContract } from 'wagmi'
 
 import { StRIFTokenAbi } from '@/lib/abis/StRIFTokenAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { tokenContracts } from '@/lib/contracts'
+
 export const useGetVotingPower = () => {
   const { address } = useAccount()
   const { data, isLoading, error } = useReadContract({
@@ -10,9 +10,6 @@ export const useGetVotingPower = () => {
     address: tokenContracts.stRIF,
     functionName: 'balanceOf',
     args: [address!],
-    query: {
-      refetchInterval: AVERAGE_BLOCKTIME,
-    },
   })
   return {
     data,

--- a/src/app/collective-rewards/components/ActiveBackers/ActiveBackers.tsx
+++ b/src/app/collective-rewards/components/ActiveBackers/ActiveBackers.tsx
@@ -1,7 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-
 import { useHandleErrors } from '../../utils'
 import { CountMetric } from '../CountMetric'
 
@@ -15,7 +13,6 @@ export const ActiveBackers = () => {
       return response.json()
     },
     queryKey: ['activeBackers'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   useHandleErrors({ error, title: 'Error loading active backers' })

--- a/src/app/collective-rewards/metrics/hooks/useIntervalTimestamp.ts
+++ b/src/app/collective-rewards/metrics/hooks/useIntervalTimestamp.ts
@@ -1,18 +1,19 @@
 import { DateTime } from 'luxon'
 import { useEffect, useState } from 'react'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
+import { useBlockTime } from '@/shared/context/BlockTimeContext'
 
 export const useIntervalTimestamp = () => {
+  const { averageBlockTimeMs } = useBlockTime()
   const [timestamp, setTimestamp] = useState(BigInt(DateTime.now().toUnixInteger()))
 
   useEffect(() => {
     const interval = setInterval(() => {
       setTimestamp(BigInt(DateTime.now().toUnixInteger()))
-    }, AVERAGE_BLOCKTIME)
+    }, averageBlockTimeMs)
 
     return () => clearInterval(interval)
-  }, [])
+  }, [averageBlockTimeMs])
 
   return timestamp
 }

--- a/src/app/collective-rewards/rewards/backers/hooks/useGetBackerStakingHistory.ts
+++ b/src/app/collective-rewards/rewards/backers/hooks/useGetBackerStakingHistory.ts
@@ -1,8 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { Address } from 'viem'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-
 import { fetchBackerStakingHistory } from '../actions/fetchBackerStakingHistory'
 
 export interface BackerStakingHistory {
@@ -32,7 +30,6 @@ export const useGetBackerStakingHistoryWithStateSync = (backer: Address) => {
       return response.json()
     },
     queryKey: ['backerStakingHistory', backer],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   return {
@@ -46,7 +43,6 @@ export const useGetBackerStakingHistoryWithGraph = (backer: Address) => {
   const { data, isLoading, error } = useQuery({
     queryFn: () => fetchBackerStakingHistory(backer),
     queryKey: ['backerStakingHistory', backer],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   return {

--- a/src/app/collective-rewards/rewards/builders/hooks/useGetBuilderRewardsClaimedLogs.ts
+++ b/src/app/collective-rewards/rewards/builders/hooks/useGetBuilderRewardsClaimedLogs.ts
@@ -3,7 +3,6 @@ import { Address, getAddress, parseEventLogs } from 'viem'
 
 import { fetchBuilderRewardsClaimed } from '@/app/collective-rewards/actions'
 import { GaugeAbi } from '@/lib/abis/tok/GaugeAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 
 type BuilderRewardsClaimedEventLog = ReturnType<
   typeof parseEventLogs<typeof GaugeAbi, true, 'BuilderRewardsClaimed'>
@@ -30,7 +29,6 @@ export const useGetBuilderRewardsClaimedLogs = (gauge: Address) => {
       }, {})
     },
     queryKey: ['builderRewardsClaimedLogs', gauge],
-    refetchInterval: AVERAGE_BLOCKTIME,
     initialData: {},
   })
 

--- a/src/app/collective-rewards/rewards/hooks/useGetChartBackingData.tsx
+++ b/src/app/collective-rewards/rewards/hooks/useGetChartBackingData.tsx
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { DailyAllocationItem } from '@/app/collective-rewards/types'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 
 export const useGetChartBackingData = () => {
   const { data, isLoading, error } = useQuery<DailyAllocationItem[], Error>({
@@ -23,7 +22,6 @@ export const useGetChartBackingData = () => {
       return result.data as DailyAllocationItem[]
     },
     queryKey: ['backingChartData'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   return {

--- a/src/app/collective-rewards/rewards/hooks/useGetChartRewardsData.tsx
+++ b/src/app/collective-rewards/rewards/hooks/useGetChartRewardsData.tsx
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { CycleRewardsItem } from '@/app/collective-rewards/types'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 
 export const useGetChartRewardsData = () => {
   const { data, isLoading, error } = useQuery<CycleRewardsItem[], Error>({
@@ -23,7 +22,6 @@ export const useGetChartRewardsData = () => {
       return result.data as CycleRewardsItem[]
     },
     queryKey: ['rewardsChartData'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   return {

--- a/src/app/collective-rewards/rewards/hooks/useGetGaugesEvents.ts
+++ b/src/app/collective-rewards/rewards/hooks/useGetGaugesEvents.ts
@@ -7,7 +7,6 @@ import {
   fetchGaugeNotifyRewardLogs,
 } from '@/app/collective-rewards/actions'
 import { GaugeAbi } from '@/lib/abis/tok/GaugeAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 
 type EventEntry = Extract<(typeof GaugeAbi)[number], AbiEvent>
 type EventName = Extract<
@@ -38,7 +37,6 @@ export const useGetGaugesEvents = <T extends EventName>(gauges: Address[], event
       }, {})
     },
     queryKey: ['useGetGaugesEvents', eventName, gauges],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   return {

--- a/src/app/collective-rewards/rewards/hooks/useGetNotifyRewardLogs.ts
+++ b/src/app/collective-rewards/rewards/hooks/useGetNotifyRewardLogs.ts
@@ -4,7 +4,6 @@ import { Address, getAddress, isAddressEqual, parseEventLogs } from 'viem'
 
 import { fetchGaugeNotifyRewardLogs } from '@/app/collective-rewards/actions'
 import { GaugeAbi } from '@/lib/abis/tok/GaugeAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 
 export type GaugeNotifyRewardEventLog = ReturnType<
   typeof parseEventLogs<typeof GaugeAbi, true, 'NotifyReward'>
@@ -32,7 +31,6 @@ export const useGetGaugeNotifyRewardLogs = (
       })
     },
     queryKey: ['notifyRewardLogs', gauge],
-    refetchInterval: AVERAGE_BLOCKTIME,
     initialData: [],
   })
 

--- a/src/app/collective-rewards/rewards/hooks/useGetRewardDistributionFinishedLogs.ts
+++ b/src/app/collective-rewards/rewards/hooks/useGetRewardDistributionFinishedLogs.ts
@@ -3,7 +3,6 @@ import { parseEventLogs } from 'viem'
 
 import { fetchRewardDistributionFinished } from '@/app/collective-rewards/actions'
 import { type BackersManagerAbi, getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BackersManagerAddress } from '@/lib/contracts'
 
 export type RewardDistributionFinishedEventLog = ReturnType<
@@ -22,7 +21,6 @@ export const useGetRewardDistributionFinishedLogs = () => {
       })
     },
     queryKey: ['RewardDistributionFinished', BackersManagerAddress],
-    refetchInterval: AVERAGE_BLOCKTIME,
     initialData: [],
   })
 

--- a/src/app/collective-rewards/shared/hooks/useGetABIWithGraph.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetABIWithGraph.ts
@@ -1,7 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-
 import { getCachedABIData } from '../actions/fetchABIData'
 import { useGetABI } from './useGetABI'
 
@@ -13,7 +11,6 @@ export const useGetMetricsAbiWithGraph = () => {
   } = useQuery({
     queryFn: () => getCachedABIData(),
     queryKey: ['abiData'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   const data = useGetABI(abiData)

--- a/src/app/collective-rewards/shared/hooks/useGetABIWithStateSync.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetABIWithStateSync.ts
@@ -1,8 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import Big from 'big.js'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-
 import { AbiData, useGetABI } from './useGetABI'
 import { useStateSyncHealthCheck } from './useStateSyncHealthCheck'
 
@@ -29,7 +27,6 @@ export const useGetMetricsAbiWithStateSync = () => {
       return response.json()
     },
     queryKey: ['abiData'],
-    refetchInterval: AVERAGE_BLOCKTIME,
     enabled: !healthCheckIsLoading && isStateSyncHealthy,
   })
 

--- a/src/app/collective-rewards/shared/hooks/useGetActiveBuildersCount.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetActiveBuildersCount.ts
@@ -1,7 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-
 export const useGetActiveBuildersCount = () => {
   const { data, isLoading, error } = useQuery<{ count: number }, Error>({
     queryFn: async () => {
@@ -12,7 +10,6 @@ export const useGetActiveBuildersCount = () => {
       return response.json()
     },
     queryKey: ['activeBuilders'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   return { data, isLoading, error }

--- a/src/app/collective-rewards/shared/hooks/useGetLastCycleRewardsWithStateSync.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetLastCycleRewardsWithStateSync.ts
@@ -1,7 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-
 import { CycleData } from './useGetABI'
 import { useStateSyncHealthCheck } from './useStateSyncHealthCheck'
 
@@ -28,7 +26,6 @@ export const useGetLastCycleRewardsWithStateSync = () => {
       return result.data as CycleData[]
     },
     queryKey: ['lastCycleRewardsWithStateSync'],
-    refetchInterval: AVERAGE_BLOCKTIME,
     enabled: !healthCheckIsLoading && isStateSyncHealthy,
   })
 

--- a/src/app/collective-rewards/shared/hooks/useGetRewardsDistributionRewards.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetRewardsDistributionRewards.ts
@@ -3,7 +3,6 @@ import { parseEventLogs } from 'viem'
 
 import { fetchRewardDistributionRewards } from '@/app/collective-rewards/actions'
 import { type BackersManagerAbi, getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BackersManagerAddress } from '@/lib/contracts'
 
 export type RewardDistributionRewardsEventLog = ReturnType<
@@ -22,7 +21,6 @@ export const useGetRewardDistributionRewardsLogs = () => {
       }) as Log[]
     },
     queryKey: ['RewardDistributionRewards', BackersManagerAddress],
-    refetchInterval: AVERAGE_BLOCKTIME,
     initialData: [],
   })
 


### PR DESCRIPTION
## Why

Once defaults come from real block time, hooks should **stop repeating** the old `AVERAGE_BLOCKTIME` import. This batch migrates the first set of collective-rewards and related hooks to **inherit** the QueryClient default, and uses **`refetchInterval: false`** where a query is backed by our HTTP APIs or should not poll on a timer.

## What to check

- Collective rewards surfaces still update after on-chain actions.
- No new periodic traffic to backend routes from these hooks.

## Stack

**C3** builds on **C2** (provider + defaults). Merge after C2 is on your target branch.
