### PR TITLE
DAO-1983 (C4/6): Migrate hooks — proposals, booster, user (batch 2)

### DIFF
--- a/src/app/collective-rewards/shared/hooks/useStateSyncHealthCheck.ts
+++ b/src/app/collective-rewards/shared/hooks/useStateSyncHealthCheck.ts
@@ -1,13 +1,12 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 
 import type { HealthCheckResult } from '@/app/api/health/healthCheck.utils'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { sentryClient } from '@/lib/sentry/sentry-client'
 
 export const useStateSyncHealthCheck = (
   options?: Omit<UseQueryOptions<HealthCheckResult, Error>, 'queryKey' | 'queryFn'>,
-) =>
-  useQuery<HealthCheckResult, Error>({
+) => {
+  return useQuery<HealthCheckResult, Error>({
     queryFn: async (): Promise<HealthCheckResult> => {
       const response = await fetch('/api/health', {
         method: 'GET',
@@ -41,7 +40,7 @@ export const useStateSyncHealthCheck = (
         throw new Error('Invalid health check data')
       }
     },
-    refetchInterval: AVERAGE_BLOCKTIME,
     ...options,
     queryKey: ['healthCheck'],
   })
+}

--- a/src/app/collective-rewards/user/hooks/useGetGaugesArray.ts
+++ b/src/app/collective-rewards/user/hooks/useGetGaugesArray.ts
@@ -3,7 +3,6 @@ import { AbiFunction, Address } from 'viem'
 import { useReadContracts } from 'wagmi'
 
 import { BuilderRegistryAbi } from '@/lib/abis/tok/BuilderRegistryAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BuilderRegistryAddress } from '@/lib/contracts'
 import { useReadBuilderRegistry } from '@/shared/hooks/contracts'
 
@@ -36,9 +35,6 @@ export const useGetGaugesArray = () => {
     error: gaugesAddressError,
   } = useReadContracts<Address[]>({
     contracts: contractCalls,
-    query: {
-      refetchInterval: AVERAGE_BLOCKTIME,
-    },
   })
 
   const gauges = useMemo(() => gaugesAddress?.map(gauge => gauge.result as Address) ?? [], [gaugesAddress])

--- a/src/app/collective-rewards/user/hooks/useGetProposalsState.ts
+++ b/src/app/collective-rewards/user/hooks/useGetProposalsState.ts
@@ -4,7 +4,6 @@ import { useReadContracts } from 'wagmi'
 
 import { ProposalsToState } from '@/app/collective-rewards/types'
 import { GovernorAbi } from '@/lib/abis/Governor'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { GovernorAddress } from '@/lib/contracts'
 import { ProposalState } from '@/shared/types'
 
@@ -28,9 +27,6 @@ export const useGetProposalsState = (proposalIds: bigint[]) => {
     error,
   } = useReadContracts<ProposalState[]>({
     contracts: contractCalls,
-    query: {
-      refetchInterval: AVERAGE_BLOCKTIME,
-    },
   })
 
   const proposalsToStates = useMemo(() => {

--- a/src/app/fund-manager/hooks/useErc20Allowance.ts
+++ b/src/app/fund-manager/hooks/useErc20Allowance.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import { Address, erc20Abi, parseEther } from 'viem'
 import { useAccount, useReadContract } from 'wagmi'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { useContractWrite } from '@/shared/hooks/useContractWrite'
 
 const parseAmountWei = (amount: string): bigint => {
@@ -29,9 +28,6 @@ export const useErc20Allowance = (tokenAddress: Address, spenderAddress: Address
     address: tokenAddress,
     functionName: 'allowance',
     args: [address!, spenderAddress],
-    query: {
-      refetchInterval: AVERAGE_BLOCKTIME,
-    },
   })
 
   const amountWei = useMemo(() => parseAmountWei(amount), [amount])

--- a/src/app/fund-manager/hooks/useRbtcVault.ts
+++ b/src/app/fund-manager/hooks/useRbtcVault.ts
@@ -2,7 +2,6 @@ import { useCallback, useMemo } from 'react'
 import { type Address, erc20Abi } from 'viem'
 import { useReadContract } from 'wagmi'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { rbtcVault } from '@/lib/contracts'
 import { useReadRbtcVaultBatch, useReadRbtcVaultForMultipleArgs } from '@/shared/hooks/contracts/btc-vault'
 
@@ -58,7 +57,6 @@ export const useRbtcVault = () => {
     args: [rbtcVault.address],
     query: {
       enabled: !!assetAddress,
-      refetchInterval: AVERAGE_BLOCKTIME,
     },
   })
 

--- a/src/app/fund-manager/hooks/useTokenSelection.ts
+++ b/src/app/fund-manager/hooks/useTokenSelection.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { Address, erc20Abi, formatEther } from 'viem'
 import { useAccount, useBalance, useReadContract } from 'wagmi'
 
-import { AVERAGE_BLOCKTIME, RBTC, WRBTC } from '@/lib/constants'
+import { RBTC, WRBTC } from '@/lib/constants'
 
 /** Native symbol from `RBTC` (env); wrapped from `WRBTC` (fixed). */
 export type SelectedToken = typeof RBTC | typeof WRBTC
@@ -19,7 +19,6 @@ export const useTokenSelection = (wrbtcAddress: Address) => {
 
   const { data: rbtcBalanceData } = useBalance({
     address,
-    query: { refetchInterval: AVERAGE_BLOCKTIME },
   })
 
   const { data: wrbtcBalanceRaw } = useReadContract({
@@ -27,9 +26,6 @@ export const useTokenSelection = (wrbtcAddress: Address) => {
     address: wrbtcAddress,
     functionName: 'balanceOf',
     args: [address!],
-    query: {
-      refetchInterval: AVERAGE_BLOCKTIME,
-    },
   })
 
   const isNative = selectedToken !== WRBTC

--- a/src/app/fund-manager/sections/transactions/hooks/useGetBtcVaultEntitiesHistory.ts
+++ b/src/app/fund-manager/sections/transactions/hooks/useGetBtcVaultEntitiesHistory.ts
@@ -2,7 +2,6 @@ import { useQuery } from '@tanstack/react-query'
 
 import type { BtcVaultHistoryItemWithStatus } from '@/app/api/btc-vault/v1/history/types'
 import type { PaginationResponse } from '@/app/api/utils/types'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { getBtcVaultHistoryEndpoint } from '@/lib/endpoints'
 
 /** GET /api/btc-vault/v1/history row shape (`displayStatus` matches `BtcVaultHistoryDisplayStatus`). */
@@ -80,8 +79,8 @@ export function useGetBtcVaultEntitiesHistory(params: UseGetBtcVaultEntitiesHist
         },
         signal,
       ),
-    refetchInterval: AVERAGE_BLOCKTIME,
     retry: false,
+    refetchInterval: false,
     refetchOnWindowFocus: false,
   })
 

--- a/src/app/my-rewards/tx-history/hooks/useGetBackedBuilders.ts
+++ b/src/app/my-rewards/tx-history/hooks/useGetBackedBuilders.ts
@@ -43,6 +43,7 @@ export const useGetBackedBuilders = (address?: Address) => {
     },
     queryKey: ['backerToBuilder', address],
     enabled: !!address,
+    refetchInterval: false,
   })
 
   // Transform the data into filter options

--- a/src/app/my-rewards/tx-history/hooks/useGetTransactionHistory.ts
+++ b/src/app/my-rewards/tx-history/hooks/useGetTransactionHistory.ts
@@ -1,7 +1,6 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { useAccount } from 'wagmi'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { TOKENS } from '@/lib/tokens'
 import { usePricesContext } from '@/shared/context/PricesContext'
 
@@ -115,7 +114,6 @@ export const useGetTransactionHistory = (params?: UseGetTransactionHistoryParams
       builder,
       rewardToken,
     ],
-    refetchInterval: AVERAGE_BLOCKTIME,
     enabled: !!address,
     placeholderData: keepPreviousData,
   })

--- a/src/app/proposals/[id]/hooks/useLike.ts
+++ b/src/app/proposals/[id]/hooks/useLike.ts
@@ -72,6 +72,7 @@ export const useLike = (proposalId: string, isConnected: boolean, signIn: () => 
       return response.json()
     },
     enabled: !!proposalId,
+    refetchInterval: false,
   })
 
   // User's own reaction query (only when authenticated)
@@ -79,6 +80,7 @@ export const useLike = (proposalId: string, isConnected: boolean, signIn: () => 
     queryKey: userReactionQueryKey(proposalId, jwtToken ?? ''),
     queryFn: () => fetchUserReaction(proposalId, jwtToken!),
     enabled: !!proposalId && !!jwtToken,
+    refetchInterval: false,
   })
 
   // Sync server-side user reaction into local state (only when uninitialized)

--- a/src/app/proposals/hooks/useFetchLatestProposals.ts
+++ b/src/app/proposals/hooks/useFetchLatestProposals.ts
@@ -8,13 +8,11 @@ import { ADDRESS_PADDING_LENGTH, RELAY_PARAMETER_PADDING_LENGTH } from '@/app/pr
 import { GovernorAbi } from '@/lib/abis/Governor'
 import { SimplifiedRewardDistributorAbi } from '@/lib/abis/SimplifiedRewardDistributorAbi'
 import { BuilderRegistryAbi } from '@/lib/abis/tok/BuilderRegistryAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 
 const useFetchLatestProposals = () => {
   return useQuery({
     queryFn: fetchProposalsCreatedCached,
     queryKey: ['proposalsCreated'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 }
 

--- a/src/app/proposals/hooks/useGetProposalSnapshot.ts
+++ b/src/app/proposals/hooks/useGetProposalSnapshot.ts
@@ -9,6 +9,7 @@ export const useGetProposalSnapshot = (proposalId: string) => {
     address: GovernorAddress,
     functionName: 'proposalSnapshot',
     args: [BigInt(proposalId)],
+    query: { refetchInterval: false },
   })
 
   return data

--- a/src/app/proposals/hooks/useGetProposalVotes.ts
+++ b/src/app/proposals/hooks/useGetProposalVotes.ts
@@ -13,7 +13,7 @@ export const useGetProposalVotes = (proposalId: string, shouldRefetch = false) =
     functionName: 'proposalVotes',
     args: [BigInt(proposalId)],
     query: {
-      ...(shouldRefetch && { refetchInterval: 5000 }),
+      refetchInterval: shouldRefetch ? 5000 : false,
     },
   })
 

--- a/src/app/proposals/hooks/useGetProposalsWithGraph.ts
+++ b/src/app/proposals/hooks/useGetProposalsWithGraph.ts
@@ -2,14 +2,13 @@ import { useQuery } from '@tanstack/react-query'
 import moment from 'moment'
 import { useMemo } from 'react'
 import { Address, formatEther } from 'viem'
-import { useBlockNumber } from 'wagmi'
-import { useReadContracts } from 'wagmi'
+import { useBlockNumber, useReadContracts } from 'wagmi'
 
 import { ProposalApiResponse } from '@/app/proposals/shared/types'
 import { GovernorAbi } from '@/lib/abis/Governor'
 import Big from '@/lib/big'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { GOVERNOR_ADDRESS } from '@/lib/constants'
+import { useBlockTime } from '@/shared/context/BlockTimeContext'
 import { ProposalState } from '@/shared/types'
 
 import { Proposal } from '../shared/types'
@@ -60,12 +59,6 @@ function convertVotesToBigNumbers(votes: ProposalApiResponse['votes']) {
     forVotes,
     abstainVotes,
   }
-}
-
-function hasNonZeroVotes(votes: ProposalApiResponse['votes']): boolean {
-  if (!votes) return false
-  const { forVotes, againstVotes, abstainVotes } = convertVotesToBigNumbers(votes)
-  return forVotes.gt(0) || againstVotes.gt(0) || abstainVotes.gt(0)
 }
 
 function parseBlockNumber(blockNumber: string | undefined): string {
@@ -124,8 +117,8 @@ function transformProposalsData(
   const transformedProposals = proposalsData.map((proposal: ProposalApiResponse) => {
     const blockchainInfo = blockchainData?.find(b => b.proposalId === proposal.proposalId)
 
-    // Prefer blockchain votes when API votes are missing or all zeros
-    const votes: ProposalApiResponse['votes'] | undefined = hasNonZeroVotes(proposal.votes)
+    // Convert blockchain votes (Big) to API format (string) if needed
+    const votes: ProposalApiResponse['votes'] | undefined = proposal.votes
       ? proposal.votes
       : blockchainInfo?.votes
         ? {
@@ -133,7 +126,7 @@ function transformProposalsData(
             forVotes: blockchainInfo.votes.forVotes.toString(),
             abstainVotes: blockchainInfo.votes.abstainVotes.toString(),
           }
-        : proposal.votes // fallback to API votes if no blockchain data
+        : undefined
 
     const quorum = proposal.quorumAtSnapshot || blockchainInfo?.quorum?.toString()
     const rawState = blockchainInfo?.rawState
@@ -181,10 +174,10 @@ function transformProposalsData(
 }
 
 export function useGetProposalsWithGraph() {
+  const { averageBlockTimeMs } = useBlockTime()
   const { data: latestBlockNumber } = useBlockNumber({
     query: {
-      refetchInterval: AVERAGE_BLOCKTIME,
-      staleTime: AVERAGE_BLOCKTIME,
+      staleTime: averageBlockTimeMs,
     },
   })
 
@@ -195,7 +188,6 @@ export function useGetProposalsWithGraph() {
   } = useQuery({
     queryFn: fetchProposalsFromAPI,
     queryKey: ['proposals'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   const proposalsFromNode = useMemo(
@@ -243,7 +235,7 @@ export function useGetProposalsWithGraph() {
     contracts: votesContracts,
     query: {
       enabled: proposalsFromNode.length > 0,
-      staleTime: AVERAGE_BLOCKTIME,
+      staleTime: averageBlockTimeMs,
     },
   })
 
@@ -259,7 +251,7 @@ export function useGetProposalsWithGraph() {
     contracts: stateContracts,
     query: {
       enabled: proposalsFromNode.length > 0,
-      staleTime: AVERAGE_BLOCKTIME,
+      staleTime: averageBlockTimeMs,
     },
   })
 

--- a/src/app/proposals/hooks/useVoteCast.ts
+++ b/src/app/proposals/hooks/useVoteCast.ts
@@ -36,7 +36,7 @@ export const useGetVoteForSpecificProposal = (
   const { data: voteEvents } = useQuery({
     queryFn: () => parseVoteCastEvents(address),
     queryKey: ['VoteCast', address],
-    enabled: !!address && !!proposalId, // Query will only run if both address and proposalId are present
+    enabled: !!address && !!proposalId,
   })
 
   const event = voteEvents?.find(event => event.args.proposalId.toString() === proposalId)


### PR DESCRIPTION
## Why

Same theme as C3: **remove duplicated polling constants** and align governance, booster, staking, and balance reads with the **dynamic default** established in C2. Proposal flows are especially sensitive to stale vote counts and state—default block-paced refetch reduces “I voted but the UI didn’t notice” without each hook owning its own interval.

## What to check

- Proposal lists / voting UI refresh within a reasonable window after transactions.
- Booster and staking views do not stay stuck behind chain head.

## Stack

**C4** follows **C3**.
