### PR TITLE
refactor(DAO-2005): update btc-vault and fund module date imports [3/5]

### DIFF
--- a/src/app/btc-vault/components/DepositWindowSection.tsx
+++ b/src/app/btc-vault/components/DepositWindowSection.tsx
@@ -5,8 +5,7 @@ import { useEffect, useState } from 'react'
 import { Countdown } from '@/components/Countdown/Countdown'
 import { Header, Label } from '@/components/Typography'
 import Big from '@/lib/big'
-
-import { formatDateFullMonthPaddedDayUtc } from '../services/ui/formatters'
+import { formatDateFullMonthPadded } from '@/lib/utils'
 import type { EpochDisplay } from '../services/ui/types'
 
 const DEPOSIT_WINDOW_SUBTITLE = 'For the current cycle, deposits can be made until'
@@ -41,7 +40,7 @@ export function DepositWindowSection({ epoch }: DepositWindowSectionProps) {
           DEPOSIT WINDOW {epoch.epochId}
         </Header>
         <Label variant="body-l" className="text-[#171412] leading-[133%]">
-          {DEPOSIT_WINDOW_SUBTITLE} {formatDateFullMonthPaddedDayUtc(epoch.endTime)}.
+          {DEPOSIT_WINDOW_SUBTITLE} {formatDateFullMonthPadded(epoch.endTime, { utc: true })}.
         </Label>
       </div>
       <Countdown

--- a/src/app/btc-vault/deposit-history/components/convertDataToRowData.ts
+++ b/src/app/btc-vault/deposit-history/components/convertDataToRowData.ts
@@ -1,10 +1,9 @@
 import { formatSymbol, getFiatAmount } from '@/app/shared/formatter'
 import { RBTC } from '@/lib/constants'
-import { formatCurrencyWithLabel } from '@/lib/utils'
+import { formatCurrencyWithLabel, formatDateMonthFirst } from '@/lib/utils'
 import type { Row } from '@/shared/context'
 
 import type { DepositWindowRow } from '../../services/types'
-import { formatDateMonthFirst } from '../../services/ui/formatters'
 import type { ColumnId, DepositHistoryCellDataMap } from './DepositHistoryTable.config'
 
 /**

--- a/src/app/fund-admin/sections/whitelist/utils.ts
+++ b/src/app/fund-admin/sections/whitelist/utils.ts
@@ -1,8 +1,7 @@
 import type { Address } from 'viem'
 
 import type { BtcVaultWhitelistedUserItem } from '@/app/api/btc-vault/v1/whitelist-role-history/action'
-import { formatDateMonthFirst } from '@/app/btc-vault/services/ui/formatters'
-import { shortAddress } from '@/lib/utils'
+import { formatDateMonthFirst, shortAddress } from '@/lib/utils'
 import type { Row } from '@/shared/context/TableContext/types'
 
 import type { ColumnId, WhitelistCellDataMap, WhitelistStatus } from './config'

--- a/src/app/fund-manager/sections/transactions/utils.ts
+++ b/src/app/fund-manager/sections/transactions/utils.ts
@@ -1,13 +1,12 @@
 import type { Address } from 'viem'
 
 import type { RequestType } from '@/app/btc-vault/services/types'
-import { formatDateMonthFirst } from '@/app/btc-vault/services/ui/formatters'
 import { getTxHistoryStatusLabel } from '@/app/btc-vault/services/ui/mappers'
 import type { DisplayStatus } from '@/app/btc-vault/services/ui/types'
 import type { BtcVaultEntityHistoryRow } from '@/app/fund-manager/sections/transactions/hooks/useGetBtcVaultEntitiesHistory'
 import Big from '@/lib/big'
 import { RBTC, WeiPerEther } from '@/lib/constants'
-import { formatCurrency, formatCurrencyWithLabel, shortAddress } from '@/lib/utils'
+import { formatCurrency, formatCurrencyWithLabel, formatDateMonthFirst, shortAddress } from '@/lib/utils'
 import type { Row } from '@/shared/context'
 
 import type { ColumnId, DepositWindowCellDataMap } from './config'


### PR DESCRIPTION
## Summary
- Point `DepositWindowSection` at shared `formatDateFullMonthPadded`
- Point deposit-history `convertDataToRowData` at shared `formatDateMonthFirst`
- Update fund-manager and fund-admin to import `formatDateMonthFirst` from `@/lib/utils`

> Stack: #2100 → #2101 → **[3/5]** → #4 → #5