### PR TITLE
fix(DAO-2233): cap Prisma connection pool to prevent DB exhaustion

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -7,8 +7,9 @@ const globalForPrisma = globalThis as typeof globalThis & {
 }
 
 if (url && !globalForPrisma._prisma) {
+  const separator = url.includes('?') ? '&' : '?'
   globalForPrisma._prisma = new PrismaClient({
-    datasources: { db: { url } },
+    datasources: { db: { url: `${url}${separator}connection_limit=5` } },
   })
 }
 


### PR DESCRIPTION
## Summary
- Just a random kick — adds `connection_limit=5` to the Prisma datasource URL to cap the connection pool and prevent DB connection exhaustion that may be causing 500 errors on the proposals page
- Matches the existing Knex pool configuration (`pool: { min: 0, max: 5 }`)