### PR TITLE
refactor(DAO-2135): move request-processing components (2/6)

### DIFF
--- a/src/app/btc-vault/BtcVaultPage.test.tsx
+++ b/src/app/btc-vault/BtcVaultPage.test.tsx
@@ -73,7 +73,7 @@ vi.mock('@/components/Countdown/Countdown', () => ({
   Countdown: () => <span data-testid="countdown">5d 23h 59m</span>,
 }))
 
-vi.mock('./ActiveRequestSection', () => ({
+vi.mock('./components/request-processing/ActiveRequestSection', () => ({
   ActiveRequestSection: () => null,
 }))
 

--- a/src/app/btc-vault/BtcVaultPage.tsx
+++ b/src/app/btc-vault/BtcVaultPage.tsx
@@ -4,7 +4,7 @@ import { useAccount } from 'wagmi'
 
 import { SectionContainer } from '@/app/communities/components/SectionContainer'
 
-import { ActiveRequestSection } from './ActiveRequestSection'
+import { ActiveRequestSection } from './components/request-processing/ActiveRequestSection'
 import { BtcVaultBanners } from './BtcVaultBanners'
 import { BtcVaultDashboard } from './components/BtcVaultDashboard'
 import { BtcVaultMetrics } from './components/BtcVaultMetrics'

--- a/src/app/btc-vault/components/request-processing/ActiveRequestSection.test.tsx
+++ b/src/app/btc-vault/components/request-processing/ActiveRequestSection.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
 
-import type { ActiveRequestDisplay } from './services/ui/types'
+import type { ActiveRequestDisplay } from '../../services/ui/types'
 
 vi.mock('@/components/ProgressBarNew', async (importOriginal) => {
   const React = require('react')

--- a/src/app/btc-vault/components/request-processing/ActiveRequestSection.tsx
+++ b/src/app/btc-vault/components/request-processing/ActiveRequestSection.tsx
@@ -2,8 +2,8 @@
 
 import { SectionContainer } from '@/app/communities/components/SectionContainer'
 
-import { RequestProcessingBlock } from './components/RequestProcessingBlock'
-import type { ActiveRequestDisplay } from './services/ui/types'
+import { RequestProcessingBlock } from './RequestProcessingBlock'
+import type { ActiveRequestDisplay } from '../../services/ui/types'
 
 interface ActiveRequestSectionProps {
   data: ActiveRequestDisplay[] | undefined

--- a/src/app/btc-vault/components/request-processing/RequestProcessingBlock.stories.tsx
+++ b/src/app/btc-vault/components/request-processing/RequestProcessingBlock.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { SectionContainer } from '@/app/communities/components/SectionContainer'
-import { RequestProcessingBlock } from './components/RequestProcessingBlock'
-import type { ActiveRequestDisplay } from './services/ui/types'
+import { RequestProcessingBlock } from './RequestProcessingBlock'
+import type { ActiveRequestDisplay } from '../../services/ui/types'
 
 const meta = {
   title: 'BTC Vault/RequestProcessingBlock',

--- a/src/app/btc-vault/components/request-processing/RequestProcessingBlock.test.tsx
+++ b/src/app/btc-vault/components/request-processing/RequestProcessingBlock.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, within } from '@testing-library/react'
 import { describe, it, expect, vi, beforeAll } from 'vitest'
-import { RequestProcessingBlock } from './components/RequestProcessingBlock'
-import type { ActiveRequestDisplay } from './services/ui/types'
+import { RequestProcessingBlock } from './RequestProcessingBlock'
+import type { ActiveRequestDisplay } from '../../services/ui/types'
 
 vi.mock('next/image', () => ({
   default: (props: Record<string, unknown>) => require('react').createElement('img', props),

--- a/src/app/btc-vault/components/request-processing/RequestProcessingBlock.tsx
+++ b/src/app/btc-vault/components/request-processing/RequestProcessingBlock.tsx
@@ -10,8 +10,8 @@ import { RBTC } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 import { btcVaultRequestHistory } from '@/shared/constants/routes'
 
-import { RequestStatusStepper } from '../request-history/[id]/components/RequestStatusStepper'
-import type { ActiveRequestDisplay } from '../services/ui/types'
+import { RequestStatusStepper } from '../../request-history/[id]/components/RequestStatusStepper'
+import type { ActiveRequestDisplay } from '../../services/ui/types'
 
 function getRequestTypeLabel(type: ActiveRequestDisplay['type']): string {
   return type === 'deposit' ? 'Deposit' : 'Withdrawal'

--- a/src/app/btc-vault/components/request-processing/index.ts
+++ b/src/app/btc-vault/components/request-processing/index.ts
@@ -1,0 +1,2 @@
+export { ActiveRequestSection } from './ActiveRequestSection'
+export { RequestProcessingBlock } from './RequestProcessingBlock'


### PR DESCRIPTION
## Summary
- Move `ActiveRequestSection` and `RequestProcessingBlock` (plus tests/stories) from btc-vault root and `components/` into `request-processing/` subfolder
- Add barrel `index.ts`

Part 2 of 6 for DAO-2135 (organize btc-vault components folder).