### PR TITLE
feat(DAO-2005): add shared formatting utilities [1/5]

### DIFF
--- a/src/lib/utils/formatDate.test.ts
+++ b/src/lib/utils/formatDate.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  formatDateDayFirst,
+  formatDateDayFirstWithTime,
+  formatDateExpanded,
+  formatDateForCsv,
+  formatDateFullMonth,
+  formatDateFullMonthPadded,
+  formatDateMonthFirst,
+  formatDateRange,
+  formatMonthYear,
+  formatPeriodToMonthYear,
+} from './formatDate'
+
+// 14 Nov 2023 21:33:20 UTC → 1700000000
+const TS = 1700000000
+
+describe('formatDateDayFirst', () => {
+  it('formats as "dd MMM yyyy"', () => {
+    const result = formatDateDayFirst(TS)
+    expect(result).toContain('2023')
+    expect(result).toMatch(/^\d{2} \w{3} \d{4}$/)
+  })
+
+  it('accepts string input', () => {
+    expect(formatDateDayFirst(String(TS))).toBe(formatDateDayFirst(TS))
+  })
+})
+
+describe('formatDateDayFirstWithTime', () => {
+  it('formats as "dd MMM yyyy, hh:mm a"', () => {
+    const result = formatDateDayFirstWithTime(TS)
+    expect(result).toContain('2023')
+    expect(result).toMatch(/^\d{2} \w{3} \d{4}, \d{2}:\d{2} [AP]M$/)
+  })
+})
+
+describe('formatDateMonthFirst', () => {
+  it('formats as "MMM d, yyyy"', () => {
+    const result = formatDateMonthFirst(TS)
+    expect(result).toContain('2023')
+    expect(result).toMatch(/^\w{3} \d{1,2}, \d{4}$/)
+  })
+})
+
+describe('formatDateFullMonth', () => {
+  it('formats as "MMMM d" in UTC', () => {
+    // 23 Feb 2025 00:00:00 UTC
+    expect(formatDateFullMonth(1740268800, { utc: true })).toBe('February 23')
+  })
+
+  it('formats March 19 in UTC', () => {
+    expect(formatDateFullMonth(1742342400, { utc: true })).toMatch(/March 19/)
+  })
+})
+
+describe('formatDateFullMonthPadded', () => {
+  it('formats with zero-padded day in UTC', () => {
+    // 6 Apr 2026 00:00:00 UTC
+    expect(formatDateFullMonthPadded(1775433600, { utc: true })).toBe('April 06')
+  })
+
+  it('pads single-digit days', () => {
+    // 5 Apr 2026 00:00:00 UTC
+    expect(formatDateFullMonthPadded(1775347200, { utc: true })).toBe('April 05')
+  })
+})
+
+describe('formatMonthYear', () => {
+  it('formats as "MMMM yyyy"', () => {
+    expect(formatMonthYear(TS)).toMatch(/^\w+ \d{4}$/)
+    expect(formatMonthYear(TS)).toContain('2023')
+  })
+
+  it('accepts string input', () => {
+    expect(formatMonthYear(String(TS))).toBe(formatMonthYear(TS))
+  })
+})
+
+describe('formatPeriodToMonthYear', () => {
+  it('converts "YYYY-MM" to "MMMM yyyy"', () => {
+    expect(formatPeriodToMonthYear('2025-03')).toBe('March 2025')
+    expect(formatPeriodToMonthYear('2024-12')).toBe('December 2024')
+    expect(formatPeriodToMonthYear('2025-01')).toBe('January 2025')
+  })
+})
+
+describe('formatDateExpanded', () => {
+  it('formats as "MMM d, HH:mm"', () => {
+    const result = formatDateExpanded(TS)
+    expect(result).toMatch(/^\w{3} \d{1,2}, \d{2}:\d{2}$/)
+  })
+
+  it('accepts string input', () => {
+    expect(formatDateExpanded(String(TS))).toBe(formatDateExpanded(TS))
+  })
+})
+
+describe('formatDateForCsv', () => {
+  it('defaults to 12h format', () => {
+    const result = formatDateForCsv(TS)
+    expect(result).toMatch(/[AP]M$/)
+  })
+
+  it('supports 24h UTC format', () => {
+    const result = formatDateForCsv(TS, { utc: true, hour12: false })
+    expect(result).not.toMatch(/[AP]M/)
+    expect(result).toContain('2023')
+  })
+})
+
+describe('formatDateRange', () => {
+  it('formats same-month range', () => {
+    // Jan 2 2024 12:00 UTC + 14 days (midday to avoid timezone edge cases)
+    const start = 1704196800
+    const duration = 14 * 86400
+    const result = formatDateRange(start, duration)
+    expect(result).toMatch(/Jan \d+ - \d+, 2024/)
+  })
+
+  it('formats single-day range', () => {
+    // Jan 2 2024 12:00 UTC
+    const start = 1704196800
+    const result = formatDateRange(start, 1)
+    expect(result).toMatch(/Jan \d+, 2024/)
+  })
+
+  it('accepts string input', () => {
+    const start = '1704196800'
+    const result = formatDateRange(start, 14 * 86400)
+    expect(result).toMatch(/Jan/)
+  })
+})

--- a/src/lib/utils/formatDate.ts
+++ b/src/lib/utils/formatDate.ts
@@ -1,0 +1,90 @@
+import { DateTime } from 'luxon'
+
+type DateInput = number | string
+
+function toSeconds(input: DateInput): number {
+  return typeof input === 'string' ? Number(input) : input
+}
+
+function toDateTime(input: DateInput, utc = false): DateTime {
+  const seconds = toSeconds(input)
+  return utc ? DateTime.fromSeconds(seconds, { zone: 'utc' }) : DateTime.fromSeconds(seconds)
+}
+
+/** "15 Mar 2025" */
+export function formatDateDayFirst(input: DateInput): string {
+  return toDateTime(input).toFormat('dd MMM yyyy')
+}
+
+/** "15 Mar 2025, 02:30 PM" */
+export function formatDateDayFirstWithTime(input: DateInput): string {
+  return toDateTime(input).toFormat('dd MMM yyyy, hh:mm a')
+}
+
+/** "Mar 18, 2026" */
+export function formatDateMonthFirst(input: DateInput): string {
+  return toDateTime(input).toFormat('MMM d, yyyy')
+}
+
+/** "February 23" — UTC by default for closing-date display */
+export function formatDateFullMonth(input: DateInput, options?: { utc?: boolean }): string {
+  return toDateTime(input, options?.utc).toFormat('MMMM d')
+}
+
+/** "April 06" — UTC by default for deposit-window display */
+export function formatDateFullMonthPadded(input: DateInput, options?: { utc?: boolean }): string {
+  return toDateTime(input, options?.utc).toFormat('MMMM dd')
+}
+
+/** "March 2025" from a unix-seconds timestamp */
+export function formatMonthYear(input: DateInput): string {
+  return toDateTime(input).toFormat('MMMM yyyy')
+}
+
+/** "March 2025" from a "YYYY-MM" period string */
+export function formatPeriodToMonthYear(period: string): string {
+  const [year, month] = period.split('-')
+  return DateTime.fromObject({ year: Number(year), month: Number(month) }).toFormat('MMMM yyyy')
+}
+
+/** "Mar 15, 14:30" — short datetime without year, 24h */
+export function formatDateExpanded(input: DateInput): string {
+  return toDateTime(input).toFormat('MMM d, HH:mm')
+}
+
+/** "Jan 1, 2024, 12:00 PM" (default) or "Jan 1, 2024, 14:00" with hour12: false */
+export function formatDateForCsv(input: DateInput, options?: { utc?: boolean; hour12?: boolean }): string {
+  const dt = toDateTime(input, options?.utc)
+  const hour12 = options?.hour12 ?? true
+  return dt.toFormat(hour12 ? 'MMM d, yyyy, hh:mm a' : 'MMM d, yyyy, HH:mm')
+}
+
+/**
+ * "Jan 1 - 15, 2024" — formats a date range from a start timestamp and duration in seconds.
+ * Handles same-month, cross-month, and cross-year ranges.
+ */
+export function formatDateRange(cycleStart: DateInput, durationSeconds: number): string {
+  const startDt = toDateTime(cycleStart)
+  // Subtract 1 second so the end falls on the last moment of the range, not the start of the next
+  const endDt = DateTime.fromSeconds(toSeconds(cycleStart) + durationSeconds - 1)
+
+  const startMonth = startDt.toFormat('MMM')
+  const startDay = String(startDt.day)
+  const startYear = startDt.toFormat('yyyy')
+  const endMonth = endDt.toFormat('MMM')
+  const endDay = String(endDt.day)
+  const endYear = endDt.toFormat('yyyy')
+
+  if (startMonth === endMonth && startYear === endYear) {
+    if (startDay === endDay) {
+      return `${startMonth} ${startDay}, ${startYear}`
+    }
+    return `${startMonth} ${startDay} - ${endDay}, ${startYear}`
+  }
+
+  if (startYear === endYear) {
+    return `${startMonth} ${startDay} - ${endMonth} ${endDay}, ${endYear}`
+  }
+
+  return `${startMonth} ${startDay}, ${startYear} - ${endMonth} ${endDay}, ${endYear}`
+}

--- a/src/lib/utils/formatDuration.test.ts
+++ b/src/lib/utils/formatDuration.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatDuration } from './formatDuration'
+
+describe('formatDuration', () => {
+  it('formats with default units (d, h, m)', () => {
+    expect(formatDuration(190200)).toBe('2d 4h 50m')
+    expect(formatDuration(3661)).toBe('1h 1m')
+    expect(formatDuration(86400)).toBe('1d 0h 0m')
+    expect(formatDuration(60)).toBe('1m')
+  })
+
+  it('formats with minutes and seconds', () => {
+    expect(formatDuration(272, ['m', 's'])).toBe('4m 32s')
+    expect(formatDuration(60, ['m', 's'])).toBe('1m 0s')
+    expect(formatDuration(0, ['m', 's'])).toBe('0s')
+  })
+
+  it('skips leading zero-valued units', () => {
+    expect(formatDuration(45, ['m', 's'])).toBe('45s')
+    expect(formatDuration(30, ['d', 'h', 'm'])).toBe('0m')
+    expect(formatDuration(3600)).toBe('1h 0m')
+  })
+
+  it('handles zero seconds', () => {
+    expect(formatDuration(0)).toBe('0m')
+  })
+
+  it('clamps negative values to zero', () => {
+    expect(formatDuration(-100)).toBe('0m')
+    expect(formatDuration(-100, ['m', 's'])).toBe('0s')
+  })
+
+  it('formats with all four units', () => {
+    expect(formatDuration(90061, ['d', 'h', 'm', 's'])).toBe('1d 1h 1m 1s')
+  })
+})

--- a/src/lib/utils/formatDuration.ts
+++ b/src/lib/utils/formatDuration.ts
@@ -1,0 +1,37 @@
+type TimeUnit = 'd' | 'h' | 'm' | 's'
+
+const UNIT_DIVISORS: Record<TimeUnit, number> = {
+  d: 86400,
+  h: 3600,
+  m: 60,
+  s: 1,
+}
+
+/**
+ * Converts a number of seconds into a human-readable duration string.
+ * Leading zero-valued units are omitted (e.g. "45s" instead of "0m 45s").
+ *
+ * @param totalSeconds - Duration in seconds (clamped to 0 if negative)
+ * @param units - Which time units to include, in order (default: ['d', 'h', 'm'])
+ * @returns Formatted string (e.g. "2d 5h 30m", "4m 32s")
+ */
+export function formatDuration(totalSeconds: number, units: TimeUnit[] = ['d', 'h', 'm']): string {
+  let remaining = Math.max(0, Math.floor(totalSeconds))
+
+  const parts: { unit: TimeUnit; value: number }[] = []
+  for (const unit of units) {
+    const divisor = UNIT_DIVISORS[unit]
+    const value = Math.floor(remaining / divisor)
+    remaining %= divisor
+    parts.push({ unit, value })
+  }
+
+  // Skip leading zeros but always keep the last unit
+  const firstNonZero = parts.findIndex(p => p.value > 0)
+  const start = firstNonZero === -1 ? parts.length - 1 : firstNonZero
+
+  return parts
+    .slice(start)
+    .map(p => `${p.value}${p.unit}`)
+    .join(' ')
+}

--- a/src/lib/utils/formatPercentage.test.ts
+++ b/src/lib/utils/formatPercentage.test.ts
@@ -2,35 +2,24 @@ import { formatPercentage } from '@/lib/utils'
 import { describe, expect, it } from 'vitest'
 
 describe('formatPercentage', () => {
-  it('should format decimal numbers correctly', () => {
-    expect(formatPercentage(10.123)).toBe('10.12')
-    expect(formatPercentage(10.126)).toBe('10.13')
-    expect(formatPercentage(10.1)).toBe('10.1')
-    expect(formatPercentage(10)).toBe('10')
+  it('pads to 2 decimal places with % suffix', () => {
+    expect(formatPercentage(10.2)).toBe('10.20%')
+    expect(formatPercentage(10)).toBe('10.00%')
+    expect(formatPercentage(0)).toBe('0.00%')
   })
 
-  it('should handle edge cases', () => {
-    expect(formatPercentage(0)).toBe('0')
-    expect(formatPercentage(99.999)).toBe('100')
+  it('rounds to 2 decimal places', () => {
+    expect(formatPercentage(10.123)).toBe('10.12%')
+    expect(formatPercentage(10.126)).toBe('10.13%')
+    expect(formatPercentage(33.335)).toBe('33.34%')
   })
 
-  it('should handle very small numbers', () => {
-    expect(formatPercentage(0.001)).toBe('0')
-    expect(formatPercentage(0.009)).toBe('0.01')
-    expect(formatPercentage(0.123)).toBe('0.12')
+  it('handles values above 100', () => {
+    expect(formatPercentage(150)).toBe('150.00%')
+    expect(formatPercentage(100.5)).toBe('100.50%')
   })
 
-  it('should handle numbers with trailing zeros', () => {
-    expect(formatPercentage(10.0)).toBe('10')
-    expect(formatPercentage(10.1)).toBe('10.1')
-    expect(formatPercentage(10.2)).toBe('10.2')
-  })
-
-  it('should reject values outside of 0-100 range', () => {
-    expect(() => formatPercentage(-1)).toThrow('Percentage value must be between 0 and 100')
-    expect(() => formatPercentage(-0.1)).toThrow('Percentage value must be between 0 and 100')
-    expect(() => formatPercentage(-999999.999)).toThrow('Percentage value must be between 0 and 100')
-    expect(() => formatPercentage(101)).toThrow('Percentage value must be between 0 and 100')
-    expect(() => formatPercentage(100.1)).toThrow('Percentage value must be between 0 and 100')
+  it('handles negative values', () => {
+    expect(formatPercentage(-5.3)).toBe('-5.30%')
   })
 })

--- a/src/lib/utils/formatPercentage.ts
+++ b/src/lib/utils/formatPercentage.ts
@@ -1,14 +1,8 @@
-// Formats a percentage number to display at most 2 decimal places, but preserves all decimals if there are fewer than 2
-// Examples:
-// formatPercentage(10) => 10
-// formatPercentage(10.1) => 10.1
-// formatPercentage(10.12) => 10.12
-// formatPercentage(10.123) => 10.12
-// formatPercentage(10.126) => 10.13
-export const formatPercentage = (val: number): string => {
-  if (val < 0 || val > 100) {
-    throw new Error('Percentage value must be between 0 and 100')
-  }
-
-  return parseFloat(val.toFixed(2)).toString()
+/**
+ * Formats a numeric percentage value to a string with exactly 2 decimal places and a `%` suffix.
+ * @param value - Numeric percentage value (e.g. 10.2 for 10.2%)
+ * @returns Formatted percentage string (e.g. "10.20%")
+ */
+export function formatPercentage(value: number): string {
+  return `${value.toFixed(2)}%`
 }

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,2 +1,4 @@
+export * from './formatDate'
+export * from './formatDuration'
 export * from './formatPercentage'
 export * from './utils'

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -6,6 +6,8 @@ import { Address, formatEther, getAddress, isAddress } from 'viem'
 
 import Big from '@/lib/big'
 
+import { formatDuration } from './formatDuration'
+
 /**
  * Merges Tailwind and clsx classes in order to avoid classes conflicts.
  * This is useful when you want to override default classes and/or add conditional classes.
@@ -260,8 +262,7 @@ export const durationToLabel = (duration: Duration | undefined): string | undefi
     return undefined
   }
 
-  const converted = duration.shiftTo('days', 'hours', 'minutes')
-  return `${converted.days}d ${converted.hours}h ${converted.minutes}m`
+  return formatDuration(Math.floor(duration.as('seconds')))
 }
 
 // prettier-ignore


### PR DESCRIPTION
## Summary
- Rewrite `formatPercentage` to produce `"10.20%"` (padded decimals + `%` suffix, no range validation)
- Add `formatDuration` with configurable time units and leading-zero suppression
- Add `formatDate` module with 10 Luxon-based date formatters covering all existing patterns
- Update `durationToLabel` to delegate to the new `formatDuration`

> Stack: **[1/5]** → #2 → #3 → #4 → #5