### PR TITLE
DAO-2230 Add "Claim Shares" action to BTC Vault page(part 1)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,12 @@ import unicorn from 'eslint-plugin-unicorn'
 import tseslint from 'typescript-eslint'
 
 const config = [
+  // Keep `eslint .` scoped to the working copy: git worktrees, build output, and IDE
+  // folders are not ignored by default and make lint appear "stuck" (duplicate src + .next).
+  {
+    ignores: ['**/.worktrees/**', '**/.next/**', '.cursor/**', '.eslintcache'],
+  },
+
   ...nextCoreWebVitals,
 
   prettierConfig,

--- a/src/app/btc-vault/constants.ts
+++ b/src/app/btc-vault/constants.ts
@@ -4,3 +4,10 @@ export const WALLET_NOT_CONNECTED_TITLE = 'Your wallet is not connected'
 /** Subtitle for the wallet-not-connected section. */
 export const WALLET_NOT_CONNECTED_SUBTITLE =
   'Connect your whitelisted Wallet to get full access to the Vault, deposit and earn yield.'
+
+/** Wait after finalize so indexers / history can catch up before invalidate + refetch. */
+export const BTC_VAULT_BACKEND_INDEX_DELAY_MS = 3000
+
+/** Tooltip copy while a vault claim tx is in flight (dashboard + request detail). */
+export const BTC_VAULT_CLAIM_IN_PROGRESS_MESSAGE =
+  'Your claim is in progress. Wait for wallet confirmation and the transaction to complete.'

--- a/src/app/btc-vault/hooks/useActiveRequests/useActiveRequests.test.ts
+++ b/src/app/btc-vault/hooks/useActiveRequests/useActiveRequests.test.ts
@@ -64,6 +64,7 @@ describe('useActiveRequests', () => {
       const { result } = renderHook(() => useActiveRequests(undefined))
 
       expect(result.current.data).toBeUndefined()
+      expect(result.current.claimableDepositRequest).toBeNull()
     })
   })
 
@@ -76,6 +77,7 @@ describe('useActiveRequests', () => {
       const { result } = renderHook(() => useActiveRequests(ADDRESS))
 
       expect(result.current.data).toEqual([])
+      expect(result.current.claimableDepositRequest).toBeNull()
     })
   })
 
@@ -100,6 +102,7 @@ describe('useActiveRequests', () => {
       expect(result.current.data?.[0].status).toBe('pending')
       expect(result.current.data?.[0].amountFormatted).toBe('1')
       expect(result.current.data?.[0].id).toBe('dep-1')
+      expect(result.current.claimableDepositRequest).toBeNull()
     })
 
     it('returns one display with status claimable and claimable info when deposit is claimable', () => {
@@ -124,6 +127,10 @@ describe('useActiveRequests', () => {
       expect(result.current.data?.[0].status).toBe('claimable')
       expect(result.current.data?.[0].claimable).toBe(true)
       expect(result.current.data?.[0].lockedSharePriceFormatted).toContain('/share')
+      expect(result.current.claimableDepositRequest).not.toBeNull()
+      expect(result.current.claimableDepositRequest?.type).toBe('deposit')
+      expect(result.current.claimableDepositRequest?.status).toBe('claimable')
+      expect(result.current.claimableDepositRequest?.id).toBe('dep-1')
     })
   })
 
@@ -172,6 +179,7 @@ describe('useActiveRequests', () => {
       expect(result.current.data?.[0].type).toBe('withdrawal')
       expect(result.current.data?.[0].status).toBe('claimable')
       expect(result.current.data?.[0].claimable).toBe(true)
+      expect(result.current.claimableDepositRequest).toBeNull()
     })
 
     it('returns approved displayStatus and computed rBTC amount when history API says approved', () => {
@@ -241,6 +249,37 @@ describe('useActiveRequests', () => {
       expect(result.current.data?.[0].status).toBe('pending')
       expect(result.current.data?.[1].type).toBe('withdrawal')
       expect(result.current.data?.[1].status).toBe('claimable')
+      expect(result.current.claimableDepositRequest).toBeNull()
+    })
+
+    it('sets claimableDepositRequest when deposit is claimable alongside a pending redeem', () => {
+      const depEpochId = 1n
+      const redEpochId = 2n
+      const assetsAtClose = 100n * ONE_ETHER
+      const supplyAtClose = 50n * ONE_SHARE_RAW
+      mockUseReadContracts
+        .mockReturnValueOnce(phase1Result([depEpochId, ONE_ETHER], [redEpochId, 3n * ONE_SHARE_RAW]))
+        .mockReturnValueOnce(
+          phase2Result([
+            { status: 'success', result: 0n },
+            { status: 'success', result: ONE_ETHER },
+            snapshotResult(assetsAtClose, supplyAtClose),
+            { status: 'success', result: 3n * ONE_SHARE_RAW },
+            { status: 'success', result: 0n },
+            snapshotResult(200n * ONE_ETHER, 100n * ONE_SHARE_RAW),
+          ]),
+        )
+
+      const { result } = renderHook(() => useActiveRequests(ADDRESS))
+
+      expect(result.current.data).toHaveLength(2)
+      expect(result.current.data?.[0].type).toBe('deposit')
+      expect(result.current.data?.[0].status).toBe('claimable')
+      expect(result.current.data?.[1].type).toBe('withdrawal')
+      expect(result.current.data?.[1].status).toBe('pending')
+      expect(result.current.claimableDepositRequest).not.toBeNull()
+      expect(result.current.claimableDepositRequest?.type).toBe('deposit')
+      expect(result.current.claimableDepositRequest?.status).toBe('claimable')
     })
   })
 
@@ -251,6 +290,7 @@ describe('useActiveRequests', () => {
       const { result } = renderHook(() => useActiveRequests(ADDRESS))
 
       expect(result.current.data).toBeUndefined()
+      expect(result.current.claimableDepositRequest).toBeNull()
     })
 
     it('returns data undefined when Phase 1 has error', () => {
@@ -263,6 +303,7 @@ describe('useActiveRequests', () => {
       const { result } = renderHook(() => useActiveRequests(ADDRESS))
 
       expect(result.current.data).toBeUndefined()
+      expect(result.current.claimableDepositRequest).toBeNull()
     })
   })
 })

--- a/src/app/btc-vault/hooks/useActiveRequests/useActiveRequests.ts
+++ b/src/app/btc-vault/hooks/useActiveRequests/useActiveRequests.ts
@@ -26,10 +26,14 @@ const HISTORY_API_PATH = '/api/btc-vault/v1/history'
  * Phase 2 (when at least one request): pending/claimable and epochSnapshot per request.
  *
  * @param address - User wallet address (controller); undefined disables reads
- * @returns { data } - ActiveRequestDisplay[] for dashboard, or undefined while loading/error
+ * @returns `data` — ActiveRequestDisplay[] for dashboard, or undefined while loading/error.
+ *   `claimableDepositRequest` — the deposit `VaultRequest` when the user can claim shares (`status === 'claimable'`);
+ *   always null for claimable withdrawals only and while data is loading or unavailable.
+ *   `refetch()` — call after on-chain success: wagmi multicall results are not keyed like TanStack invalidation alone.
  */
 export function useActiveRequests(address: string | undefined): {
   data: ActiveRequestDisplay[] | undefined
+  claimableDepositRequest: VaultRequest | null
   refetch: () => void
 } {
   const { prices } = usePricesContext()
@@ -147,10 +151,17 @@ export function useActiveRequests(address: string | undefined): {
   // SAFETY: narrow type to avoid wagmi's "excessively deep" instantiation in useMemo deps
   const phase2Data = phase2Raw as readonly { status: string; result?: unknown }[] | undefined
 
-  const data = useMemo((): ActiveRequestDisplay[] | undefined => {
-    if (!address) return undefined
-    if (isLoading1 || error1) return undefined
-    if (!phase1Data || phase1Data.length < 2) return undefined
+  const { data, claimableDepositRequest } = useMemo((): {
+    data: ActiveRequestDisplay[] | undefined
+    claimableDepositRequest: VaultRequest | null
+  } => {
+    const empty = {
+      data: undefined as ActiveRequestDisplay[] | undefined,
+      claimableDepositRequest: null as VaultRequest | null,
+    }
+    if (!address || isLoading1 || error1 || !phase1Data || phase1Data.length < 2) {
+      return empty
+    }
 
     const depositResult =
       phase1Data[0]?.status === 'success' ? (phase1Data[0].result as readonly [bigint, bigint]) : undefined
@@ -161,12 +172,15 @@ export function useActiveRequests(address: string | undefined): {
     const redEpochId = redeemResult?.[0] ?? 0n
     const redShares = redeemResult?.[1] ?? 0n
 
-    if (depAssets === 0n && redShares === 0n) return []
+    if (depAssets === 0n && redShares === 0n) {
+      return { data: [], claimableDepositRequest: null }
+    }
 
-    if (!needsPhase2) return []
-    if (isLoading2 || error2 || !phase2Data) return undefined
+    if (!needsPhase2) return { data: [], claimableDepositRequest: null }
+    if (isLoading2 || error2 || !phase2Data) return empty
 
     const requests: Array<{ req: VaultRequest; claimableInfo: ClaimableInfo | null }> = []
+    let claimableDepositRequest: VaultRequest | null = null
     const hasDeposit = depAssets > 0n
     const hasRedeem = redShares > 0n
 
@@ -199,18 +213,22 @@ export function useActiveRequests(address: string | undefined): {
           supplyAtCloseWei: supplyAtClose,
         }
       }
+      const depositReq: VaultRequest = {
+        id: `dep-${depEpochId}`,
+        type: 'deposit',
+        amount: depAssets,
+        status,
+        epochId: String(depEpochId),
+        batchRedeemId: null,
+        timestamps: { created: depHistory?.timestamp ?? 0 },
+        txHashes: depHistory?.transactionHash ? { submit: depHistory.transactionHash } : {},
+        ...(depDisplayStatus && { displayStatus: depDisplayStatus }),
+      }
+      if (status === 'claimable') {
+        claimableDepositRequest = depositReq
+      }
       requests.push({
-        req: {
-          id: `dep-${depEpochId}`,
-          type: 'deposit',
-          amount: depAssets,
-          status,
-          epochId: String(depEpochId),
-          batchRedeemId: null,
-          timestamps: { created: depHistory?.timestamp ?? 0 },
-          txHashes: depHistory?.transactionHash ? { submit: depHistory.transactionHash } : {},
-          ...(depDisplayStatus && { displayStatus: depDisplayStatus }),
-        },
+        req: depositReq,
         claimableInfo,
       })
     }
@@ -263,7 +281,10 @@ export function useActiveRequests(address: string | undefined): {
       })
     }
 
-    return requests.map(({ req, claimableInfo }) => toActiveRequestDisplay(req, claimableInfo, rbtcPrice))
+    return {
+      data: requests.map(({ req, claimableInfo }) => toActiveRequestDisplay(req, claimableInfo, rbtcPrice)),
+      claimableDepositRequest,
+    }
   }, [
     address,
     phase1Data,
@@ -288,5 +309,5 @@ export function useActiveRequests(address: string | undefined): {
     doRefetchHistory()
   }, [doRefetchPhase1, doRefetchPhase2, doRefetchHistory])
 
-  return { data, refetch }
+  return { data, claimableDepositRequest, refetch }
 }

--- a/src/app/btc-vault/hooks/useClaimRequest/useClaimRequest.test.ts
+++ b/src/app/btc-vault/hooks/useClaimRequest/useClaimRequest.test.ts
@@ -76,7 +76,7 @@ describe('useClaimRequest', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockUseAccount.mockReturnValue({ address: ADDRESS })
-    mockUseReadContract.mockReturnValue({ data: undefined, isLoading: false })
+    mockUseReadContract.mockReturnValue({ data: undefined, isLoading: false, isError: false })
   })
 
   it('does not enable contract read for non-claimable requests', () => {
@@ -143,9 +143,16 @@ describe('useClaimRequest', () => {
   })
 
   it('claim() rejects when no claimable amount', async () => {
-    mockUseReadContract.mockReturnValue({ data: undefined, isLoading: false })
+    mockUseReadContract.mockReturnValue({ data: undefined, isLoading: false, isError: false })
 
     const { result } = renderHook(() => useClaimRequest(CLAIMABLE_DEPOSIT))
     await expect(result.current.claim()).rejects.toThrow('No claimable amount available')
+  })
+
+  it('canClaim is false and isReadingError when contract read fails', () => {
+    mockUseReadContract.mockReturnValue({ data: undefined, isLoading: false, isError: true })
+    const { result } = renderHook(() => useClaimRequest(CLAIMABLE_DEPOSIT))
+    expect(result.current.isReadingError).toBe(true)
+    expect(result.current.canClaim).toBe(false)
   })
 })

--- a/src/app/btc-vault/hooks/useClaimRequest/useClaimRequest.ts
+++ b/src/app/btc-vault/hooks/useClaimRequest/useClaimRequest.ts
@@ -15,6 +15,8 @@ import { useFinalizeWithdrawal } from '../useFinalizeWithdrawal'
  * that dispatches to `useFinalizeDeposit` or `useFinalizeWithdrawal` based on request type.
  *
  * Only performs the contract read when `request.status === 'claimable'`.
+ * When `isReadingError` is true, `canClaim` is false — callers may hide the control, show an error
+ * state, or use another affordance (e.g. dashboard Claim Shares hides until the read succeeds).
  */
 export function useClaimRequest(request: VaultRequest | null) {
   const { address } = useAccount()
@@ -23,7 +25,11 @@ export function useClaimRequest(request: VaultRequest | null) {
 
   const functionName = requestType === 'deposit' ? 'claimableDepositRequest' : 'claimableRedeemRequest'
 
-  const { data: claimableAmount, isLoading: isReadingAmount } = useReadContract({
+  const {
+    data: claimableAmount,
+    isLoading: isReadingAmount,
+    isError: isReadingError,
+  } = useReadContract({
     ...rbtcVault,
     functionName,
     args: address ? [address as Address] : undefined,
@@ -58,11 +64,15 @@ export function useClaimRequest(request: VaultRequest | null) {
       claim,
       claimableAmount: (claimableAmount as bigint | undefined) ?? 0n,
       isReadingAmount,
+      isReadingError,
       isRequesting,
       isTxPending,
       canClaim:
-        isClaimable && (claimableAmount as bigint | undefined) != null && (claimableAmount as bigint) > 0n,
+        isClaimable &&
+        !isReadingError &&
+        (claimableAmount as bigint | undefined) != null &&
+        (claimableAmount as bigint) > 0n,
     }),
-    [claim, claimableAmount, isReadingAmount, isRequesting, isTxPending, isClaimable],
+    [claim, claimableAmount, isReadingAmount, isReadingError, isRequesting, isTxPending, isClaimable],
   )
 }

--- a/src/shared/notification/executeTxFlow.test.ts
+++ b/src/shared/notification/executeTxFlow.test.ts
@@ -111,6 +111,26 @@ describe('executeTxFlow', () => {
       })
       expect(result).toBe(mockTxHash)
     })
+
+    it('should await async onSuccess before the flow promise resolves', async () => {
+      mockOnRequestTx.mockResolvedValue(mockTxHash)
+      mockWaitForTransactionReceipt.mockResolvedValue({} as any)
+      const action = 'staking' as const
+      const order: string[] = []
+
+      await executeTxFlow({
+        onRequestTx: mockOnRequestTx,
+        action,
+        onSuccess: async () => {
+          order.push('onSuccess-start')
+          await Promise.resolve()
+          order.push('onSuccess-end')
+        },
+      })
+      order.push('flow-resolved')
+
+      expect(order).toEqual(['onSuccess-start', 'onSuccess-end', 'flow-resolved'])
+    })
   })
 
   describe('Error Paths', () => {

--- a/src/shared/notification/executeTxFlow.ts
+++ b/src/shared/notification/executeTxFlow.ts
@@ -13,7 +13,7 @@ interface Props {
   action: keyof typeof TX_MESSAGES
   onRequestTx: () => Promise<Hash>
   onPending?: (txHash: Hash) => void
-  onSuccess?: (txHash: Hash) => void
+  onSuccess?: (txHash: Hash) => void | Promise<void>
   onError?: (txHash: Hash | undefined, err: Error) => void
   onComplete?: (txHash: Hash | undefined) => void
 }
@@ -109,7 +109,7 @@ export const executeTxFlow = async ({
     })
 
     updateToast(txHash, createToastConfig(success, txHash))
-    onSuccess?.(txHash)
+    await Promise.resolve(onSuccess?.(txHash))
   } catch (err) {
     if (!isUserRejectedTxError(err)) {
       onError?.(txHash, err as Error)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -59,7 +59,7 @@ const forkProject = {
       '**/providers/uniswap.test.ts',
       '**/api/swap/**/*.test.ts',
     ],
-    exclude: ['**/node_modules/**'],
+    exclude: ['**/node_modules/**', '**/.worktree*/**'],
     env: forkPublicEnv,
   },
 }
@@ -100,7 +100,7 @@ export default defineConfig({
           environment: 'node',
           setupFiles: path.join(__dirname, 'vitest.setup.ts'),
           include: ['**/api/**/*.test.ts', '**/api/**/*.test.tsx'],
-          exclude: ['**/node_modules/**', '**/api/swap/**/*.test.ts'],
+          exclude: ['**/node_modules/**', '**/api/swap/**/*.test.ts', '**/.worktree*/**'],
           env: unitTestnetEnv,
         },
       },


### PR DESCRIPTION
## Why this PR exists

BTC Vault async deposits eventually reach a **claimable** state: the user should be able to **receive vault shares** on-chain once the deposit batch is settled. The visible buttons and page wiring are in **Part 2**; this PR is the **plumbing** so UI does not duplicate contract reads, finalize logic, or transaction toasts.

## What to focus on

- **`useActiveRequests`** exposes the **claimable deposit** `VaultRequest` when the protocol marks it claimable, so screens do not re-derive it from the full active-request list.
- **`useClaimRequest`** bundles **claimable amount read** and **finalize deposit vs withdrawal** dispatch, with safe behavior when the read fails (UI can hide or show a non-claiming state).
- **`executeTxFlow`** supports a **post-completion** step so successful claims can **wait for indexers / refetch** in line with other vault flows.
- **Shared vault constants** hold tooltip copy and a short **post-finalize delay** to avoid racing backend history.
- **ESLint** ignores `**/.worktrees/**` so local git worktrees do not duplicate `src` and make `eslint .` look stuck.
- **Vitest** `unit-node` (and fork) now exclude `**/.worktree*/**` so `git push` pre-push does not execute duplicate API tests from nested worktrees.

**Merge order:** merge this PR before **Part 2** (or rebase Part 2 onto `main` after this lands).
