### PR TITLE
DAO-1983 (C5/6): Migrate hooks — vault & shared readers (batch 3)

### DIFF
--- a/src/app/providers/NFT/BoosterContext.tsx
+++ b/src/app/providers/NFT/BoosterContext.tsx
@@ -1,6 +1,5 @@
 'use client'
 import { useQuery } from '@tanstack/react-query'
-import axios from 'axios'
 import { createContext, ReactNode, useCallback, useContext, useMemo } from 'react'
 import { Address } from 'viem'
 import { useAccount } from 'wagmi'
@@ -106,8 +105,6 @@ export const BoosterProvider = ({ children }: BoosterContextProviderProps) => {
 }
 
 export const useNFTBoosterContext = () => useContext(BoosterContext)
-
-export const axiosInstance = axios.create()
 
 export const useFetchBoostData = () => {
   const now = Date.now()

--- a/src/app/providers/NFT/BoosterContext.tsx
+++ b/src/app/providers/NFT/BoosterContext.tsx
@@ -1,10 +1,9 @@
 'use client'
 import { useQuery } from '@tanstack/react-query'
+import axios from 'axios'
 import { createContext, ReactNode, useCallback, useContext, useMemo } from 'react'
 import { Address } from 'viem'
 import { useAccount } from 'wagmi'
-
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 
 import { fetchBoostData, fetchLatestFile } from './boost.utils'
 
@@ -108,6 +107,8 @@ export const BoosterProvider = ({ children }: BoosterContextProviderProps) => {
 
 export const useNFTBoosterContext = () => useContext(BoosterContext)
 
+export const axiosInstance = axios.create()
+
 export const useFetchBoostData = () => {
   const now = Date.now()
   const {
@@ -117,7 +118,6 @@ export const useFetchBoostData = () => {
   } = useQuery<string>({
     queryFn: async () => fetchLatestFile(now),
     queryKey: ['nftBoosterLatestFile'],
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   const hasActiveCampaign = !!latestFile && latestFile.trim() !== 'None'
@@ -129,7 +129,6 @@ export const useFetchBoostData = () => {
   } = useQuery<BoostData>({
     queryFn: async () => fetchBoostData(latestFile?.trim(), now),
     queryKey: ['nftBoosterData'],
-    refetchInterval: AVERAGE_BLOCKTIME,
     enabled: hasActiveCampaign,
   })
 

--- a/src/app/staking-history/hooks/useGetStakingHistory.ts
+++ b/src/app/staking-history/hooks/useGetStakingHistory.ts
@@ -2,8 +2,6 @@ import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { useAccount } from 'wagmi'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-
 import { fetchStakingHistory, StakingHistoryResponse } from '../utils/api'
 import { StakingHistoryItem } from '../utils/types'
 
@@ -47,7 +45,6 @@ export const useGetStakingHistory = (params?: UseGetStakingHistoryParams) => {
       sortDirection,
       type.length > 0 ? [...type].sort().join(',') : '',
     ],
-    refetchInterval: AVERAGE_BLOCKTIME,
     enabled: !!address,
   })
 

--- a/src/app/user/Balances/hooks/useGetAddressTokens.ts
+++ b/src/app/user/Balances/hooks/useGetAddressTokens.ts
@@ -5,7 +5,7 @@ import { useBalance, useReadContracts } from 'wagmi'
 
 import { AddressToken } from '@/app/user/types'
 import { RIFTokenAbi } from '@/lib/abis/RIFTokenAbi'
-import { AVERAGE_BLOCKTIME, RBTC, RIF, STRIF, USDRIF, USDT0 } from '@/lib/constants'
+import { RBTC, RIF, STRIF, USDRIF, USDT0 } from '@/lib/constants'
 import { MulticallAddress, tokenContracts } from '@/lib/contracts'
 
 const getTokenFunction = (
@@ -53,9 +53,6 @@ export const useGetAddressTokens = (address: Address, chainId?: number) => {
       getTokenFunction(tokenContracts.USDT0, address, 'balanceOf'),
     ],
     multicallAddress: MulticallAddress,
-    query: {
-      refetchInterval: AVERAGE_BLOCKTIME,
-    },
   })
 
   const {
@@ -65,6 +62,7 @@ export const useGetAddressTokens = (address: Address, chainId?: number) => {
   } = useQuery({
     queryKey: ['tokenData'],
     queryFn: () => fetch('/user/api/tokens').then(res => res.json()),
+    refetchInterval: false,
   })
 
   const rifTokenData =

--- a/src/app/user/Delegation/hooks/useGetDelegates.ts
+++ b/src/app/user/Delegation/hooks/useGetDelegates.ts
@@ -2,7 +2,6 @@ import { Address } from 'viem'
 import { useReadContract } from 'wagmi'
 
 import { StRIFTokenAbi } from '@/lib/abis/StRIFTokenAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { tokenContracts } from '@/lib/contracts'
 
 const stRifContract = {
@@ -20,9 +19,6 @@ export const useGetDelegates = (address: Address | undefined) => {
       ...stRifContract,
       functionName: 'delegates',
       args: [address],
-      query: {
-        refetchInterval: AVERAGE_BLOCKTIME,
-      },
     },
   )
 

--- a/src/app/vault/history/hooks/useGetVaultHistory.ts
+++ b/src/app/vault/history/hooks/useGetVaultHistory.ts
@@ -2,8 +2,6 @@ import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { useAccount } from 'wagmi'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-
 import { fetchVaultHistory, VaultHistoryResponse } from '../utils/api'
 import { VaultHistoryItemAPI } from '../utils/types'
 
@@ -58,7 +56,6 @@ export const useGetVaultHistory = (params?: UseGetVaultHistoryParams) => {
       sortDirection,
       type.length > 0 ? [...type].sort().join(',') : '',
     ],
-    refetchInterval: AVERAGE_BLOCKTIME,
     enabled: !!address,
   })
 

--- a/src/app/vault/hooks/useVaultDepositLimiter.ts
+++ b/src/app/vault/hooks/useVaultDepositLimiter.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import { useAccount, useReadContracts } from 'wagmi'
 
 import { VaultDepositLimiterAbi } from '@/lib/abis/VaultDepositLimiterAbi'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 
 import { useVaultDepositLimiterAddress } from './useVaultDepositLimiterAddress'
 
@@ -62,7 +61,6 @@ export function useVaultDepositLimiter() {
   } = useReadContracts({
     contracts,
     query: {
-      refetchInterval: AVERAGE_BLOCKTIME, // Refetch every minute
       enabled: !!depositLimiterAddress, // Only run when we have the address
     },
   })

--- a/src/app/vault/hooks/useVaultDepositLimiterAddress.ts
+++ b/src/app/vault/hooks/useVaultDepositLimiterAddress.ts
@@ -17,7 +17,7 @@ export function useVaultDepositLimiterAddress() {
     abi: vault.abi,
     functionName: 'depositLimiter',
     query: {
-      // No refetch interval since this value doesn't change
+      refetchInterval: false,
       staleTime: Infinity,
       gcTime: Infinity,
     },

--- a/src/shared/hooks/contracts/btc-vault/useReadPermissionsManager.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadPermissionsManager.ts
@@ -1,7 +1,6 @@
 import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
 
 import { getAbi, type PermissionsManagerAbi } from '@/lib/abis/btc-vault'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { permissionsManager } from '@/lib/contracts'
 
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
@@ -24,7 +23,6 @@ export const useReadPermissionsManager = <TFunctionName extends PermissionsManag
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/btc-vault/useReadPermissionsManagerForMultipleArgs.test.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadPermissionsManagerForMultipleArgs.test.ts
@@ -2,7 +2,6 @@ import { renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, Mock, vi } from 'vitest'
 import { useReadContracts } from 'wagmi'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { permissionsManager } from '@/lib/contracts'
 
 import { useReadPermissionsManagerForMultipleArgs } from './useReadPermissionsManagerForMultipleArgs'
@@ -79,10 +78,9 @@ describe('useReadPermissionsManagerForMultipleArgs', () => {
             functionName: 'hasRole',
           },
         ],
-        query: {
+        query: expect.objectContaining({
           retry: true,
-          refetchInterval: AVERAGE_BLOCKTIME,
-        },
+        }),
       }),
     )
   })

--- a/src/shared/hooks/contracts/btc-vault/useReadPermissionsManagerForMultipleArgs.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadPermissionsManagerForMultipleArgs.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import { UseReadContractReturnType, useReadContracts } from 'wagmi'
 
 import { getAbi, type PermissionsManagerAbi } from '@/lib/abis/btc-vault'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { permissionsManager } from '@/lib/contracts'
 
 import { UseReadContractForMultipleArgsConfig, ViewPureFunctionName } from '../types'
@@ -34,7 +33,6 @@ export const useReadPermissionsManagerForMultipleArgs = <
     })),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/btc-vault/useReadRbtcBuffer.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadRbtcBuffer.ts
@@ -4,7 +4,6 @@ import { UseReadContractParameters } from 'wagmi'
 
 import { BufferAbi } from '@/lib/abis/btc-vault'
 import { getAbi } from '@/lib/abis/btc-vault'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { buffer } from '@/lib/contracts'
 
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
@@ -24,7 +23,6 @@ export const useReadRbtcBuffer = <TFunctionName extends BufferFunctionName>(
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/btc-vault/useReadRbtcVault.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadRbtcVault.ts
@@ -1,7 +1,6 @@
 import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
 
 import { getAbi, type RBTCAsyncVaultAbi } from '@/lib/abis/btc-vault'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { rbtcVault } from '@/lib/contracts'
 
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
@@ -24,7 +23,6 @@ export const useReadRbtcVault = <TFunctionName extends RbtcAsyncVaultFunctionNam
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/btc-vault/useReadRbtcVaultBatch.test.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadRbtcVaultBatch.test.ts
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, it, Mock, vi } from 'vitest'
 import { useReadContracts } from 'wagmi'
 
 import { getAbi } from '@/lib/abis/btc-vault'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { rbtcVault } from '@/lib/contracts'
 
 import { useReadRbtcVaultBatch } from './useReadRbtcVaultBatch'
@@ -65,7 +64,6 @@ describe('useReadRbtcVaultBatch', () => {
         ],
         query: expect.objectContaining({
           retry: true,
-          refetchInterval: AVERAGE_BLOCKTIME,
         }),
       }),
     )
@@ -95,7 +93,6 @@ describe('useReadRbtcVaultBatch', () => {
         ],
         query: expect.objectContaining({
           retry: true,
-          refetchInterval: AVERAGE_BLOCKTIME,
         }),
       }),
     )
@@ -140,7 +137,6 @@ describe('useReadRbtcVaultBatch', () => {
         query: expect.objectContaining({
           enabled: false,
           retry: true,
-          refetchInterval: AVERAGE_BLOCKTIME,
         }),
       }),
     )

--- a/src/shared/hooks/contracts/btc-vault/useReadRbtcVaultBatch.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadRbtcVaultBatch.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import { UseReadContractReturnType, useReadContracts } from 'wagmi'
 
 import { getAbi, type RBTCAsyncVaultAbi } from '@/lib/abis/btc-vault'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { rbtcVault } from '@/lib/contracts'
 
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
@@ -67,7 +66,6 @@ export function useReadRbtcVaultBatch<T extends readonly AnyRbtcVaultConfig[]>(
     contracts,
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/btc-vault/useReadRbtcVaultForMultipleArgs.test.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadRbtcVaultForMultipleArgs.test.ts
@@ -2,7 +2,6 @@ import { renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, Mock, vi } from 'vitest'
 import { useReadContracts } from 'wagmi'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { rbtcVault } from '@/lib/contracts'
 
 import { useReadRbtcVaultForMultipleArgs } from './useReadRbtcVaultForMultipleArgs'
@@ -70,10 +69,9 @@ describe('useReadRbtcVaultForMultipleArgs', () => {
             functionName: 'epochSnapshot',
           },
         ],
-        query: {
+        query: expect.objectContaining({
           retry: true,
-          refetchInterval: AVERAGE_BLOCKTIME,
-        },
+        }),
       }),
     )
   })


### PR DESCRIPTION
## Why

Vault and delegation flows need trustworthy, timely reads. This batch continues migrating hooks and shared contract readers off the legacy constant so they **follow the same default** as the rest of the app, with explicit opt-outs only where semantics require it.

## What to check

- Vault and delegation screens reflect recent txs without manual refresh.
- Shared readers used by multiple features behave consistently.

## Stack

**C5** follows **C4**.
