### PR TITLE
DAO-1983 (C6/6): Final batch + remove legacy block-time constants

### DIFF
--- a/src/components/Countdown/Countdown.stories.tsx
+++ b/src/components/Countdown/Countdown.stories.tsx
@@ -3,6 +3,7 @@ import { Countdown } from './Countdown'
 import { TimeSource } from './types'
 import Big from '@/lib/big'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { BlockTimeProvider } from '@/shared/context/BlockTimeContext'
 
 const queryClient = new QueryClient()
 
@@ -16,7 +17,9 @@ const meta: Meta<typeof Countdown> = {
   decorators: [
     Story => (
       <QueryClientProvider client={queryClient}>
-        <Story />
+        <BlockTimeProvider>
+          <Story />
+        </BlockTimeProvider>
       </QueryClientProvider>
     ),
   ],

--- a/src/components/Countdown/Countdown.tsx
+++ b/src/components/Countdown/Countdown.tsx
@@ -1,22 +1,29 @@
+'use client'
+
 import moment from 'moment'
 import { useBlockNumber } from 'wagmi'
 
 import { Paragraph } from '@/components/Typography'
 import Big from '@/lib/big'
-import { DEFAULT_NUMBER_OF_SECONDS_PER_BLOCK } from '@/lib/constants'
 import { cn } from '@/lib/utils'
+import { useBlockTime } from '@/shared/context/BlockTimeContext'
 
 import { CountdownProps, TimeSource } from './types'
 
 /**
  * Calculates the time remaining in seconds
  */
-const calculateTimeRemaining = (end: Big, currentTime: Big, timeSource: TimeSource): number => {
+const calculateTimeRemaining = (
+  end: Big,
+  currentTime: Big,
+  timeSource: TimeSource,
+  secondsPerBlock: number,
+): number => {
   const remaining = end.minus(currentTime)
   if (remaining.lte(0)) return 0
 
   if (timeSource === 'blocks') {
-    return remaining.mul(DEFAULT_NUMBER_OF_SECONDS_PER_BLOCK).toNumber()
+    return remaining.mul(secondsPerBlock).toNumber()
   } else {
     return remaining.toNumber()
   }
@@ -104,6 +111,7 @@ export function Countdown({
   className,
   colorDirection = 'normal',
 }: CountdownProps) {
+  const { secondsPerBlock } = useBlockTime()
   const { data: currentBlockNumber } = useBlockNumber()
 
   // Calculate current time based on timeSource
@@ -114,7 +122,7 @@ export function Countdown({
         : Big(0)
       : Big(Math.floor(Date.now() / 1000))
 
-  const timeRemainingSec = calculateTimeRemaining(end, currentTime, timeSource)
+  const timeRemainingSec = calculateTimeRemaining(end, currentTime, timeSource, secondsPerBlock)
   const ratio = calculateRatio(end, currentTime, referenceStart)
 
   // Color coding is automatically disabled if ratio cannot be calculated (no referenceStart)

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -89,7 +89,6 @@ export const DEPOSITOR_ROLE = '0x013e1f410e70025de956b8838ba99c3a9a9f7eb3e6d6780
 // keccak256('WHITELISTED_USER_ROLE') — mirrors Roles.sol (internal constant, no on-chain getter)
 export const WHITELISTED_USER_ROLE = '0x013e1f410e70025de956b8838ba99c3a9a9f7eb3e6d678062363333c8abd7ea0'
 
-export const AVERAGE_BLOCKTIME = 60_000
 export const CACHE_REVALIDATE_SECONDS = 20
 
 export const RIF = 'RIF'
@@ -111,7 +110,6 @@ export const GRANT_TOKEN_LIMITS = {
 export const RNS_REGISTRY_ADDRESS = process.env.NEXT_PUBLIC_RNS_REGISTRY_ADDRESS as Address
 
 export const NODE_URL = process.env.NEXT_PUBLIC_NODE_URL
-export const DEFAULT_NUMBER_OF_SECONDS_PER_BLOCK = 25
 
 export const GOOGLE_TAG_ID = 'GTM-PTL6VZMT'
 

--- a/src/shared/hooks/contracts/btc-vault/useReadRbtcVaultForMultipleArgs.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadRbtcVaultForMultipleArgs.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import { UseReadContractReturnType, useReadContracts } from 'wagmi'
 
 import { getAbi, type RBTCAsyncVaultAbi } from '@/lib/abis/btc-vault'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { rbtcVault } from '@/lib/contracts'
 
 import { UseReadContractForMultipleArgsConfig, ViewPureFunctionName } from '../types'
@@ -32,7 +31,6 @@ export const useReadRbtcVaultForMultipleArgs = <TFunctionName extends RbtcAsyncV
     })),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/btc-vault/useReadSyntheticYield.ts
+++ b/src/shared/hooks/contracts/btc-vault/useReadSyntheticYield.ts
@@ -1,7 +1,6 @@
 import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
 
 import { getAbi, SyntheticYieldAbi } from '@/lib/abis/btc-vault'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { syntheticYield } from '@/lib/contracts'
 
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
@@ -24,7 +23,6 @@ export const useReadSyntheticYield = <TFunctionName extends SyntheticYieldFuncti
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/collective-rewards/useReadBackersManager.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadBackersManager.ts
@@ -1,7 +1,6 @@
 import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
 
 import { type BackersManagerAbi, getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BackersManagerAddress } from '@/lib/contracts'
 
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
@@ -24,7 +23,6 @@ export const useReadBackersManager = <TFunctionName extends BackersManagerFuncti
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/collective-rewards/useReadBuilderRegistry.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadBuilderRegistry.ts
@@ -1,7 +1,6 @@
 import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
 
 import { type BuilderRegistryAbi, getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BuilderRegistryAddress } from '@/lib/contracts'
 
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
@@ -24,7 +23,6 @@ export const useReadBuilderRegistry = <TFunctionName extends BuilderRegistryFunc
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/collective-rewards/useReadBuilderRegistryForMultipleArgs.test.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadBuilderRegistryForMultipleArgs.test.ts
@@ -1,12 +1,10 @@
 import { getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BuilderRegistryAddress } from '@/lib/contracts'
 import { renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, Mock, vi } from 'vitest'
 import { useReadContracts } from 'wagmi'
 import { useReadBuilderRegistryForMultipleArgs } from './useReadBuilderRegistryForMultipleArgs'
 
-// Mock wagmi's useReadContracts
 vi.mock('wagmi', () => ({
   useReadContracts: vi.fn(),
 }))
@@ -59,7 +57,6 @@ describe('useReadBuilderRegistries hook', () => {
         ],
         query: {
           retry: true,
-          refetchInterval: AVERAGE_BLOCKTIME,
         },
       }),
     )

--- a/src/shared/hooks/contracts/collective-rewards/useReadBuilderRegistryForMultipleArgs.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadBuilderRegistryForMultipleArgs.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import { UseReadContractParameters, UseReadContractReturnType, useReadContracts } from 'wagmi'
 
 import { type BuilderRegistryAbi, getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BuilderRegistryAddress } from '@/lib/contracts'
 
 import { UseReadContractForMultipleArgsConfig, ViewPureFunctionName } from '../types'
@@ -33,7 +32,6 @@ export const useReadBuilderRegistryForMultipleArgs = <TFunctionName extends Buil
     })),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/collective-rewards/useReadCycleTimeKeeper.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadCycleTimeKeeper.ts
@@ -1,7 +1,6 @@
 import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
 
 import { type CycleTimeKeeperAbi, getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { BackersManagerAddress } from '@/lib/contracts'
 
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
@@ -24,7 +23,6 @@ export const useReadCycleTimeKeeper = <TFunctionName extends CycleTimeKeeperFunc
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/collective-rewards/useReadGauges.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadGauges.ts
@@ -3,7 +3,6 @@ import { Abi } from 'viem'
 import { UseReadContractParameters, UseReadContractReturnType, useReadContracts } from 'wagmi'
 
 import { type GaugeAbi, getAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 
 import { UseReadContractsConfig, ViewPureFunctionName } from '../types'
 
@@ -34,7 +33,6 @@ export const useReadGauges = <TFunctionName extends GaugeFunctionName>(
     })),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/contracts/collective-rewards/useReadRewardDistributor.ts
+++ b/src/shared/hooks/contracts/collective-rewards/useReadRewardDistributor.ts
@@ -1,7 +1,6 @@
 import { useReadContract, UseReadContractParameters, UseReadContractReturnType } from 'wagmi'
 
 import { getAbi, type RewardDistributorAbi } from '@/lib/abis/tok'
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 import { RewardDistributorAddress } from '@/lib/contracts'
 
 import { UseReadContractConfig, ViewPureFunctionName } from '../types'
@@ -24,7 +23,6 @@ export const useReadRewardDistributor = <TFunctionName extends RewardDistributor
     ...(config as any),
     query: {
       retry: true,
-      refetchInterval: AVERAGE_BLOCKTIME,
       ...query,
     },
   })

--- a/src/shared/hooks/useDiscourseTopic.ts
+++ b/src/shared/hooks/useDiscourseTopic.ts
@@ -6,7 +6,7 @@ import type { DiscourseTopicResponse } from '@/shared/types/discourse'
 interface UseDiscourseTopicOptions {
   enabled?: boolean
   staleTime?: number
-  refetchInterval?: number
+  refetchInterval?: number | false
 }
 
 /**
@@ -27,7 +27,7 @@ export function useDiscourseTopic(
   discourseUrl: string | null | undefined,
   options: UseDiscourseTopicOptions = {},
 ) {
-  const { enabled = true, staleTime = 5 * 60 * 1000, refetchInterval } = options
+  const { enabled = true, staleTime = 5 * 60 * 1000, refetchInterval = false } = options
 
   return useQuery<DiscourseTopicResponse, Error>({
     queryKey: ['discourse-topic', discourseUrl],

--- a/src/shared/hooks/useExecuteProposal.ts
+++ b/src/shared/hooks/useExecuteProposal.ts
@@ -34,6 +34,7 @@ export const useExecuteProposal = (proposalId: string) => {
   const { data: timelockAddress } = useReadContract({
     ...DAO_DEFAULT_PARAMS,
     functionName: 'timelock',
+    query: { refetchInterval: false },
   })
 
   const { data: minDelay } = useReadContract({
@@ -42,7 +43,8 @@ export const useExecuteProposal = (proposalId: string) => {
     functionName: 'getMinDelay',
     query: {
       enabled: !!timelockAddress,
-      staleTime: 60000, // Timelock delay rarely changes
+      refetchInterval: false,
+      staleTime: 60000,
     },
   })
 

--- a/src/shared/hooks/useGetExternalDelegatedAmount.ts
+++ b/src/shared/hooks/useGetExternalDelegatedAmount.ts
@@ -4,7 +4,7 @@ import { useAccount, useReadContract } from 'wagmi'
 
 import { useGetDelegates } from '@/app/user/Delegation/hooks/useGetDelegates'
 import { StRIFTokenAbi } from '@/lib/abis/StRIFTokenAbi'
-import { AVERAGE_BLOCKTIME, STRIF_ADDRESS } from '@/lib/constants'
+import { STRIF_ADDRESS } from '@/lib/constants'
 import { getEnsDomainName } from '@/lib/rns'
 
 /**
@@ -52,9 +52,6 @@ export const useGetExternalDelegatedAmount = (address: Address | undefined) => {
       address: STRIF_ADDRESS,
       functionName: 'getVotes',
       args: [ownAddress],
-      query: {
-        refetchInterval: AVERAGE_BLOCKTIME,
-      },
     },
   )
 
@@ -64,9 +61,6 @@ export const useGetExternalDelegatedAmount = (address: Address | undefined) => {
       address: STRIF_ADDRESS,
       functionName: 'getVotes',
       args: [delegateeAddress],
-      query: {
-        refetchInterval: AVERAGE_BLOCKTIME,
-      },
     },
   )
 
@@ -80,9 +74,6 @@ export const useGetExternalDelegatedAmount = (address: Address | undefined) => {
       address: STRIF_ADDRESS,
       functionName: 'balanceOf',
       args: [ownAddress],
-      query: {
-        refetchInterval: AVERAGE_BLOCKTIME,
-      },
     },
   )
 

--- a/src/shared/hooks/usePagination.ts
+++ b/src/shared/hooks/usePagination.ts
@@ -1,8 +1,6 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query'
 import { useCallback, useMemo, useState } from 'react'
 
-import { AVERAGE_BLOCKTIME } from '@/lib/constants'
-
 interface UsePaginatedQueryOptions<T> {
   queryKey: string[]
   queryFn: () => Promise<T[]>
@@ -30,7 +28,6 @@ export function usePagination<T>({
     queryKey,
     queryFn,
     refetchOnWindowFocus: false,
-    refetchInterval: AVERAGE_BLOCKTIME,
   })
 
   const allItems = useMemo(() => (Array.isArray(data) ? data : []), [data])

--- a/src/shared/hooks/useProposalState.ts
+++ b/src/shared/hooks/useProposalState.ts
@@ -23,7 +23,7 @@ export const useProposalState = (proposalId: string, shouldRefetch = true) => {
     functionName: 'state',
     args: [BigInt(proposalId)],
     query: {
-      ...(shouldRefetch && { refetchInterval: 5000 }),
+      refetchInterval: shouldRefetch ? 5000 : false,
     },
   })
 

--- a/src/shared/hooks/useVoteOnProposal.ts
+++ b/src/shared/hooks/useVoteOnProposal.ts
@@ -27,7 +27,7 @@ export const useVoteOnProposal = (proposalId: string, shouldRefetch = true) => {
     functionName: 'hasVoted',
     args: [BigInt(proposalId), address as Address],
     query: {
-      ...(shouldRefetch && { refetchInterval: 5000 }),
+      refetchInterval: shouldRefetch ? 5000 : false,
     },
   })
 


### PR DESCRIPTION
## Why

The last readers (including BTC vault) and fund-manager hooks are moved off `AVERAGE_BLOCKTIME`. This PR also **removes the legacy exports** from `constants` and updates **Countdown** to use `useBlockTime()` so “blocks × seconds” uses the same average the rest of the app trusts.

Until this lands, the old constant must remain for any file not yet migrated—this PR finishes that migration for the DAO-1983 scope.

## What to check

- No remaining imports of `AVERAGE_BLOCKTIME` / removed seconds-per-block constant in this workstream.
- Countdowns tied to blocks look reasonable vs explorer timing.
- Fund manager and BTC vault UIs still refresh predictably after actions.

## Stack

**Final** slice of Strategy C—merge **after C5**.
