### PR TITLE
refactor(DAO-2005): consolidate staking, vault, proposal formatters and remove moment from Countdown [5/5]

### DIFF
--- a/src/app/api/staking/v1/addresses/[address]/history/csv/route.ts
+++ b/src/app/api/staking/v1/addresses/[address]/history/csv/route.ts
@@ -12,6 +12,7 @@ import { getFiatAmount } from '@/app/shared/formatter'
 import Big from '@/lib/big'
 import { RIF, STRIF } from '@/lib/constants'
 import { logger } from '@/lib/logger'
+import { formatDateForCsv as sharedFormatDateForCsv, formatPeriodToMonthYear } from '@/lib/utils'
 
 import type { StakingHistoryByPeriodAndAction } from '../types'
 
@@ -51,24 +52,10 @@ const formatCurrencyForCsv = (amount: bigint | string, price: number): string =>
   }).format(Number(usdAmount.toString()))
 }
 
-const formatPeriod = (period: string): string => {
-  const [year, month] = period.split('-')
-  const date = new Date(Number(year), Number(month) - 1, 1)
-  return date.toLocaleString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' })
-}
+const formatPeriod = (period: string): string => formatPeriodToMonthYear(period)
 
-const formatDateForCsv = (timestamp: string | number): string => {
-  const date = new Date(Number(timestamp) * 1000)
-  return date.toLocaleString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-    timeZone: 'UTC',
-  })
-}
+const formatDateForCsv = (timestamp: string | number): string =>
+  sharedFormatDateForCsv(timestamp, { utc: true, hour12: false })
 
 const escapeCsvValue = (value: string): string => {
   if (value.includes(',') || value.includes('"') || value.includes('\n')) {

--- a/src/app/proposals/shared/utils.ts
+++ b/src/app/proposals/shared/utils.ts
@@ -11,6 +11,7 @@ import {
 import { GovernorAbi } from '@/lib/abis/Governor'
 import Big from '@/lib/big'
 import { MAX_NAME_LENGTH_FOR_PROPOSAL, TALLY_DESCRIPTION_SEPARATOR } from '@/lib/constants'
+import { formatMonthYear } from '@/lib/utils'
 import { ProposalCategory } from '@/shared/types'
 
 import { Milestones } from './types'
@@ -414,8 +415,7 @@ export function serializeBigInts(calldatasParsed: DecodedData[]): SerializedDeco
 
 export function formatTimestampToMonthYear(timestamp: string | undefined): string {
   if (!timestamp) return ' - '
-  const date = new Date(Number(timestamp) * 1000) // seconds → ms
-  return date.toLocaleString('en-US', { month: 'long', year: 'numeric' })
+  return formatMonthYear(timestamp)
 }
 
 // Utility function to safely convert amount to bigint

--- a/src/app/staking-history/components/convertDataToRowData.ts
+++ b/src/app/staking-history/components/convertDataToRowData.ts
@@ -1,15 +1,9 @@
-import { formatExpandedDate } from '@/app/my-rewards/tx-history/utils/utils'
 import { formatSymbol, getFiatAmount } from '@/app/shared/formatter'
 import { StakingHistoryTable } from '@/app/staking-history/components/StakingHistoryTable.config'
 import { StakingHistoryItem } from '@/app/staking-history/utils/types'
 import { GetPricesResult } from '@/app/user/types'
 import { RIF, STRIF } from '@/lib/constants'
-
-const formatPeriod = (period: string): string => {
-  const [year, month] = period.split('-')
-  const date = new Date(Number(year), Number(month) - 1, 1)
-  return date.toLocaleString('en-US', { month: 'long', year: 'numeric' })
-}
+import { formatDateExpanded, formatPeriodToMonthYear } from '@/lib/utils'
 
 export const convertDataToRowData = (
   data: StakingHistoryItem[],
@@ -29,13 +23,13 @@ export const convertDataToRowData = (
     rows[i] = {
       id: `${staking.period}-${i}`,
       data: {
-        period: formatPeriod(staking.period),
+        period: formatPeriodToMonthYear(staking.period),
         action: staking.action,
         amount: formatSymbol(staking.amount, STRIF),
         total_amount: usdAmount.toFixed(2).toString(),
         transactions: staking.transactions.map(tx => ({
           ...tx,
-          date: formatExpandedDate(String(tx.timestamp)),
+          date: formatDateExpanded(String(tx.timestamp)),
           amount: formatSymbol(tx.amount, STRIF),
           total_amount: getFiatAmount(BigInt(tx.amount), price).toFixed(2).toString(),
         })),

--- a/src/app/vault/history/components/convertDataToRowData.ts
+++ b/src/app/vault/history/components/convertDataToRowData.ts
@@ -1,19 +1,13 @@
-import { formatExpandedDate } from '@/app/my-rewards/tx-history/utils/utils'
 import { formatSymbol } from '@/app/shared/formatter'
 import { TOKEN_SYMBOL, VaultHistoryTable } from '@/app/vault/history/components/VaultHistoryTable.config'
 import { VaultHistoryItemAPI } from '@/app/vault/history/utils/types'
 import Big from '@/lib/big'
+import { formatDateExpanded, formatPeriodToMonthYear } from '@/lib/utils'
 
 const TOKEN_DECIMALS = 18
 
 /** Safely converts wei string to USD string using Big.js arithmetic */
 const weiToUsd = (wei: string): string => Big(wei).div(Big(10).pow(TOKEN_DECIMALS)).toFixed(2)
-
-const formatPeriod = (period: string): string => {
-  const [year, month] = period.split('-')
-  const date = new Date(Number(year), Number(month) - 1, 1)
-  return date.toLocaleString('en-US', { month: 'long', year: 'numeric' })
-}
 
 /**
  * Converts raw API data to table row data
@@ -34,13 +28,13 @@ export const convertDataToRowData = (data: VaultHistoryItemAPI[]): VaultHistoryT
     rows[i] = {
       id: `${item.period}-${item.action}-${i}`,
       data: {
-        period: formatPeriod(item.period),
+        period: formatPeriodToMonthYear(item.period),
         action: item.action,
         assets: assetsFormatted,
         total_usd: signedUsdAmount,
         transactions: item.transactions.map(tx => ({
           ...tx,
-          date: formatExpandedDate(String(tx.timestamp)),
+          date: formatDateExpanded(String(tx.timestamp)),
           assets: formatSymbol(tx.assets, TOKEN_SYMBOL),
           total_usd: weiToUsd(tx.assets),
         })),

--- a/src/components/Countdown/Countdown.tsx
+++ b/src/components/Countdown/Countdown.tsx
@@ -1,10 +1,9 @@
-import moment from 'moment'
 import { useBlockNumber } from 'wagmi'
 
 import { Paragraph } from '@/components/Typography'
 import Big from '@/lib/big'
 import { DEFAULT_NUMBER_OF_SECONDS_PER_BLOCK } from '@/lib/constants'
-import { cn } from '@/lib/utils'
+import { cn, formatDuration } from '@/lib/utils'
 
 import { CountdownProps, TimeSource } from './types'
 
@@ -42,14 +41,7 @@ const calculateRatio = (end: Big, currentTime: Big, referenceStart?: Big): numbe
 /**
  * Converts seconds to human-readable format (e.g., "2d 5h 30m")
  */
-const formatTimeRemaining = (seconds: number): string => {
-  const duration = moment.duration(seconds, 'seconds')
-  const days = duration.days()
-  const hours = duration.hours()
-  const minutes = duration.minutes()
-
-  return `${days}d ${hours}h ${minutes}m`
-}
+const formatTimeRemaining = (seconds: number): string => formatDuration(seconds)
 
 /**
  * Determines the text color class based on the ratio and color direction


### PR DESCRIPTION
## Summary
- Remove 3 duplicate `formatPeriod` functions; replace with shared `formatPeriodToMonthYear`
- Replace `formatExpandedDate` imports with shared `formatDateExpanded` in vault/history and staking-history
- Staking CSV route delegates to shared `formatDateForCsv` with UTC/24h options
- `formatTimestampToMonthYear` in proposals delegates to shared `formatMonthYear`
- `Countdown` component uses `formatDuration` instead of `moment.duration`, removing the moment.js dependency

> Stack: #2100 → #2101 → #2102 → #2103 → **[5/5]**