### PR TITLE
refactor(DAO-2005): migrate my-rewards date formatters to shared utilities [4/5]

### DIFF
--- a/src/app/my-rewards/tx-history/backer/utils/convertDataToRowData.ts
+++ b/src/app/my-rewards/tx-history/backer/utils/convertDataToRowData.ts
@@ -7,11 +7,11 @@ import { formatSymbol, getFiatAmount } from '@/app/shared/formatter'
 import { GetPricesResult } from '@/app/user/types'
 import { tokenContracts } from '@/lib/contracts'
 import { TOKENS_BY_ADDRESS } from '@/lib/tokens'
-import { formatCurrency } from '@/lib/utils'
+import { formatCurrency, formatDateRange } from '@/lib/utils'
 
 import { GroupedTransactionDetail, TransactionHistoryTable } from '../../config'
 import { TransactionHistoryItem } from '../../utils/types'
-import { calculateCycleNumber, formatDateRange } from '../../utils/utils'
+import { calculateCycleNumber } from '../../utils/utils'
 
 export const convertDataToRowData = (
   data: TransactionHistoryItem[],
@@ -49,7 +49,7 @@ export const convertDataToRowData = (
       const builderAddress = getAddress(item.builder)
       const builder = getBuilderByAddress(builderAddress)
       const cycleNumber = calculateCycleNumber(item.cycleStart, cycleDuration)
-      const dateRange = formatDateRange(item.cycleStart, cycleDuration)
+      const dateRange = formatDateRange(item.cycleStart, cycleDuration.as('seconds'))
       const transactionType = item.type
       const amounts: { address: Address; value: string; symbol: string }[] = []
       let totalUsdValue = Big(0)
@@ -107,7 +107,7 @@ export const convertDataToRowData = (
       const firstItem = builderItems[0]
       const builder = getBuilderByAddress(builderAddress)
       const cycleNumber = calculateCycleNumber(firstItem.cycleStart, cycleDuration)
-      const dateRange = formatDateRange(firstItem.cycleStart, cycleDuration)
+      const dateRange = formatDateRange(firstItem.cycleStart, cycleDuration.as('seconds'))
       const transactionType = firstItem.type
 
       const amountsByToken: Record<Address, { symbol: string; amount: bigint; price: number }> = {}
@@ -189,7 +189,7 @@ export const convertDataToRowData = (
       // Multiple transactions to different builders - create expandable grouped row
       const firstItem = items[0]
       const cycleNumber = calculateCycleNumber(firstItem.cycleStart, cycleDuration)
-      const dateRange = formatDateRange(firstItem.cycleStart, cycleDuration)
+      const dateRange = formatDateRange(firstItem.cycleStart, cycleDuration.as('seconds'))
       const transactionType = firstItem.type
       const amountsByToken: Record<Address, { symbol: string; amount: bigint }> = {}
 

--- a/src/app/my-rewards/tx-history/builder/utils/convertBuilderDataToRowData.ts
+++ b/src/app/my-rewards/tx-history/builder/utils/convertBuilderDataToRowData.ts
@@ -6,11 +6,11 @@ import { Builder } from '@/app/collective-rewards/types'
 import { formatSymbol, getFiatAmount } from '@/app/shared/formatter'
 import { GetPricesResult } from '@/app/user/types'
 import { TOKENS_BY_ADDRESS } from '@/lib/tokens'
-import { formatCurrency } from '@/lib/utils'
+import { formatCurrency, formatDateRange } from '@/lib/utils'
 
 import { TransactionHistoryTable } from '../../config'
 import { TransactionHistoryItem } from '../../utils/types'
-import { calculateCycleNumber, formatDateRange } from '../../utils/utils'
+import { calculateCycleNumber } from '../../utils/utils'
 
 /**
  * Converts builder transaction history data to row data format.
@@ -40,7 +40,7 @@ export const convertBuilderDataToRowData = (
     const firstItem = items[0]
     const builderAddress = getAddress(firstItem.builder)
     const cycleNumber = calculateCycleNumber(firstItem.cycleStart, cycleDuration)
-    const dateRange = formatDateRange(firstItem.cycleStart, cycleDuration)
+    const dateRange = formatDateRange(firstItem.cycleStart, cycleDuration.as('seconds'))
 
     // Single transaction - no grouping needed
     if (items.length === 1) {

--- a/src/app/my-rewards/tx-history/components/CsvButton.tsx
+++ b/src/app/my-rewards/tx-history/components/CsvButton.tsx
@@ -6,11 +6,11 @@ import { Builder } from '@/app/collective-rewards/types'
 import { GetPricesResult } from '@/app/user/types'
 import { CsvIcon } from '@/components/Icons'
 import { TOKENS } from '@/lib/tokens'
-import { cn } from '@/lib/utils'
+import { cn, formatDateForCsv } from '@/lib/utils'
 import { showToast } from '@/shared/notification'
 
 import { TransactionHistoryItem } from '../utils/types'
-import { calculateCycleNumber, formatDateForCsv, processTransactionAmount } from '../utils/utils'
+import { calculateCycleNumber, processTransactionAmount } from '../utils/utils'
 
 const MAX_EXPORT_ROWS = 50000
 

--- a/src/app/my-rewards/tx-history/components/desktop/DesktopDataRow.tsx
+++ b/src/app/my-rewards/tx-history/components/desktop/DesktopDataRow.tsx
@@ -2,8 +2,7 @@
 
 import { Fragment, useState } from 'react'
 
-import { formatExpandedDate } from '@/app/my-rewards/tx-history/utils/utils'
-import { cn } from '@/lib/utils'
+import { cn, formatDateExpanded } from '@/lib/utils'
 
 import { TransactionHistoryTable } from '../../config'
 import { AmountCell, CycleCell, DateCell, FromToCell, TotalAmountCell, TypeCell } from './Cells'
@@ -68,7 +67,7 @@ export const DesktopDataRow = ({ row, ...props }: DesktopDataRowProps) => {
             <CycleCell cycle={null} isDetailRow isHovered={isHovered} />
             <DateCell
               timestamp={detail.blockTimestamp}
-              formatted={formatExpandedDate(detail.blockTimestamp)}
+              formatted={formatDateExpanded(detail.blockTimestamp)}
               transactionHash={detail.transactionHash}
               isDetailRow
               isHovered={isHovered}

--- a/src/app/my-rewards/tx-history/utils/utils.ts
+++ b/src/app/my-rewards/tx-history/utils/utils.ts
@@ -10,18 +10,6 @@ import { TOKENS_BY_ADDRESS } from '@/lib/tokens'
 
 import { TransactionHistoryItem } from './types'
 
-export const formatExpandedDate = (timestamp: string): string => {
-  const date = new Date(Number(timestamp) * 1000)
-  const options: Intl.DateTimeFormatOptions = {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  }
-  return date.toLocaleString('en-US', options)
-}
-
 /**
  * Calculate cycle number from cycle start timestamp
  */
@@ -29,58 +17,6 @@ export const calculateCycleNumber = (cycleStartTimestamp: string, cycleDuration:
   const cycleStartSeconds = Number(cycleStartTimestamp)
   const cycleDurationSeconds = cycleDuration.as('seconds')
   return Math.floor((cycleStartSeconds - FIRST_CYCLE_START_SECONDS) / cycleDurationSeconds) + 1
-}
-
-/**
- * Format date range for cycle display (e.g., "Jan 1 - 15, 2024")
- */
-export const formatDateRange = (cycleStart: string, cycleDuration: Duration): string => {
-  const startDate = new Date(Number(cycleStart) * 1000)
-  const endDate = new Date((Number(cycleStart) + cycleDuration.as('seconds')) * 1000 - 1)
-
-  const formatOptions: Intl.DateTimeFormatOptions = {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  }
-
-  const startFormatted = startDate.toLocaleDateString('en-US', formatOptions)
-  const endFormatted = endDate.toLocaleDateString('en-US', formatOptions)
-
-  // Extract parts for custom formatting
-  const startParts = startFormatted.split(', ')
-  const endParts = endFormatted.split(', ')
-  const [startMonth, startDay] = startParts[0].split(' ')
-  const [endMonth, endDay] = endParts[0].split(' ')
-  const startYear = startParts[1]
-  const endYear = endParts[1]
-
-  if (startMonth === endMonth && startYear === endYear) {
-    if (startDay === endDay) {
-      return `${startMonth} ${startDay}, ${startYear}`
-    }
-    return `${startMonth} ${startDay} - ${endDay}, ${startYear}`
-  }
-
-  if (startYear === endYear) {
-    return `${startMonth} ${startDay} - ${endMonth} ${endDay}, ${endYear}`
-  }
-
-  return `${startMonth} ${startDay}, ${startYear} - ${endMonth} ${endDay}, ${endYear}`
-}
-
-/**
- * Format date for CSV export (e.g., "Jan 1, 2024, 12:00 PM")
- */
-export const formatDateForCsv = (timestamp: string): string => {
-  const date = new Date(Number(timestamp) * 1000)
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
 }
 
 /**


### PR DESCRIPTION
## Summary
- Remove `formatExpandedDate`, `formatDateRange`, and `formatDateForCsv` from tx-history utils
- Update `DesktopDataRow`, `CsvButton`, backer and builder `convertDataToRowData` to import from `@/lib/utils`
- `formatDateRange` callers now pass `cycleDuration.as('seconds')` instead of a Duration object

> Stack: #2100 → #2101 → #2102 → **[4/5]** → #5