### PR TITLE
refactor(DAO-2005): migrate btc-vault formatters to shared utilities [2/5]

### DIFF
--- a/src/app/btc-vault/components/BtcVaultMetrics.test.tsx
+++ b/src/app/btc-vault/components/BtcVaultMetrics.test.tsx
@@ -3,8 +3,7 @@ import { cleanup, render, screen, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { RBTC } from '@/lib/constants'
-
-import { formatDateMonthFirst } from '../services/ui/formatters'
+import { formatDateMonthFirst } from '@/lib/utils'
 import { BtcVaultMetrics } from './BtcVaultMetrics'
 
 const renderWithProviders = () =>

--- a/src/app/btc-vault/components/BtcVaultMetrics.tsx
+++ b/src/app/btc-vault/components/BtcVaultMetrics.tsx
@@ -14,7 +14,7 @@ import { usePricesContext } from '@/shared/context'
 
 import { useEpochState } from '../hooks/useEpochState'
 import { useVaultMetrics } from '../hooks/useVaultMetrics'
-import { formatDateClosingOn, formatDateMonthFirst } from '../services/ui/formatters'
+import { formatDateFullMonth, formatDateMonthFirst } from '@/lib/utils'
 import { lockedSharePriceToNavPerHumanShareWei } from '../services/vaultShareNav'
 
 const PLACEHOLDER = '—'
@@ -54,7 +54,7 @@ export const BtcVaultMetrics = () => {
   const depositWindowValue = useMemo(() => {
     if (isMetricsLoading || !epoch) return PLACEHOLDER
     if (epoch.status === 'open' && epoch.endTime != null) {
-      return `closing on ${formatDateClosingOn(epoch.endTime)}`
+      return `closing on ${formatDateFullMonth(epoch.endTime, { utc: true })}`
     }
     return PLACEHOLDER
   }, [epoch, isMetricsLoading])

--- a/src/app/btc-vault/components/DepositWindowSection.tsx
+++ b/src/app/btc-vault/components/DepositWindowSection.tsx
@@ -5,8 +5,8 @@ import { useEffect, useState } from 'react'
 import { Countdown } from '@/components/Countdown/Countdown'
 import { Header, Label } from '@/components/Typography'
 import Big from '@/lib/big'
+import { formatDateFullMonthPadded } from '@/lib/utils'
 
-import { formatDateFullMonthPaddedDayUtc } from '../services/ui/formatters'
 import type { EpochDisplay } from '../services/ui/types'
 
 const DEPOSIT_WINDOW_SUBTITLE = 'For the current cycle, deposits can be made until'
@@ -41,7 +41,7 @@ export function DepositWindowSection({ epoch }: DepositWindowSectionProps) {
           DEPOSIT WINDOW {epoch.epochId}
         </Header>
         <Label variant="body-l" className="text-[#171412] leading-[133%]">
-          {DEPOSIT_WINDOW_SUBTITLE} {formatDateFullMonthPaddedDayUtc(epoch.endTime)}.
+          {DEPOSIT_WINDOW_SUBTITLE} {formatDateFullMonthPadded(epoch.endTime, { utc: true })}.
         </Label>
       </div>
       <Countdown

--- a/src/app/btc-vault/deposit-history/components/convertDataToRowData.ts
+++ b/src/app/btc-vault/deposit-history/components/convertDataToRowData.ts
@@ -1,10 +1,9 @@
 import { formatSymbol, getFiatAmount } from '@/app/shared/formatter'
 import { RBTC } from '@/lib/constants'
-import { formatCurrencyWithLabel } from '@/lib/utils'
+import { formatCurrencyWithLabel, formatDateMonthFirst } from '@/lib/utils'
 import type { Row } from '@/shared/context'
 
 import type { DepositWindowRow } from '../../services/types'
-import { formatDateMonthFirst } from '../../services/ui/formatters'
 import type { ColumnId, DepositHistoryCellDataMap } from './DepositHistoryTable.config'
 
 /**

--- a/src/app/btc-vault/services/ui/formatters.test.ts
+++ b/src/app/btc-vault/services/ui/formatters.test.ts
@@ -1,14 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import {
-  formatApyPercent,
-  formatPercent,
-  formatTimestamp,
-  formatDateShort,
-  formatDateClosingOn,
-  formatDateFullMonthPaddedDayUtc,
-  shortenTxHash,
-  formatCountdown,
-} from './formatters'
+import { formatApyPercent, shortenTxHash, formatCountdown } from './formatters'
 
 describe('formatApyPercent', () => {
   it('formats 8.5% APY from decimal', () => {
@@ -16,15 +7,6 @@ describe('formatApyPercent', () => {
   })
   it('formats 0% APY', () => {
     expect(formatApyPercent(0)).toBe('0.00')
-  })
-})
-
-describe('formatPercent', () => {
-  it('formats float to percentage string', () => {
-    expect(formatPercent(10.2)).toBe('10.20%')
-  })
-  it('formats zero', () => {
-    expect(formatPercent(0)).toBe('0.00%')
   })
 })
 
@@ -41,55 +23,5 @@ describe('shortenTxHash', () => {
 describe('formatCountdown', () => {
   it('returns "Expired" for past timestamps', () => {
     expect(formatCountdown(0)).toBe('Expired')
-  })
-})
-
-describe('formatTimestamp', () => {
-  it('defaults to day-first date-only format', () => {
-    const result = formatTimestamp(1700000000)
-    expect(result).toContain('2023')
-    expect(result).toMatch(/^\d{2} \w{3} \d{4}$/)
-  })
-
-  it('includes time when includeTime option is true', () => {
-    const result = formatTimestamp(1700000000, { includeTime: true })
-    expect(result).toContain('2023')
-    expect(result).toMatch(/^\d{2} \w{3} \d{4}, \d{2}:\d{2} [AP]M$/)
-  })
-})
-
-describe('formatDateShort', () => {
-  it('formats unix timestamp to day-first date-only string (e.g. 21 May 2025)', () => {
-    const result = formatDateShort(1747872000) // 21 May 2025 00:00:00 UTC
-    expect(result).toContain('2025')
-    expect(result).toMatch(/^\d{2} \w{3} \d{4}$/)
-  })
-  it('uses updated when present for lastUpdated display', () => {
-    const created = 1700000000
-    const updated = 1700086400
-    expect(formatDateShort(created)).not.toBe(formatDateShort(updated))
-  })
-})
-
-describe('formatDateClosingOn', () => {
-  it('formats unix timestamp to month and day (e.g. February 23)', () => {
-    // 23 Feb 2025 00:00:00 UTC
-    const result = formatDateClosingOn(1740268800)
-    expect(result).toBe('February 23')
-  })
-  it('formats March 19', () => {
-    const result = formatDateClosingOn(1742342400) // 19 Mar 2025 00:00:00 UTC
-    expect(result).toMatch(/March 19/)
-  })
-})
-
-describe('formatDateFullMonthPaddedDayUtc', () => {
-  it('formats with full month and zero-padded day (e.g. April 06)', () => {
-    // 6 Apr 2026 00:00:00 UTC
-    const result = formatDateFullMonthPaddedDayUtc(1775433600)
-    expect(result).toBe('April 06')
-  })
-  it('pads single-digit days', () => {
-    expect(formatDateFullMonthPaddedDayUtc(1775347200)).toBe('April 05') // 5 Apr 2026 UTC
   })
 })

--- a/src/app/btc-vault/services/ui/formatters.ts
+++ b/src/app/btc-vault/services/ui/formatters.ts
@@ -1,4 +1,4 @@
-import { DateTime } from 'luxon'
+import { formatDuration } from '@/lib/utils'
 
 /**
  * Converts an APY decimal value to a percentage string with 2 decimal places.
@@ -7,64 +7,6 @@ import { DateTime } from 'luxon'
  */
 export function formatApyPercent(apy: number): string {
   return (apy * 100).toFixed(2)
-}
-
-/**
- * Formats a numeric value as a percentage string with 2 decimal places.
- * @param value - Numeric percentage value
- * @returns Formatted string with % suffix (e.g. "10.20%")
- */
-export function formatPercent(value: number): string {
-  return `${value.toFixed(2)}%`
-}
-
-/**
- * Formats a Unix timestamp (seconds) into a day-first date string.
- * @param unix - Unix timestamp in seconds
- * @param options.includeTime - When true, appends time (e.g. "15 Mar 2025, 02:30 PM")
- * @returns Formatted date string (e.g. "15 Mar 2025")
- */
-export function formatTimestamp(unix: number, options?: { includeTime?: boolean }): string {
-  const format = options?.includeTime ? 'dd MMM yyyy, hh:mm a' : 'dd MMM yyyy'
-  return DateTime.fromSeconds(unix).toFormat(format)
-}
-
-/**
- * Formats a Unix timestamp (seconds) into a day-first date-only string.
- * @param unix - Unix timestamp in seconds
- * @returns Formatted date string (e.g. "21 May 2025")
- */
-export function formatDateShort(unix: number): string {
-  return DateTime.fromSeconds(unix).toFormat('dd MMM yyyy')
-}
-
-/**
- * Formats a Unix timestamp (seconds) into a month-first date-only string with comma after day.
- * @param unix - Unix timestamp in seconds
- * @returns Formatted date string (e.g. "Mar 18, 2026")
- */
-export function formatDateMonthFirst(unix: number): string {
-  return DateTime.fromSeconds(unix).toFormat('MMM d, yyyy')
-}
-
-/**
- * Formats a Unix timestamp (seconds) for "closing on [Month Day]" display (e.g. "February 23").
- * Uses UTC so the calendar day is stable across client timezones.
- * @param unix - Unix timestamp in seconds
- * @returns Formatted date string (e.g. "February 23")
- */
-export function formatDateClosingOn(unix: number): string {
-  return DateTime.fromSeconds(unix, { zone: 'utc' }).toFormat('MMMM d')
-}
-
-/**
- * Formats a Unix timestamp (seconds) as full month name and zero-padded day (UTC).
- * For deposit-window style copy (e.g. "April 06") where {@link formatDateClosingOn} uses an unpadded day.
- * @param unix - Unix timestamp in seconds
- * @returns Formatted string (e.g. "April 06")
- */
-export function formatDateFullMonthPaddedDayUtc(unix: number): string {
-  return DateTime.fromSeconds(unix, { zone: 'utc' }).toFormat('MMMM dd')
 }
 
 /**
@@ -85,7 +27,5 @@ export function shortenTxHash(hash: string): string {
 export function formatCountdown(endTime: number): string {
   const remaining = endTime - Math.floor(Date.now() / 1000)
   if (remaining <= 0) return 'Expired'
-  const m = Math.floor(remaining / 60)
-  const s = remaining % 60
-  return m > 0 ? `${m}m ${s}s` : `${s}s`
+  return formatDuration(remaining, ['m', 's'])
 }

--- a/src/app/btc-vault/services/ui/mappers.ts
+++ b/src/app/btc-vault/services/ui/mappers.ts
@@ -4,7 +4,13 @@ import { DEPOSIT_ACTIONS } from '@/app/api/btc-vault/v1/schemas'
 import { formatSymbol, getFiatAmount } from '@/app/shared/formatter'
 import Big from '@/lib/big'
 import { RBTC } from '@/lib/constants'
-import { formatCurrencyWithLabel, shortAddress } from '@/lib/utils'
+import {
+  formatCurrencyWithLabel,
+  formatDateDayFirst,
+  formatDateMonthFirst,
+  formatPercentage,
+  shortAddress,
+} from '@/lib/utils'
 
 import {
   ACTIVE_REQUEST_REASON,
@@ -30,15 +36,7 @@ import type {
 } from '../types'
 import { lockedSharePriceFromEpochSnapshot, lockedSharePriceToNavPerHumanShareWei } from '../vaultShareNav'
 import type { BtcVaultHistoryApiResponse, BtcVaultHistoryItemWithStatus } from './api-types'
-import {
-  formatApyPercent,
-  formatCountdown,
-  formatDateMonthFirst,
-  formatDateShort,
-  formatPercent,
-  formatTimestamp,
-  shortenTxHash,
-} from './formatters'
+import { formatApyPercent, formatCountdown, shortenTxHash } from './formatters'
 import type {
   ActionEligibility,
   ActiveRequestDisplay,
@@ -128,7 +126,7 @@ export function toEpochDisplay(raw: EpochState): EpochDisplay {
     raw.status === 'open'
       ? `Closes in ${formatCountdown(raw.endTime)}`
       : raw.status === 'claimable' && raw.settledAt != null
-        ? `Settled ${formatTimestamp(raw.settledAt)}`
+        ? `Settled ${formatDateDayFirst(raw.settledAt)}`
         : raw.status.charAt(0).toUpperCase() + raw.status.slice(1)
   return {
     epochId: raw.epochId,
@@ -136,7 +134,7 @@ export function toEpochDisplay(raw: EpochState): EpochDisplay {
     statusSummary,
     isAcceptingRequests,
     endTime: raw.endTime,
-    closesAtFormatted: formatDateShort(raw.endTime),
+    closesAtFormatted: formatDateDayFirst(raw.endTime),
   }
 }
 
@@ -162,7 +160,7 @@ export function toUserPositionDisplay(raw: UserPosition, rbtcPrice: number): Use
     rbtcBalanceFormatted: formatSymbol(raw.rbtcBalance, RBTC),
     vaultTokensFormatted: formatSymbol(raw.vaultTokens, 'ctokenvault'),
     positionValueFormatted: formatSymbol(raw.positionValue, RBTC),
-    percentOfVaultFormatted: formatPercent(raw.percentOfVault),
+    percentOfVaultFormatted: formatPercentage(raw.percentOfVault),
     vaultTokensRaw: raw.vaultTokens,
     rbtcBalanceRaw: raw.rbtcBalance,
 
@@ -171,7 +169,7 @@ export function toUserPositionDisplay(raw: UserPosition, rbtcPrice: number): Use
     currentEarningsFormatted: formatSymbol(currentEarnings, RBTC),
     totalBalanceFormatted: formatSymbol(raw.positionValue, RBTC),
     totalBalanceRaw: raw.positionValue,
-    yieldPercentToDateFormatted: formatPercent(yieldPercent),
+    yieldPercentToDateFormatted: formatPercentage(yieldPercent),
 
     fiatWalletBalance: hasFiat ? formatCurrencyWithLabel(getFiatAmount(raw.rbtcBalance, rbtcPrice)) : null,
     fiatVaultShares: hasFiat ? formatCurrencyWithLabel(getFiatAmount(raw.positionValue, rbtcPrice)) : null,
@@ -325,7 +323,7 @@ export function toActiveRequestDisplay(
     type: req.type,
     amountFormatted,
     status: req.status,
-    createdAtFormatted: formatTimestamp(req.timestamps.created),
+    createdAtFormatted: formatDateDayFirst(req.timestamps.created),
     claimable: claimableInfo?.claimable ?? false,
     lockedSharePriceFormatted:
       claimableInfo?.lockedSharePrice != null
@@ -334,7 +332,7 @@ export function toActiveRequestDisplay(
     finalizeId: req.type === 'deposit' ? req.epochId : req.batchRedeemId,
     epochId: req.epochId,
     batchRedeemId: req.batchRedeemId,
-    lastUpdatedFormatted: formatDateShort(lastUpdated),
+    lastUpdatedFormatted: formatDateDayFirst(lastUpdated),
     sharesFormatted,
     usdEquivalentFormatted,
     ...(req.displayStatus && { displayStatus: req.displayStatus }),
@@ -425,8 +423,8 @@ export function toPaginatedHistoryDisplay(
         type: req.type,
         amountFormatted,
         status: req.status,
-        createdAtFormatted: formatTimestamp(req.timestamps.created),
-        finalizedAtFormatted: req.timestamps.finalized ? formatTimestamp(req.timestamps.finalized) : null,
+        createdAtFormatted: formatDateDayFirst(req.timestamps.created),
+        finalizedAtFormatted: req.timestamps.finalized ? formatDateDayFirst(req.timestamps.finalized) : null,
         submitTxShort: req.txHashes.submit ? shortenTxHash(req.txHashes.submit) : null,
         finalizeTxShort: req.txHashes.finalize ? shortenTxHash(req.txHashes.finalize) : null,
         submitTxFull: req.txHashes.submit ?? null,
@@ -435,7 +433,7 @@ export function toPaginatedHistoryDisplay(
         displayStatusLabel,
         fiatAmountFormatted,
         claimTokenType: isDeposit ? ('rbtc' as const) : ('shares' as const),
-        updatedAtFormatted: formatDateShort(updatedAt),
+        updatedAtFormatted: formatDateDayFirst(updatedAt),
       }
     }),
     total: raw.total,
@@ -546,7 +544,7 @@ export function apiHistoryToPaginatedDisplay(
           ? formatCurrencyWithLabel(Big(formatEther(amountWei)).mul(rbtcPrice))
           : null,
       claimTokenType: isDeposit ? ('rbtc' as const) : ('shares' as const),
-      updatedAtFormatted: formatDateShort(item.timestamp),
+      updatedAtFormatted: formatDateDayFirst(item.timestamp),
     }
   })
 

--- a/src/app/fund-admin/sections/whitelist/utils.ts
+++ b/src/app/fund-admin/sections/whitelist/utils.ts
@@ -1,8 +1,7 @@
 import type { Address } from 'viem'
 
 import type { BtcVaultWhitelistedUserItem } from '@/app/api/btc-vault/v1/whitelist-role-history/action'
-import { formatDateMonthFirst } from '@/app/btc-vault/services/ui/formatters'
-import { shortAddress } from '@/lib/utils'
+import { formatDateMonthFirst, shortAddress } from '@/lib/utils'
 import type { Row } from '@/shared/context/TableContext/types'
 
 import type { ColumnId, WhitelistCellDataMap, WhitelistStatus } from './config'

--- a/src/app/fund-manager/sections/transactions/utils.ts
+++ b/src/app/fund-manager/sections/transactions/utils.ts
@@ -1,12 +1,12 @@
 import type { Address } from 'viem'
 
 import type { RequestType } from '@/app/btc-vault/services/types'
-import { formatDateMonthFirst } from '@/app/btc-vault/services/ui/formatters'
 import { getTxHistoryStatusLabel } from '@/app/btc-vault/services/ui/mappers'
 import type { DisplayStatus } from '@/app/btc-vault/services/ui/types'
 import type { BtcVaultEntityHistoryRow } from '@/app/fund-manager/sections/transactions/hooks/useGetBtcVaultEntitiesHistory'
 import Big from '@/lib/big'
 import { RBTC, WeiPerEther } from '@/lib/constants'
+import { formatDateMonthFirst } from '@/lib/utils'
 import { formatCurrency, formatCurrencyWithLabel, shortAddress } from '@/lib/utils'
 import type { Row } from '@/shared/context'
 

--- a/src/lib/utils/formatDate.test.ts
+++ b/src/lib/utils/formatDate.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  formatDateDayFirst,
+  formatDateDayFirstWithTime,
+  formatDateExpanded,
+  formatDateForCsv,
+  formatDateFullMonth,
+  formatDateFullMonthPadded,
+  formatDateMonthFirst,
+  formatDateRange,
+  formatMonthYear,
+  formatPeriodToMonthYear,
+} from './formatDate'
+
+// 14 Nov 2023 21:33:20 UTC → 1700000000
+const TS = 1700000000
+
+describe('formatDateDayFirst', () => {
+  it('formats as "dd MMM yyyy"', () => {
+    const result = formatDateDayFirst(TS)
+    expect(result).toContain('2023')
+    expect(result).toMatch(/^\d{2} \w{3} \d{4}$/)
+  })
+
+  it('accepts string input', () => {
+    expect(formatDateDayFirst(String(TS))).toBe(formatDateDayFirst(TS))
+  })
+})
+
+describe('formatDateDayFirstWithTime', () => {
+  it('formats as "dd MMM yyyy, hh:mm a"', () => {
+    const result = formatDateDayFirstWithTime(TS)
+    expect(result).toContain('2023')
+    expect(result).toMatch(/^\d{2} \w{3} \d{4}, \d{2}:\d{2} [AP]M$/)
+  })
+})
+
+describe('formatDateMonthFirst', () => {
+  it('formats as "MMM d, yyyy"', () => {
+    const result = formatDateMonthFirst(TS)
+    expect(result).toContain('2023')
+    expect(result).toMatch(/^\w{3} \d{1,2}, \d{4}$/)
+  })
+})
+
+describe('formatDateFullMonth', () => {
+  it('formats as "MMMM d" in UTC', () => {
+    // 23 Feb 2025 00:00:00 UTC
+    expect(formatDateFullMonth(1740268800, { utc: true })).toBe('February 23')
+  })
+
+  it('formats March 19 in UTC', () => {
+    expect(formatDateFullMonth(1742342400, { utc: true })).toMatch(/March 19/)
+  })
+})
+
+describe('formatDateFullMonthPadded', () => {
+  it('formats with zero-padded day in UTC', () => {
+    // 6 Apr 2026 00:00:00 UTC
+    expect(formatDateFullMonthPadded(1775433600, { utc: true })).toBe('April 06')
+  })
+
+  it('pads single-digit days', () => {
+    // 5 Apr 2026 00:00:00 UTC
+    expect(formatDateFullMonthPadded(1775347200, { utc: true })).toBe('April 05')
+  })
+})
+
+describe('formatMonthYear', () => {
+  it('formats as "MMMM yyyy"', () => {
+    expect(formatMonthYear(TS)).toMatch(/^\w+ \d{4}$/)
+    expect(formatMonthYear(TS)).toContain('2023')
+  })
+
+  it('accepts string input', () => {
+    expect(formatMonthYear(String(TS))).toBe(formatMonthYear(TS))
+  })
+})
+
+describe('formatPeriodToMonthYear', () => {
+  it('converts "YYYY-MM" to "MMMM yyyy"', () => {
+    expect(formatPeriodToMonthYear('2025-03')).toBe('March 2025')
+    expect(formatPeriodToMonthYear('2024-12')).toBe('December 2024')
+    expect(formatPeriodToMonthYear('2025-01')).toBe('January 2025')
+  })
+})
+
+describe('formatDateExpanded', () => {
+  it('formats as "MMM d, HH:mm"', () => {
+    const result = formatDateExpanded(TS)
+    expect(result).toMatch(/^\w{3} \d{1,2}, \d{2}:\d{2}$/)
+  })
+
+  it('accepts string input', () => {
+    expect(formatDateExpanded(String(TS))).toBe(formatDateExpanded(TS))
+  })
+})
+
+describe('formatDateForCsv', () => {
+  it('defaults to 12h format', () => {
+    const result = formatDateForCsv(TS)
+    expect(result).toMatch(/[AP]M$/)
+  })
+
+  it('supports 24h UTC format', () => {
+    const result = formatDateForCsv(TS, { utc: true, hour12: false })
+    expect(result).not.toMatch(/[AP]M/)
+    expect(result).toContain('2023')
+  })
+})
+
+describe('formatDateRange', () => {
+  it('formats same-month range', () => {
+    // Jan 2 2024 12:00 UTC + 14 days (midday to avoid timezone edge cases)
+    const start = 1704196800
+    const duration = 14 * 86400
+    const result = formatDateRange(start, duration)
+    expect(result).toMatch(/Jan \d+ - \d+, 2024/)
+  })
+
+  it('formats single-day range', () => {
+    // Jan 2 2024 12:00 UTC
+    const start = 1704196800
+    const result = formatDateRange(start, 1)
+    expect(result).toMatch(/Jan \d+, 2024/)
+  })
+
+  it('accepts string input', () => {
+    const start = '1704196800'
+    const result = formatDateRange(start, 14 * 86400)
+    expect(result).toMatch(/Jan/)
+  })
+})

--- a/src/lib/utils/formatDate.ts
+++ b/src/lib/utils/formatDate.ts
@@ -1,0 +1,90 @@
+import { DateTime } from 'luxon'
+
+type DateInput = number | string
+
+function toSeconds(input: DateInput): number {
+  return typeof input === 'string' ? Number(input) : input
+}
+
+function toDateTime(input: DateInput, utc = false): DateTime {
+  const seconds = toSeconds(input)
+  return utc ? DateTime.fromSeconds(seconds, { zone: 'utc' }) : DateTime.fromSeconds(seconds)
+}
+
+/** "15 Mar 2025" */
+export function formatDateDayFirst(input: DateInput): string {
+  return toDateTime(input).toFormat('dd MMM yyyy')
+}
+
+/** "15 Mar 2025, 02:30 PM" */
+export function formatDateDayFirstWithTime(input: DateInput): string {
+  return toDateTime(input).toFormat('dd MMM yyyy, hh:mm a')
+}
+
+/** "Mar 18, 2026" */
+export function formatDateMonthFirst(input: DateInput): string {
+  return toDateTime(input).toFormat('MMM d, yyyy')
+}
+
+/** "February 23" — UTC by default for closing-date display */
+export function formatDateFullMonth(input: DateInput, options?: { utc?: boolean }): string {
+  return toDateTime(input, options?.utc).toFormat('MMMM d')
+}
+
+/** "April 06" — UTC by default for deposit-window display */
+export function formatDateFullMonthPadded(input: DateInput, options?: { utc?: boolean }): string {
+  return toDateTime(input, options?.utc).toFormat('MMMM dd')
+}
+
+/** "March 2025" from a unix-seconds timestamp */
+export function formatMonthYear(input: DateInput): string {
+  return toDateTime(input).toFormat('MMMM yyyy')
+}
+
+/** "March 2025" from a "YYYY-MM" period string */
+export function formatPeriodToMonthYear(period: string): string {
+  const [year, month] = period.split('-')
+  return DateTime.fromObject({ year: Number(year), month: Number(month) }).toFormat('MMMM yyyy')
+}
+
+/** "Mar 15, 14:30" — short datetime without year, 24h */
+export function formatDateExpanded(input: DateInput): string {
+  return toDateTime(input).toFormat('MMM d, HH:mm')
+}
+
+/** "Jan 1, 2024, 12:00 PM" (default) or "Jan 1, 2024, 14:00" with hour12: false */
+export function formatDateForCsv(input: DateInput, options?: { utc?: boolean; hour12?: boolean }): string {
+  const dt = toDateTime(input, options?.utc)
+  const hour12 = options?.hour12 ?? true
+  return dt.toFormat(hour12 ? 'MMM d, yyyy, hh:mm a' : 'MMM d, yyyy, HH:mm')
+}
+
+/**
+ * "Jan 1 - 15, 2024" — formats a date range from a start timestamp and duration in seconds.
+ * Handles same-month, cross-month, and cross-year ranges.
+ */
+export function formatDateRange(cycleStart: DateInput, durationSeconds: number): string {
+  const startDt = toDateTime(cycleStart)
+  // Subtract 1 second so the end falls on the last moment of the range, not the start of the next
+  const endDt = DateTime.fromSeconds(toSeconds(cycleStart) + durationSeconds - 1)
+
+  const startMonth = startDt.toFormat('MMM')
+  const startDay = String(startDt.day)
+  const startYear = startDt.toFormat('yyyy')
+  const endMonth = endDt.toFormat('MMM')
+  const endDay = String(endDt.day)
+  const endYear = endDt.toFormat('yyyy')
+
+  if (startMonth === endMonth && startYear === endYear) {
+    if (startDay === endDay) {
+      return `${startMonth} ${startDay}, ${startYear}`
+    }
+    return `${startMonth} ${startDay} - ${endDay}, ${startYear}`
+  }
+
+  if (startYear === endYear) {
+    return `${startMonth} ${startDay} - ${endMonth} ${endDay}, ${endYear}`
+  }
+
+  return `${startMonth} ${startDay}, ${startYear} - ${endMonth} ${endDay}, ${endYear}`
+}

--- a/src/lib/utils/formatDuration.test.ts
+++ b/src/lib/utils/formatDuration.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatDuration } from './formatDuration'
+
+describe('formatDuration', () => {
+  it('formats with default units (d, h, m)', () => {
+    expect(formatDuration(190200)).toBe('2d 4h 50m')
+    expect(formatDuration(3661)).toBe('1h 1m')
+    expect(formatDuration(86400)).toBe('1d 0h 0m')
+    expect(formatDuration(60)).toBe('1m')
+  })
+
+  it('formats with minutes and seconds', () => {
+    expect(formatDuration(272, ['m', 's'])).toBe('4m 32s')
+    expect(formatDuration(60, ['m', 's'])).toBe('1m 0s')
+    expect(formatDuration(0, ['m', 's'])).toBe('0s')
+  })
+
+  it('skips leading zero-valued units', () => {
+    expect(formatDuration(45, ['m', 's'])).toBe('45s')
+    expect(formatDuration(30, ['d', 'h', 'm'])).toBe('0m')
+    expect(formatDuration(3600)).toBe('1h 0m')
+  })
+
+  it('handles zero seconds', () => {
+    expect(formatDuration(0)).toBe('0m')
+  })
+
+  it('clamps negative values to zero', () => {
+    expect(formatDuration(-100)).toBe('0m')
+    expect(formatDuration(-100, ['m', 's'])).toBe('0s')
+  })
+
+  it('formats with all four units', () => {
+    expect(formatDuration(90061, ['d', 'h', 'm', 's'])).toBe('1d 1h 1m 1s')
+  })
+})

--- a/src/lib/utils/formatDuration.ts
+++ b/src/lib/utils/formatDuration.ts
@@ -1,0 +1,37 @@
+type TimeUnit = 'd' | 'h' | 'm' | 's'
+
+const UNIT_DIVISORS: Record<TimeUnit, number> = {
+  d: 86400,
+  h: 3600,
+  m: 60,
+  s: 1,
+}
+
+/**
+ * Converts a number of seconds into a human-readable duration string.
+ * Leading zero-valued units are omitted (e.g. "45s" instead of "0m 45s").
+ *
+ * @param totalSeconds - Duration in seconds (clamped to 0 if negative)
+ * @param units - Which time units to include, in order (default: ['d', 'h', 'm'])
+ * @returns Formatted string (e.g. "2d 5h 30m", "4m 32s")
+ */
+export function formatDuration(totalSeconds: number, units: TimeUnit[] = ['d', 'h', 'm']): string {
+  let remaining = Math.max(0, Math.floor(totalSeconds))
+
+  const parts: { unit: TimeUnit; value: number }[] = []
+  for (const unit of units) {
+    const divisor = UNIT_DIVISORS[unit]
+    const value = Math.floor(remaining / divisor)
+    remaining %= divisor
+    parts.push({ unit, value })
+  }
+
+  // Skip leading zeros but always keep the last unit
+  const firstNonZero = parts.findIndex(p => p.value > 0)
+  const start = firstNonZero === -1 ? parts.length - 1 : firstNonZero
+
+  return parts
+    .slice(start)
+    .map(p => `${p.value}${p.unit}`)
+    .join(' ')
+}

--- a/src/lib/utils/formatPercentage.test.ts
+++ b/src/lib/utils/formatPercentage.test.ts
@@ -2,35 +2,24 @@ import { formatPercentage } from '@/lib/utils'
 import { describe, expect, it } from 'vitest'
 
 describe('formatPercentage', () => {
-  it('should format decimal numbers correctly', () => {
-    expect(formatPercentage(10.123)).toBe('10.12')
-    expect(formatPercentage(10.126)).toBe('10.13')
-    expect(formatPercentage(10.1)).toBe('10.1')
-    expect(formatPercentage(10)).toBe('10')
+  it('pads to 2 decimal places with % suffix', () => {
+    expect(formatPercentage(10.2)).toBe('10.20%')
+    expect(formatPercentage(10)).toBe('10.00%')
+    expect(formatPercentage(0)).toBe('0.00%')
   })
 
-  it('should handle edge cases', () => {
-    expect(formatPercentage(0)).toBe('0')
-    expect(formatPercentage(99.999)).toBe('100')
+  it('rounds to 2 decimal places', () => {
+    expect(formatPercentage(10.123)).toBe('10.12%')
+    expect(formatPercentage(10.126)).toBe('10.13%')
+    expect(formatPercentage(33.335)).toBe('33.34%')
   })
 
-  it('should handle very small numbers', () => {
-    expect(formatPercentage(0.001)).toBe('0')
-    expect(formatPercentage(0.009)).toBe('0.01')
-    expect(formatPercentage(0.123)).toBe('0.12')
+  it('handles values above 100', () => {
+    expect(formatPercentage(150)).toBe('150.00%')
+    expect(formatPercentage(100.5)).toBe('100.50%')
   })
 
-  it('should handle numbers with trailing zeros', () => {
-    expect(formatPercentage(10.0)).toBe('10')
-    expect(formatPercentage(10.1)).toBe('10.1')
-    expect(formatPercentage(10.2)).toBe('10.2')
-  })
-
-  it('should reject values outside of 0-100 range', () => {
-    expect(() => formatPercentage(-1)).toThrow('Percentage value must be between 0 and 100')
-    expect(() => formatPercentage(-0.1)).toThrow('Percentage value must be between 0 and 100')
-    expect(() => formatPercentage(-999999.999)).toThrow('Percentage value must be between 0 and 100')
-    expect(() => formatPercentage(101)).toThrow('Percentage value must be between 0 and 100')
-    expect(() => formatPercentage(100.1)).toThrow('Percentage value must be between 0 and 100')
+  it('handles negative values', () => {
+    expect(formatPercentage(-5.3)).toBe('-5.30%')
   })
 })

--- a/src/lib/utils/formatPercentage.ts
+++ b/src/lib/utils/formatPercentage.ts
@@ -1,14 +1,8 @@
-// Formats a percentage number to display at most 2 decimal places, but preserves all decimals if there are fewer than 2
-// Examples:
-// formatPercentage(10) => 10
-// formatPercentage(10.1) => 10.1
-// formatPercentage(10.12) => 10.12
-// formatPercentage(10.123) => 10.12
-// formatPercentage(10.126) => 10.13
-export const formatPercentage = (val: number): string => {
-  if (val < 0 || val > 100) {
-    throw new Error('Percentage value must be between 0 and 100')
-  }
-
-  return parseFloat(val.toFixed(2)).toString()
+/**
+ * Formats a numeric percentage value to a string with exactly 2 decimal places and a `%` suffix.
+ * @param value - Numeric percentage value (e.g. 10.2 for 10.2%)
+ * @returns Formatted percentage string (e.g. "10.20%")
+ */
+export function formatPercentage(value: number): string {
+  return `${value.toFixed(2)}%`
 }

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,2 +1,4 @@
+export * from './formatDate'
+export * from './formatDuration'
 export * from './formatPercentage'
 export * from './utils'

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -6,6 +6,8 @@ import { Address, formatEther, getAddress, isAddress } from 'viem'
 
 import Big from '@/lib/big'
 
+import { formatDuration } from './formatDuration'
+
 /**
  * Merges Tailwind and clsx classes in order to avoid classes conflicts.
  * This is useful when you want to override default classes and/or add conditional classes.
@@ -260,8 +262,7 @@ export const durationToLabel = (duration: Duration | undefined): string | undefi
     return undefined
   }
 
-  const converted = duration.shiftTo('days', 'hours', 'minutes')
-  return `${converted.days}d ${converted.hours}h ${converted.minutes}m`
+  return formatDuration(Math.floor(duration.as('seconds')))
 }
 
 // prettier-ignore


### PR DESCRIPTION
## Summary
- Remove `formatPercent` and all date functions from btc-vault `formatters.ts`
- Update `mappers.ts` to import `formatPercentage`, `formatDateDayFirst`, `formatDateMonthFirst` from `@/lib/utils`
- Update `BtcVaultMetrics` to use `formatDateFullMonth` and `formatDateMonthFirst` from shared utils

> Stack: #2100 → **[2/5]** → #3 → #4 → #5