### PR TITLE
feat(DAO-2183): use AlwaysEnabledButton for mobile tooltip on disabled actions

### DIFF
--- a/src/app/btc-vault/components/BtcVaultActions.test.tsx
+++ b/src/app/btc-vault/components/BtcVaultActions.test.tsx
@@ -1,6 +1,6 @@
 import { TooltipProvider } from '@radix-ui/react-tooltip'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
 import { type ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -89,48 +89,55 @@ describe('BtcVaultActions', () => {
     cleanup()
   })
 
-  it('disables both buttons while a deposit request transaction is submitting', () => {
+  it('blocks CTA while a deposit request transaction is submitting', () => {
     mockUseSubmitDeposit.mockReturnValue({
       onRequestDeposit: vi.fn(),
       isRequesting: true,
       isTxPending: false,
     })
 
-    const { getByTestId } = renderWithQueryClient(<BtcVaultActions />)
+    const { getByTestId, queryByTestId } = renderWithQueryClient(<BtcVaultActions />)
 
-    expect(getByTestId('DepositButton')).toBeDisabled()
-    expect(getByTestId('WithdrawButton')).toBeDisabled()
+    // Buttons stay enabled (AlwaysEnabledButton) but CTA is guarded
+    expect(getByTestId('DepositButton')).toBeEnabled()
+    expect(getByTestId('WithdrawButton')).toBeEnabled()
+    fireEvent.click(getByTestId('DepositButton'))
+    expect(queryByTestId('BtcDepositModal')).toBeNull()
   })
 
-  it('disables both buttons while a withdraw transaction is pending', () => {
+  it('blocks CTA while a withdraw transaction is pending', () => {
     mockUseSubmitWithdrawal.mockReturnValue({
       onRequestRedeem: vi.fn(),
       isRequesting: false,
       isTxPending: true,
     })
 
-    const { getByTestId } = renderWithQueryClient(<BtcVaultActions />)
+    const { getByTestId, queryByTestId } = renderWithQueryClient(<BtcVaultActions />)
 
-    expect(getByTestId('DepositButton')).toBeDisabled()
-    expect(getByTestId('WithdrawButton')).toBeDisabled()
+    expect(getByTestId('DepositButton')).toBeEnabled()
+    expect(getByTestId('WithdrawButton')).toBeEnabled()
+    fireEvent.click(getByTestId('WithdrawButton'))
+    expect(queryByTestId('BtcWithdrawModal')).toBeNull()
   })
 
   it('enables deposit and withdraw when eligibility allows and nothing is submitting', () => {
     const { getByTestId } = renderWithQueryClient(<BtcVaultActions />)
 
-    expect(getByTestId('DepositButton')).not.toBeDisabled()
-    expect(getByTestId('WithdrawButton')).not.toBeDisabled()
+    expect(getByTestId('DepositButton')).toBeEnabled()
+    expect(getByTestId('WithdrawButton')).toBeEnabled()
   })
 
-  it('disables both buttons while vault share allowance is approving', () => {
+  it('blocks CTA while vault share allowance is approving', () => {
     mockUseBtcVaultSharesAllowance.mockReturnValue({
       ...defaultAllowanceHook,
       isRequesting: true,
     })
 
-    const { getByTestId } = renderWithQueryClient(<BtcVaultActions />)
+    const { getByTestId, queryByTestId } = renderWithQueryClient(<BtcVaultActions />)
 
-    expect(getByTestId('DepositButton')).toBeDisabled()
-    expect(getByTestId('WithdrawButton')).toBeDisabled()
+    expect(getByTestId('DepositButton')).toBeEnabled()
+    expect(getByTestId('WithdrawButton')).toBeEnabled()
+    fireEvent.click(getByTestId('DepositButton'))
+    expect(queryByTestId('BtcDepositModal')).toBeNull()
   })
 })

--- a/src/app/btc-vault/components/BtcVaultActions.tsx
+++ b/src/app/btc-vault/components/BtcVaultActions.tsx
@@ -3,8 +3,8 @@
 import { useCallback, useState } from 'react'
 import { useAccount } from 'wagmi'
 
-import { Button } from '@/components/Button'
-import { Tooltip } from '@/components/Tooltip'
+import { AlwaysEnabledButton } from '@/app/components/Button/AlwaysEnabledButton'
+import { TooltipConditionPair } from '@/app/components/Tooltip/ConditionalTooltip'
 import { executeTxFlow } from '@/shared/notification'
 
 import { useActionEligibility } from '../hooks/useActionEligibility'
@@ -69,6 +69,13 @@ export const BtcVaultActions = ({ onRequestSubmitted }: BtcVaultActionsProps) =>
   const depositTooltipText = isAnySubmitting ? REQUEST_SUBMITTING_REASON : depositBlockReason
   const withdrawTooltipText = isAnySubmitting ? REQUEST_SUBMITTING_REASON : withdrawBlockReason
 
+  const depositConditions: TooltipConditionPair[] = [
+    { condition: () => depositDisabled && !!depositTooltipText, lazyContent: () => depositTooltipText },
+  ]
+  const withdrawConditions: TooltipConditionPair[] = [
+    { condition: () => withdrawDisabled && !!withdrawTooltipText, lazyContent: () => withdrawTooltipText },
+  ]
+
   const handleDepositSubmit = useCallback(
     async (params: DepositRequestParams) => {
       executeTxFlow({
@@ -115,26 +122,22 @@ export const BtcVaultActions = ({ onRequestSubmitted }: BtcVaultActionsProps) =>
   return (
     <div data-testid="BtcVaultActionsContent" className="flex flex-col gap-4">
       <div className="flex gap-4">
-        <Tooltip text={depositTooltipText} disabled={!depositDisabled || !depositTooltipText}>
-          <Button
-            variant="primary"
-            onClick={() => setIsDepositModalOpen(true)}
-            disabled={depositDisabled}
-            data-testid="DepositButton"
-          >
-            Deposit
-          </Button>
-        </Tooltip>
-        <Tooltip text={withdrawTooltipText} disabled={!withdrawDisabled || !withdrawTooltipText}>
-          <Button
-            variant="primary"
-            onClick={() => setIsWithdrawModalOpen(true)}
-            disabled={withdrawDisabled}
-            data-testid="WithdrawButton"
-          >
-            Withdraw
-          </Button>
-        </Tooltip>
+        <AlwaysEnabledButton
+          variant="primary"
+          onClick={() => !depositDisabled && setIsDepositModalOpen(true)}
+          conditionPairs={depositConditions}
+          data-testid="DepositButton"
+        >
+          Deposit
+        </AlwaysEnabledButton>
+        <AlwaysEnabledButton
+          variant="primary"
+          onClick={() => !withdrawDisabled && setIsWithdrawModalOpen(true)}
+          conditionPairs={withdrawConditions}
+          data-testid="WithdrawButton"
+        >
+          Withdraw
+        </AlwaysEnabledButton>
       </div>
 
       {isDepositModalOpen && (


### PR DESCRIPTION
## Summary
- Replace disabled `Button` + `Tooltip` with `AlwaysEnabledButton` (wrapping `ConditionalTooltip`) for the BTC Vault deposit/withdraw actions
- On mobile, tapping a blocked button now shows a tooltip explaining why (e.g., "Your address is not whitelisted for deposits"), instead of showing a greyed-out button with no explanation
- CTA is guarded via `onClick` so the modal never opens when the action is blocked