### PR TITLE
DAO-2230 Add "Claim Shares" action to BTC Vault page(part 2)

### DIFF
--- a/src/app/btc-vault/BtcVaultPage.test.tsx
+++ b/src/app/btc-vault/BtcVaultPage.test.tsx
@@ -78,7 +78,7 @@ vi.mock('./ActiveRequestSection', () => ({
 }))
 
 vi.mock('./hooks/useActiveRequests', () => ({
-  useActiveRequests: () => ({ data: undefined, refetch: vi.fn() }),
+  useActiveRequests: () => ({ data: undefined, claimableDepositRequest: null, refetch: vi.fn() }),
 }))
 
 vi.mock('./components/capital-allocation/CapitalAllocationSection', () => ({

--- a/src/app/btc-vault/BtcVaultPage.tsx
+++ b/src/app/btc-vault/BtcVaultPage.tsx
@@ -17,7 +17,12 @@ const NAME = 'BTC Vault'
 
 export const BtcVaultPage = () => {
   const { address } = useAccount()
-  const { data: activeRequests, refetch: refetchActiveRequests } = useActiveRequests(address)
+  const {
+    data: activeRequests,
+    refetch: refetchActiveRequests,
+    claimableDepositRequest,
+  } = useActiveRequests(address)
+
   return (
     <div
       data-testid={NAME} // TODO: DAO-2029 Standardize data-test-ids to using kebab-case only
@@ -33,8 +38,11 @@ export const BtcVaultPage = () => {
         </SectionContainer>
       </section>
 
-      {/* Dashboard Zone - F4 */}
-      <BtcVaultDashboard onRequestSubmitted={refetchActiveRequests} />
+      <BtcVaultDashboard
+        onRequestSubmitted={refetchActiveRequests}
+        claimableDepositRequest={claimableDepositRequest}
+        onAfterClaimRefetch={refetchActiveRequests}
+      />
 
       {/* Capital Allocation Transparency - DAO-2017 */}
       <CapitalAllocationSection />

--- a/src/app/btc-vault/components/BtcVaultClaimSharesButton.test.tsx
+++ b/src/app/btc-vault/components/BtcVaultClaimSharesButton.test.tsx
@@ -1,0 +1,228 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { TooltipProvider } from '@radix-ui/react-tooltip'
+import { type ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BTC_VAULT_BACKEND_INDEX_DELAY_MS } from '../constants'
+import { BtcVaultClaimSharesButton } from './BtcVaultClaimSharesButton'
+
+const mockUseAccount = vi.fn()
+const mockExecuteTxFlow = vi.fn()
+const mockClaim = vi.fn()
+const mockUseClaimRequest = vi.fn()
+const mockInvalidateAfterAction = vi.fn()
+const mockOnAfterClaimRefetch = vi.fn()
+
+function TestWrapper({ children }: { children: ReactNode }) {
+  return <TooltipProvider>{children}</TooltipProvider>
+}
+
+vi.mock('wagmi', () => ({
+  useAccount: () => mockUseAccount(),
+}))
+
+vi.mock('../hooks/useBtcVaultInvalidation', () => ({
+  useBtcVaultInvalidation: () => ({
+    invalidateAfterSubmit: vi.fn(),
+    invalidateAfterAction: mockInvalidateAfterAction,
+  }),
+}))
+
+vi.mock('../hooks/useClaimRequest', () => ({
+  useClaimRequest: (...args: unknown[]) => mockUseClaimRequest(...args),
+}))
+
+vi.mock('@/shared/notification', () => ({
+  executeTxFlow: (args: unknown) => mockExecuteTxFlow(args),
+}))
+
+const ONE_BTC = 10n ** 18n
+
+const MOCK_CLAIMABLE_DEPOSIT = {
+  id: 'dep-1',
+  type: 'deposit' as const,
+  amount: ONE_BTC,
+  status: 'claimable' as const,
+  epochId: '1',
+  batchRedeemId: null,
+  timestamps: { created: 1700000000 },
+  txHashes: { submit: '0x' + 'a'.repeat(64) },
+}
+
+describe('BtcVaultClaimSharesButton', () => {
+  beforeEach(() => {
+    mockUseAccount.mockReturnValue({ address: '0x1234567890123456789012345678901234567890' })
+    mockUseClaimRequest.mockReturnValue({
+      claim: mockClaim,
+      canClaim: true,
+      isRequesting: false,
+      isTxPending: false,
+      isReadingAmount: false,
+      isReadingError: false,
+    })
+    mockExecuteTxFlow.mockResolvedValue(undefined)
+    mockClaim.mockResolvedValue('0xclaimhash')
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('renders nothing when wallet has no address', () => {
+    mockUseAccount.mockReturnValue({ address: undefined })
+    const { container } = render(<BtcVaultClaimSharesButton vaultRequest={MOCK_CLAIMABLE_DEPOSIT} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when vaultRequest is null', () => {
+    const { container } = render(<BtcVaultClaimSharesButton vaultRequest={null} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when on-chain claimable amount is zero', () => {
+    mockUseClaimRequest.mockReturnValue({
+      claim: mockClaim,
+      canClaim: false,
+      isRequesting: false,
+      isTxPending: false,
+      isReadingAmount: false,
+      isReadingError: false,
+    })
+    const { container } = render(<BtcVaultClaimSharesButton vaultRequest={MOCK_CLAIMABLE_DEPOSIT} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing while reading claimable amount', () => {
+    mockUseClaimRequest.mockReturnValue({
+      claim: mockClaim,
+      canClaim: false,
+      isRequesting: false,
+      isTxPending: false,
+      isReadingAmount: true,
+      isReadingError: false,
+    })
+    const { container } = render(<BtcVaultClaimSharesButton vaultRequest={MOCK_CLAIMABLE_DEPOSIT} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when claimable read errors', () => {
+    mockUseClaimRequest.mockReturnValue({
+      claim: mockClaim,
+      canClaim: false,
+      isRequesting: false,
+      isTxPending: false,
+      isReadingAmount: false,
+      isReadingError: true,
+    })
+    const { container } = render(<BtcVaultClaimSharesButton vaultRequest={MOCK_CLAIMABLE_DEPOSIT} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows non-disabled Claiming… with tooltip path when claim tx in progress (isRequesting)', () => {
+    mockUseClaimRequest.mockReturnValue({
+      claim: mockClaim,
+      canClaim: true,
+      isRequesting: true,
+      isTxPending: false,
+      isReadingAmount: false,
+      isReadingError: false,
+    })
+    render(<BtcVaultClaimSharesButton vaultRequest={MOCK_CLAIMABLE_DEPOSIT} />, {
+      wrapper: TestWrapper,
+    })
+    const btn = screen.getByTestId('btc-vault-claim-shares-button')
+    expect(btn).toHaveTextContent('Claiming...')
+    expect(btn).not.toBeDisabled()
+    fireEvent.click(btn)
+    expect(mockExecuteTxFlow).not.toHaveBeenCalled()
+  })
+
+  it('shows non-disabled Claiming… when only isTxPending', () => {
+    mockUseClaimRequest.mockReturnValue({
+      claim: mockClaim,
+      canClaim: true,
+      isRequesting: false,
+      isTxPending: true,
+      isReadingAmount: false,
+      isReadingError: false,
+    })
+    render(<BtcVaultClaimSharesButton vaultRequest={MOCK_CLAIMABLE_DEPOSIT} />, {
+      wrapper: TestWrapper,
+    })
+    const btn = screen.getByTestId('btc-vault-claim-shares-button')
+    expect(btn).toHaveTextContent('Claiming...')
+    expect(btn).not.toBeDisabled()
+  })
+
+  it('does not invoke executeTxFlow twice on rapid double-click', async () => {
+    let release!: () => void
+    const gate = new Promise<void>(resolve => {
+      release = resolve
+    })
+    mockExecuteTxFlow.mockImplementation(() => gate)
+    render(
+      <BtcVaultClaimSharesButton
+        vaultRequest={MOCK_CLAIMABLE_DEPOSIT}
+        onAfterClaimRefetch={mockOnAfterClaimRefetch}
+      />,
+    )
+    const btn = screen.getByTestId('btc-vault-claim-shares-button')
+    fireEvent.click(btn)
+    fireEvent.click(btn)
+    expect(mockExecuteTxFlow).toHaveBeenCalledTimes(1)
+    release()
+    await waitFor(() => expect(mockExecuteTxFlow).toHaveBeenCalledTimes(1))
+  })
+
+  it('shows Claim Shares and calls executeTxFlow with btcVaultClaim on click', async () => {
+    render(
+      <BtcVaultClaimSharesButton
+        vaultRequest={MOCK_CLAIMABLE_DEPOSIT}
+        onAfterClaimRefetch={mockOnAfterClaimRefetch}
+      />,
+    )
+
+    expect(screen.getByTestId('btc-vault-claim-shares-button')).toHaveTextContent('Claim Shares')
+    fireEvent.click(screen.getByTestId('btc-vault-claim-shares-button'))
+
+    await waitFor(() => {
+      expect(mockExecuteTxFlow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'btcVaultClaim',
+        }),
+      )
+    })
+    const call = mockExecuteTxFlow.mock.calls[0][0] as {
+      onRequestTx: () => Promise<unknown>
+      onSuccess: () => Promise<void>
+    }
+    await call.onRequestTx()
+    expect(mockClaim).toHaveBeenCalled()
+  })
+
+  it('onSuccess invalidates cache and refetches', async () => {
+    vi.useFakeTimers()
+    mockExecuteTxFlow.mockImplementation(
+      async ({ onSuccess }: { onSuccess?: () => Promise<void> }) => {
+        await onSuccess?.()
+      },
+    )
+    render(
+      <BtcVaultClaimSharesButton
+        vaultRequest={MOCK_CLAIMABLE_DEPOSIT}
+        onAfterClaimRefetch={mockOnAfterClaimRefetch}
+      />,
+    )
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('btc-vault-claim-shares-button'))
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(BTC_VAULT_BACKEND_INDEX_DELAY_MS)
+    })
+
+    expect(mockInvalidateAfterAction).toHaveBeenCalledWith('dep-1')
+    expect(mockOnAfterClaimRefetch).toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+})

--- a/src/app/btc-vault/components/BtcVaultClaimSharesButton.tsx
+++ b/src/app/btc-vault/components/BtcVaultClaimSharesButton.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useRef } from 'react'
+import { useAccount } from 'wagmi'
+
+import { ConditionalTooltip } from '@/app/components/Tooltip/ConditionalTooltip'
+import { Button } from '@/components/Button'
+import { executeTxFlow } from '@/shared/notification'
+
+import { BTC_VAULT_BACKEND_INDEX_DELAY_MS, BTC_VAULT_CLAIM_IN_PROGRESS_MESSAGE } from '../constants'
+import { useBtcVaultInvalidation } from '../hooks/useBtcVaultInvalidation'
+import { useClaimRequest } from '../hooks/useClaimRequest'
+import type { VaultRequest } from '../services/types'
+
+const buttonClassName = 'h-auto min-h-11 w-full shrink-0 py-0.5 px-4 md:min-h-0'
+
+export interface BtcVaultClaimSharesButtonProps {
+  vaultRequest: VaultRequest | null
+  onAfterClaimRefetch?: () => void
+}
+
+export function BtcVaultClaimSharesButton({
+  vaultRequest,
+  onAfterClaimRefetch,
+}: BtcVaultClaimSharesButtonProps) {
+  const { address } = useAccount()
+  const claimFlowLock = useRef(false)
+  const { invalidateAfterAction } = useBtcVaultInvalidation()
+  const { claim, canClaim, isRequesting, isTxPending, isReadingAmount, isReadingError } =
+    useClaimRequest(vaultRequest)
+
+  if (!address) return null
+  if (!vaultRequest || vaultRequest.type !== 'deposit' || vaultRequest.status !== 'claimable') {
+    return null
+  }
+
+  if (isReadingAmount || isReadingError) {
+    return null
+  }
+
+  const isClaimPending = isRequesting || isTxPending
+
+  if (!canClaim && !isClaimPending) {
+    return null
+  }
+
+  const handleClaim = async () => {
+    if (claimFlowLock.current) return
+    claimFlowLock.current = true
+    try {
+      await executeTxFlow({
+        action: 'btcVaultClaim',
+        onRequestTx: () => claim(),
+        onSuccess: async () => {
+          await new Promise(resolve => setTimeout(resolve, BTC_VAULT_BACKEND_INDEX_DELAY_MS))
+          invalidateAfterAction(vaultRequest.id)
+          onAfterClaimRefetch?.()
+        },
+      })
+    } finally {
+      claimFlowLock.current = false
+    }
+  }
+
+  if (isClaimPending) {
+    return (
+      <ConditionalTooltip
+        supportMobileTap
+        className="w-full p-0"
+        conditionPairs={[
+          {
+            condition: () => true,
+            lazyContent: () => BTC_VAULT_CLAIM_IN_PROGRESS_MESSAGE,
+          },
+        ]}
+      >
+        <Button
+          variant="primary"
+          className={buttonClassName}
+          textClassName="text-sm"
+          data-testid="btc-vault-claim-shares-button"
+          disabled={false}
+          onClick={() => {}}
+        >
+          Claiming...
+        </Button>
+      </ConditionalTooltip>
+    )
+  }
+
+  return (
+    <Button
+      variant="primary"
+      className={buttonClassName}
+      textClassName="text-sm"
+      data-testid="btc-vault-claim-shares-button"
+      disabled={false}
+      onClick={handleClaim}
+    >
+      Claim Shares
+    </Button>
+  )
+}

--- a/src/app/btc-vault/components/BtcVaultDashboard.test.tsx
+++ b/src/app/btc-vault/components/BtcVaultDashboard.test.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from 'react'
 
 import { VAULT_SHARE_MULTIPLIER, WeiPerEther } from '@/lib/constants'
 
+import type { VaultRequest } from '../services/types'
 import type { UserPositionDisplay } from '../services/ui/types'
 import { BtcVaultDashboard } from './BtcVaultDashboard'
 
@@ -27,6 +28,23 @@ vi.mock('../hooks/useUserPosition/useUserPosition', () => ({
 
 vi.mock('./BtcVaultActions', () => ({
   BtcVaultActions: () => <div data-testid="btc-vault-actions" />,
+}))
+
+vi.mock('./BtcVaultClaimSharesButton', () => ({
+  BtcVaultClaimSharesButton: ({
+    vaultRequest,
+    onAfterClaimRefetch,
+  }: {
+    vaultRequest: VaultRequest | null
+    onAfterClaimRefetch?: () => void
+  }) => (
+    <button
+      type="button"
+      data-testid="btc-vault-claim-shares-probe"
+      data-request-id={vaultRequest?.id ?? ''}
+      data-has-refetch={onAfterClaimRefetch ? 'yes' : 'no'}
+    />
+  ),
 }))
 
 const MOCK_DISPLAY: UserPositionDisplay = {
@@ -219,5 +237,33 @@ describe('BtcVaultDashboard', () => {
 
     const dashes = screen.getAllByText('—')
     expect(dashes.length).toBe(7)
+  })
+
+  it('forwards claimableDepositRequest and onAfterClaimRefetch to Claim Shares', () => {
+    const onRefetch = vi.fn()
+    const claimableReq: VaultRequest = {
+      id: 'dep-dash-probe',
+      type: 'deposit',
+      status: 'claimable',
+      amount: 1n,
+      epochId: '1',
+      batchRedeemId: null,
+      timestamps: { created: 0 },
+      txHashes: {},
+    }
+    render(
+      <BtcVaultDashboard claimableDepositRequest={claimableReq} onAfterClaimRefetch={onRefetch} />,
+      { wrapper: Wrapper },
+    )
+    const probe = screen.getByTestId('btc-vault-claim-shares-probe')
+    expect(probe).toHaveAttribute('data-request-id', 'dep-dash-probe')
+    expect(probe).toHaveAttribute('data-has-refetch', 'yes')
+  })
+
+  it('passes null claimableDepositRequest to Claim Shares when omitted', () => {
+    render(<BtcVaultDashboard />, { wrapper: Wrapper })
+    const probe = screen.getByTestId('btc-vault-claim-shares-probe')
+    expect(probe).toHaveAttribute('data-request-id', '')
+    expect(probe).toHaveAttribute('data-has-refetch', 'no')
   })
 })

--- a/src/app/btc-vault/components/BtcVaultDashboard.tsx
+++ b/src/app/btc-vault/components/BtcVaultDashboard.tsx
@@ -12,7 +12,11 @@ import { RBTC } from '@/lib/constants'
 import { btcVaultRequestHistory } from '@/shared/constants/routes'
 
 import { useUserPosition } from '../hooks/useUserPosition/useUserPosition'
+import type { VaultRequest } from '../services/types'
 import { BtcVaultActions } from './BtcVaultActions'
+import { BtcVaultClaimSharesButton } from './BtcVaultClaimSharesButton'
+
+const METRIC_COLUMN = 'w-full md:w-[214px] md:min-w-[180px]'
 
 const LoadingValue = () => <Span className="animate-pulse text-text-60">0</Span>
 
@@ -29,9 +33,15 @@ function metricAmount(isLoading: boolean, isError: boolean, value: string | unde
  */
 interface BtcVaultDashboardProps {
   onRequestSubmitted?: () => void
+  claimableDepositRequest?: VaultRequest | null
+  onAfterClaimRefetch?: () => void
 }
 
-export const BtcVaultDashboard = ({ onRequestSubmitted }: BtcVaultDashboardProps) => {
+export const BtcVaultDashboard = ({
+  onRequestSubmitted,
+  claimableDepositRequest = null,
+  onAfterClaimRefetch,
+}: BtcVaultDashboardProps) => {
   const { address, isConnected } = useAccount()
   const { data, isLoading, isError } = useUserPosition(address)
 
@@ -43,7 +53,7 @@ export const BtcVaultDashboard = ({ onRequestSubmitted }: BtcVaultDashboardProps
         {/* Row 1: Wallet, Vault shares, Share of vault */}
         <div className="flex flex-col gap-4 md:flex-row md:flex-wrap md:gap-x-6 md:gap-y-6 w-full">
           <BalanceInfo
-            className="w-full md:w-[214px] md:min-w-[180px]"
+            className={METRIC_COLUMN}
             title="Wallet"
             amount={metricAmount(isLoading, isError, data?.rbtcBalanceFormatted)}
             symbol={RBTC}
@@ -51,16 +61,22 @@ export const BtcVaultDashboard = ({ onRequestSubmitted }: BtcVaultDashboardProps
             tooltipContent="Your rBTC balance available in your connected wallet"
             data-testid="metric-wallet"
           />
+          <div className={`flex flex-col gap-4 ${METRIC_COLUMN}`}>
+            <BalanceInfo
+              className="w-full"
+              title="Vault shares"
+              amount={metricAmount(isLoading, isError, data?.vaultTokensFormatted)}
+              fiatAmount={isLoading || isError ? undefined : data?.fiatVaultShares}
+              tooltipContent="Your share tokens representing deposited rBTC in the vault"
+              data-testid="metric-vault-shares"
+            />
+            <BtcVaultClaimSharesButton
+              vaultRequest={claimableDepositRequest}
+              onAfterClaimRefetch={onAfterClaimRefetch}
+            />
+          </div>
           <BalanceInfo
-            className="w-full md:w-[214px] md:min-w-[180px]"
-            title="Vault shares"
-            amount={metricAmount(isLoading, isError, data?.vaultTokensFormatted)}
-            fiatAmount={isLoading || isError ? undefined : data?.fiatVaultShares}
-            tooltipContent="Your share tokens representing deposited rBTC in the vault"
-            data-testid="metric-vault-shares"
-          />
-          <BalanceInfo
-            className="w-full md:w-[214px] md:min-w-[180px]"
+            className={METRIC_COLUMN}
             title="Your share of vault"
             amount={metricAmount(isLoading, isError, data?.percentOfVaultFormatted)}
             tooltipContent="Your ownership percentage of the total vault assets"
@@ -70,7 +86,7 @@ export const BtcVaultDashboard = ({ onRequestSubmitted }: BtcVaultDashboardProps
 
         {/* Row 2: Principal, Current earnings, Total balance, Yield % */}
         <div className="flex flex-col gap-4 md:flex-row md:flex-wrap md:gap-x-6 md:gap-y-6 w-full">
-          <div className="w-full md:w-[214px] md:min-w-[180px]">
+          <div className={METRIC_COLUMN}>
             <BalanceInfo
               title="Principal deposited"
               amount={metricAmount(isLoading, isError, data?.totalDepositedPrincipalFormatted)}
@@ -88,7 +104,7 @@ export const BtcVaultDashboard = ({ onRequestSubmitted }: BtcVaultDashboardProps
             </Link>
           </div>
           <BalanceInfo
-            className="w-full md:w-[214px] md:min-w-[180px]"
+            className={METRIC_COLUMN}
             title="Current earnings"
             amount={metricAmount(isLoading, isError, data?.currentEarningsFormatted)}
             symbol={RBTC}
@@ -97,7 +113,7 @@ export const BtcVaultDashboard = ({ onRequestSubmitted }: BtcVaultDashboardProps
             data-testid="metric-earnings"
           />
           <BalanceInfo
-            className="w-full md:w-[214px] md:min-w-[180px]"
+            className={METRIC_COLUMN}
             title="Total balance"
             amount={metricAmount(isLoading, isError, data?.totalBalanceFormatted)}
             symbol={RBTC}
@@ -106,7 +122,7 @@ export const BtcVaultDashboard = ({ onRequestSubmitted }: BtcVaultDashboardProps
             data-testid="metric-total-balance"
           />
           <BalanceInfo
-            className="w-full md:w-[214px] md:min-w-[180px]"
+            className={METRIC_COLUMN}
             title="Yield % to date"
             amount={metricAmount(isLoading, isError, data?.yieldPercentToDateFormatted)}
             tooltipContent="Cumulative yield earned on your deposited principal"

--- a/src/app/btc-vault/components/BtcVaultMetrics.tsx
+++ b/src/app/btc-vault/components/BtcVaultMetrics.tsx
@@ -23,7 +23,7 @@ const TVL_TOOLTIP = 'Total Value Locked — aggregate rBTC held by the vault'
 const DEPOSIT_WINDOW_TOOLTIP = 'Current deposit window closes at this date'
 const PRICE_PER_SHARE_TOOLTIP = 'Price of one vault share in rBTC terms (NAV per share)'
 
-export const BtcVaultMetrics = () => {
+export function BtcVaultMetrics() {
   const { data: metrics, isLoading: metricsLoading, error: metricsError } = useVaultMetrics()
   const { data: epoch } = useEpochState()
   const { prices } = usePricesContext()

--- a/src/app/btc-vault/page.test.tsx
+++ b/src/app/btc-vault/page.test.tsx
@@ -32,7 +32,7 @@ vi.mock('./hooks/useActionEligibility', () => ({
 }))
 
 vi.mock('./hooks/useActiveRequests', () => ({
-  useActiveRequests: () => ({ data: undefined }),
+  useActiveRequests: () => ({ data: undefined, claimableDepositRequest: null, refetch: vi.fn() }),
 }))
 
 vi.mock('./hooks/useEpochState', () => ({

--- a/src/app/btc-vault/request-history/[id]/TransactionDetailPage.test.tsx
+++ b/src/app/btc-vault/request-history/[id]/TransactionDetailPage.test.tsx
@@ -1,7 +1,13 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { TooltipProvider } from '@radix-ui/react-tooltip'
+import { type ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { TransactionDetailPage } from './TransactionDetailPage'
+
+function renderWithTooltip(ui: ReactNode) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>)
+}
 
 const mockUseAccount = vi.fn()
 const mockUseRequestById = vi.fn()
@@ -147,6 +153,7 @@ describe('TransactionDetailPage', () => {
       canClaim: false,
       claimableAmount: 0n,
       isReadingAmount: false,
+      isReadingError: false,
       isRequesting: false,
       isTxPending: false,
     })
@@ -158,18 +165,18 @@ describe('TransactionDetailPage', () => {
   })
 
   it('renders "WITHDRAWAL REQUEST" title for a withdrawal', () => {
-    render(<TransactionDetailPage id="req-withdrawal-pending" />)
+    renderWithTooltip(<TransactionDetailPage id="req-withdrawal-pending" />)
     expect(screen.getByText('WITHDRAWAL REQUEST')).toBeInTheDocument()
   })
 
   it('renders "DEPOSIT REQUEST" title for a deposit', () => {
     mockUseRequestById.mockReturnValue({ data: { request: MOCK_DEPOSIT_DONE, claimableInfo: null }, isLoading: false })
-    render(<TransactionDetailPage id="req-deposit-done" />)
+    renderWithTooltip(<TransactionDetailPage id="req-deposit-done" />)
     expect(screen.getByText('DEPOSIT REQUEST')).toBeInTheDocument()
   })
 
   it('renders stepper, detail grid, and cancel button for pending request', () => {
-    render(<TransactionDetailPage id="req-withdrawal-pending" />)
+    renderWithTooltip(<TransactionDetailPage id="req-withdrawal-pending" />)
     expect(screen.getByTestId('request-status-stepper')).toBeInTheDocument()
     expect(screen.getByTestId('request-detail-grid')).toBeInTheDocument()
     expect(screen.getByTestId('cancel-request-button')).toBeInTheDocument()
@@ -177,14 +184,14 @@ describe('TransactionDetailPage', () => {
 
   it('does not render cancel button for non-pending request', () => {
     mockUseRequestById.mockReturnValue({ data: { request: MOCK_DEPOSIT_DONE, claimableInfo: null }, isLoading: false })
-    render(<TransactionDetailPage id="req-deposit-done" />)
+    renderWithTooltip(<TransactionDetailPage id="req-deposit-done" />)
     expect(screen.getByTestId('request-detail-grid')).toBeInTheDocument()
     expect(screen.queryByTestId('cancel-request-button')).not.toBeInTheDocument()
   })
 
   it('renders not-connected oops when wallet is disconnected', () => {
     mockUseAccount.mockReturnValue({ address: undefined, isConnected: false })
-    render(<TransactionDetailPage id="req-withdrawal-pending" />)
+    renderWithTooltip(<TransactionDetailPage id="req-withdrawal-pending" />)
     expect(screen.getByTestId('transaction-detail-oops-not-connected')).toBeInTheDocument()
     expect(screen.getByText('Connect your wallet to view request details')).toBeInTheDocument()
     expect(screen.getByTestId('connect-wallet-button')).toBeInTheDocument()
@@ -192,7 +199,7 @@ describe('TransactionDetailPage', () => {
 
   it('renders not-found oops when request ID does not match', () => {
     mockUseRequestById.mockReturnValue({ data: null, isLoading: false })
-    render(<TransactionDetailPage id="unknown-id" />)
+    renderWithTooltip(<TransactionDetailPage id="unknown-id" />)
     expect(screen.getByTestId('transaction-detail-oops-not-found')).toBeInTheDocument()
     expect(screen.getByText('Request not found')).toBeInTheDocument()
     expect(screen.getByTestId('back-to-history-link')).toBeInTheDocument()
@@ -200,13 +207,13 @@ describe('TransactionDetailPage', () => {
 
   it('renders loading state while data is being fetched', () => {
     mockUseRequestById.mockReturnValue({ data: undefined, isLoading: true })
-    render(<TransactionDetailPage id="req-withdrawal-pending" />)
+    renderWithTooltip(<TransactionDetailPage id="req-withdrawal-pending" />)
     expect(screen.getByTestId('loading-spinner')).toBeInTheDocument()
     expect(screen.queryByTestId('transaction-detail-page')).not.toBeInTheDocument()
   })
 
   it('opens cancel confirmation modal when cancel button is clicked', () => {
-    render(<TransactionDetailPage id="req-withdrawal-pending" />)
+    renderWithTooltip(<TransactionDetailPage id="req-withdrawal-pending" />)
     expect(screen.queryByTestId('CancelRequestModal')).not.toBeInTheDocument()
     fireEvent.click(screen.getByTestId('cancel-request-button'))
     expect(screen.getByTestId('CancelRequestModal')).toBeInTheDocument()
@@ -215,7 +222,7 @@ describe('TransactionDetailPage', () => {
 
   it('does not render cancel button for approved withdrawal', () => {
     mockUseRequestById.mockReturnValue({ data: { request: MOCK_WITHDRAWAL_APPROVED, claimableInfo: null }, isLoading: false })
-    render(<TransactionDetailPage id="req-withdrawal-approved" />)
+    renderWithTooltip(<TransactionDetailPage id="req-withdrawal-approved" />)
     expect(screen.getByTestId('request-detail-grid')).toBeInTheDocument()
     expect(screen.queryByTestId('cancel-request-button')).not.toBeInTheDocument()
   })
@@ -227,10 +234,11 @@ describe('TransactionDetailPage', () => {
       canClaim: true,
       claimableAmount: ONE_BTC / 2n,
       isReadingAmount: false,
+      isReadingError: false,
       isRequesting: false,
       isTxPending: false,
     })
-    render(<TransactionDetailPage id="req-withdrawal-claimable" />)
+    renderWithTooltip(<TransactionDetailPage id="req-withdrawal-claimable" />)
     expect(screen.getByTestId('claim-button')).toBeInTheDocument()
     expect(screen.getByTestId('claim-button')).toHaveTextContent('Claim rBTC')
     expect(screen.queryByTestId('cancel-request-button')).not.toBeInTheDocument()
@@ -243,10 +251,11 @@ describe('TransactionDetailPage', () => {
       canClaim: true,
       claimableAmount: ONE_BTC,
       isReadingAmount: false,
+      isReadingError: false,
       isRequesting: false,
       isTxPending: false,
     })
-    render(<TransactionDetailPage id="req-deposit-claimable" />)
+    renderWithTooltip(<TransactionDetailPage id="req-deposit-claimable" />)
     expect(screen.getByTestId('claim-button')).toBeInTheDocument()
     expect(screen.getByTestId('claim-button')).toHaveTextContent('Claim Shares')
     expect(screen.queryByTestId('cancel-request-button')).not.toBeInTheDocument()
@@ -261,10 +270,11 @@ describe('TransactionDetailPage', () => {
       canClaim: true,
       claimableAmount: ONE_BTC / 2n,
       isReadingAmount: false,
+      isReadingError: false,
       isRequesting: false,
       isTxPending: false,
     })
-    render(<TransactionDetailPage id="req-withdrawal-claimable" />)
+    renderWithTooltip(<TransactionDetailPage id="req-withdrawal-claimable" />)
     fireEvent.click(screen.getByTestId('claim-button'))
     await waitFor(() => {
       expect(mockExecuteTxFlow).toHaveBeenCalledWith(
@@ -277,13 +287,56 @@ describe('TransactionDetailPage', () => {
     })
   })
 
+  it('shows non-disabled Claiming… on claim button while only isTxPending', () => {
+    mockUseRequestById.mockReturnValue({ data: { request: MOCK_WITHDRAWAL_CLAIMABLE, claimableInfo: null }, isLoading: false })
+    mockUseClaimRequest.mockReturnValue({
+      claim: mockClaim,
+      canClaim: true,
+      claimableAmount: ONE_BTC / 2n,
+      isReadingAmount: false,
+      isReadingError: false,
+      isRequesting: false,
+      isTxPending: true,
+    })
+    renderWithTooltip(<TransactionDetailPage id="req-withdrawal-claimable" />)
+    const btn = screen.getByTestId('claim-button')
+    expect(btn).toHaveTextContent('Claiming...')
+    expect(btn).not.toBeDisabled()
+    fireEvent.click(btn)
+    expect(mockExecuteTxFlow).not.toHaveBeenCalled()
+  })
+
+  it('does not invoke executeTxFlow twice on rapid double-click', async () => {
+    mockUseRequestById.mockReturnValue({ data: { request: MOCK_WITHDRAWAL_CLAIMABLE, claimableInfo: null }, isLoading: false })
+    mockUseClaimRequest.mockReturnValue({
+      claim: mockClaim,
+      canClaim: true,
+      claimableAmount: ONE_BTC / 2n,
+      isReadingAmount: false,
+      isReadingError: false,
+      isRequesting: false,
+      isTxPending: false,
+    })
+    let release!: () => void
+    const gate = new Promise<void>(resolve => {
+      release = resolve
+    })
+    mockExecuteTxFlow.mockImplementation(() => gate)
+    renderWithTooltip(<TransactionDetailPage id="req-withdrawal-claimable" />)
+    fireEvent.click(screen.getByTestId('claim-button'))
+    fireEvent.click(screen.getByTestId('claim-button'))
+    expect(mockExecuteTxFlow).toHaveBeenCalledTimes(1)
+    release()
+    await waitFor(() => expect(mockExecuteTxFlow).toHaveBeenCalledTimes(1))
+  })
+
   it('closes modal when wallet approves the cancel transaction', async () => {
     mockOnCancelRequest.mockResolvedValue('0xmockhash')
     mockExecuteTxFlow.mockImplementation(async ({ onPending }) => {
       onPending?.('0xmockhash')
       return '0xmockhash'
     })
-    render(<TransactionDetailPage id="req-withdrawal-pending" />)
+    renderWithTooltip(<TransactionDetailPage id="req-withdrawal-pending" />)
     fireEvent.click(screen.getByTestId('cancel-request-button'))
     expect(screen.getByTestId('CancelRequestModal')).toBeInTheDocument()
     fireEvent.click(screen.getByTestId('CancelRequestConfirm'))

--- a/src/app/btc-vault/request-history/[id]/TransactionDetailPage.tsx
+++ b/src/app/btc-vault/request-history/[id]/TransactionDetailPage.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useCallback, useRef } from 'react'
 import { useAccount } from 'wagmi'
 
 import { LoadingSpinner } from '@/components/LoadingSpinner'
@@ -8,6 +9,7 @@ import { usePricesContext } from '@/shared/context/PricesContext'
 import { useModal } from '@/shared/hooks/useModal'
 import { executeTxFlow } from '@/shared/notification'
 
+import { BTC_VAULT_BACKEND_INDEX_DELAY_MS } from '../../constants'
 import { useBtcVaultInvalidation } from '../../hooks/useBtcVaultInvalidation'
 import { useCancelBtcVaultRequest } from '../../hooks/useCancelRequest'
 import { useClaimableInfo } from '../../hooks/useClaimableInfo'
@@ -37,6 +39,25 @@ export function TransactionDetailPage({ id }: TransactionDetailPageProps) {
     isTxPending: isClaimTxPending,
   } = useClaimRequest(request ?? null)
 
+  const claimFlowLock = useRef(false)
+
+  const handleClaim = useCallback(async () => {
+    if (claimFlowLock.current) return
+    claimFlowLock.current = true
+    try {
+      await executeTxFlow({
+        action: 'btcVaultClaim',
+        onRequestTx: () => claim(),
+        onSuccess: async () => {
+          await new Promise(resolve => setTimeout(resolve, BTC_VAULT_BACKEND_INDEX_DELAY_MS))
+          invalidateAfterAction(id)
+        },
+      })
+    } finally {
+      claimFlowLock.current = false
+    }
+  }, [claim, id, invalidateAfterAction])
+
   if (!address || !isConnected) {
     return <TransactionDetailOops variant="not-connected" />
   }
@@ -52,26 +73,13 @@ export function TransactionDetailPage({ id }: TransactionDetailPageProps) {
   const detail = toRequestDetailDisplay(request, claimableInfo, rbtcPrice, address)
   const isClaimPending = isClaiming || isClaimTxPending
 
-  const BACKEND_INDEX_DELAY_MS = 3000
-
-  const handleClaim = async () => {
-    await executeTxFlow({
-      action: 'btcVaultClaim',
-      onRequestTx: () => claim(),
-      onSuccess: async () => {
-        await new Promise(resolve => setTimeout(resolve, BACKEND_INDEX_DELAY_MS))
-        invalidateAfterAction(id)
-      },
-    })
-  }
-
   const handleConfirmCancel = async () => {
     await executeTxFlow({
       action: 'btcVaultCancel',
       onRequestTx: () => onCancelRequest(),
       onPending: () => closeModal(),
       onSuccess: async () => {
-        await new Promise(resolve => setTimeout(resolve, BACKEND_INDEX_DELAY_MS))
+        await new Promise(resolve => setTimeout(resolve, BTC_VAULT_BACKEND_INDEX_DELAY_MS))
         invalidateAfterAction(id)
       },
     })

--- a/src/app/btc-vault/request-history/[id]/components/TransactionDetailView.tsx
+++ b/src/app/btc-vault/request-history/[id]/components/TransactionDetailView.tsx
@@ -1,8 +1,10 @@
 'use client'
 
+import { ConditionalTooltip } from '@/app/components/Tooltip/ConditionalTooltip'
 import { Button } from '@/components/Button'
 import { Header } from '@/components/Typography'
 
+import { BTC_VAULT_CLAIM_IN_PROGRESS_MESSAGE } from '../../../constants'
 import type { RequestStatus, RequestType } from '../../../services/types'
 import type { DisplayStatus, RequestDetailDisplay } from '../../../services/ui/types'
 import { RequestDetailGrid } from './RequestDetailGrid'
@@ -35,16 +37,27 @@ export function TransactionDetailView({
       <div className="bg-bg-80 rounded py-8 px-4 md:p-6 w-full flex flex-col gap-6">
         <RequestStatusStepper status={status} type={type} displayStatus={displayStatus} />
         <RequestDetailGrid detail={detail} />
-        {detail.claimable && (
-          <Button
-            variant="primary"
-            data-testid="claim-button"
-            onClick={onClaim}
-            disabled={isClaimPending || !onClaim}
-          >
-            {isClaimPending ? 'Claiming...' : detail.type === 'deposit' ? 'Claim Shares' : 'Claim rBTC'}
-          </Button>
-        )}
+        {detail.claimable &&
+          (isClaimPending ? (
+            <ConditionalTooltip
+              supportMobileTap
+              className="p-0"
+              conditionPairs={[
+                {
+                  condition: () => true,
+                  lazyContent: () => BTC_VAULT_CLAIM_IN_PROGRESS_MESSAGE,
+                },
+              ]}
+            >
+              <Button variant="primary" data-testid="claim-button" disabled={false} onClick={() => {}}>
+                Claiming...
+              </Button>
+            </ConditionalTooltip>
+          ) : (
+            <Button variant="primary" data-testid="claim-button" onClick={onClaim} disabled={!onClaim}>
+              {detail.type === 'deposit' ? 'Claim Shares' : 'Claim rBTC'}
+            </Button>
+          ))}
         {detail.canCancel && (
           <Button variant="secondary-outline" data-testid="cancel-request-button" onClick={onCancel}>
             Cancel request


### PR DESCRIPTION
## Why this PR exists

Users with a **claimable async deposit** need a clear **Claim Shares** action from the **vault dashboard** and from **request history detail**, aligned with how finalize flows work elsewhere. This PR connects those surfaces to the hooks and transaction flow from **Part 1**.

## What to focus on

- **Dashboard** shows the claim control when a claimable deposit exists; loading and read-error states avoid implying the user can claim before on-chain data is reliable.
- **Request detail** uses the same pattern for claimable deposit rows so behavior matches the dashboard.
- **Vault page** threads **claimable request** and **refetch after claim** so balances and history update after a successful transaction.

**Depends on:** Part 1. Until Part 1 is merged into `main`, this PR targets branch `dao-2230-claim-shares-part-1`. After Part 1 merges, retarget the PR base to `main` if GitHub does not update it automatically.
