### PR TITLE
DAO-2251: Deposit/withdraw buttons stay disabled after claim/redeem on BTC vault page

### DIFF
--- a/.workflow/devlogs/STORY-DAO-2251-phase-1-devlog.md
+++ b/.workflow/devlogs/STORY-DAO-2251-phase-1-devlog.md
@@ -1,0 +1,44 @@
+# Devlog: STORY-DAO-2251 — Phase 1
+
+**Date:** 2026-04-15  
+**Phase:** 1 of 1  
+**Developer:** Developer Agent
+
+---
+
+## What Was Planned
+
+- Add `get-btc-vault-action-eligibility-contracts.ts` and wire `useActionEligibility` to it.
+- Fix `useBtcVaultInvalidation`: `active-requests-history` key, drop bogus `action-eligibility` key, invalidate wagmi `readContracts` via `readContractsQueryKey` and shared contracts; align `config` usage with `executeTxFlow` if needed.
+- Compose parent `onAfterClaimRefetch` / `onAfterRedeemRefetch` with `useActionEligibility` refetch in `BtcVaultDashboard` (parent first, then eligibility).
+- Update `useBtcVaultInvalidation.test.ts` and `BtcVaultDashboard.test.tsx`.
+
+## What Was Done
+
+- Added `src/app/btc-vault/hooks/get-btc-vault-action-eligibility-contracts.ts` exporting `getBtcVaultActionEligibilityContracts(address)`.
+- `useActionEligibility` now builds the multicall from that helper.
+- `useBtcVaultInvalidation` invalidates `['btc-vault', 'active-requests-history', address]`, skips the unused `action-eligibility` key, and invalidates `readContractsQueryKey({ contracts, chainId })` when `address` is set. Uses `useChainId()` from wagmi context (no `@/config` import in this hook).
+- `BtcVaultDashboard` wraps claim/redeem callbacks with `useCallback` handlers that call the page callback then `void refetchActionEligibility()`.
+- Tests: invalidation expectations updated; added case for missing `address`; dashboard tests trigger probe `onClick` and assert refetch ordering; claim/redeem probes always receive a refetch handler (`data-has-refetch` now `yes` without parent callback).
+
+## Deviations from Plan
+
+
+| Deviation                                                           | Reason                                                                                                                                                                     | Impact                                                                                      |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| No `import { config } from '@/config'` in `useBtcVaultInvalidation` | Importing `@/config` in the invalidation hook pulled full wagmi config through `ledgerConnector` and broke `useBtcVaultInvalidation.test.ts` (partial `vi.mock('wagmi')`). | `useChainId()` without arguments uses the Wagmi provider config, matching runtime behavior. |
+
+
+## Discoveries
+
+- `@wagmi/core/query` `readContractsQueryKey` takes a single options object (contracts + `chainId`), not `(config, options)` as sometimes assumed in prose plans.
+
+## Plan Amendments
+
+Recorded in `STORY-DAO-2251-plan.md` **Plan Amendments** table.
+
+## Notes for Code Review
+
+- Confirm `useChainId()` matches the chain id embedded in `useReadContracts` query keys for the eligibility multicall in all environments (single-chain app config should align).
+- Sequential refetch: parent `refetchActiveRequests` (or other page callback) runs before eligibility refetch; both are fire-and-forget after the parent sync portion.
+

--- a/src/app/btc-vault/components/BtcVaultClaimSharesButton.test.tsx
+++ b/src/app/btc-vault/components/BtcVaultClaimSharesButton.test.tsx
@@ -119,7 +119,22 @@ describe('BtcVaultClaimSharesButton', () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it('shows non-disabled Claiming… with tooltip path when claim tx in progress (isRequesting)', () => {
+  it('shows Claiming… while executeTxFlow is pending even if wagmi flags are false', async () => {
+    mockExecuteTxFlow.mockImplementation(() => new Promise(() => {}))
+    render(<BtcVaultClaimSharesButton vaultRequest={MOCK_CLAIMABLE_DEPOSIT} />, {
+      wrapper: TestWrapper,
+    })
+    const btn = screen.getByTestId('btc-vault-claim-shares-button')
+    fireEvent.click(btn)
+    await waitFor(() => {
+      expect(screen.getByTestId('btc-vault-claim-shares-button')).toHaveTextContent('Claiming...')
+    })
+    const claimingBtn = screen.getByTestId('btc-vault-claim-shares-button') as HTMLButtonElement
+    expect(claimingBtn.disabled).toBe(false)
+    expect(claimingBtn).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('shows inert Claiming… (primary look) with tooltip when claim tx in progress (isRequesting)', () => {
     mockUseClaimRequest.mockReturnValue({
       claim: mockClaim,
       canClaim: true,
@@ -131,14 +146,15 @@ describe('BtcVaultClaimSharesButton', () => {
     render(<BtcVaultClaimSharesButton vaultRequest={MOCK_CLAIMABLE_DEPOSIT} />, {
       wrapper: TestWrapper,
     })
-    const btn = screen.getByTestId('btc-vault-claim-shares-button')
+    const btn = screen.getByTestId('btc-vault-claim-shares-button') as HTMLButtonElement
     expect(btn).toHaveTextContent('Claiming...')
-    expect(btn).not.toBeDisabled()
+    expect(btn.disabled).toBe(false)
+    expect(btn).toHaveAttribute('aria-disabled', 'true')
     fireEvent.click(btn)
     expect(mockExecuteTxFlow).not.toHaveBeenCalled()
   })
 
-  it('shows non-disabled Claiming… when only isTxPending', () => {
+  it('shows inert Claiming… (primary look) when only isTxPending', () => {
     mockUseClaimRequest.mockReturnValue({
       claim: mockClaim,
       canClaim: true,
@@ -150,9 +166,10 @@ describe('BtcVaultClaimSharesButton', () => {
     render(<BtcVaultClaimSharesButton vaultRequest={MOCK_CLAIMABLE_DEPOSIT} />, {
       wrapper: TestWrapper,
     })
-    const btn = screen.getByTestId('btc-vault-claim-shares-button')
+    const btn = screen.getByTestId('btc-vault-claim-shares-button') as HTMLButtonElement
     expect(btn).toHaveTextContent('Claiming...')
-    expect(btn).not.toBeDisabled()
+    expect(btn.disabled).toBe(false)
+    expect(btn).toHaveAttribute('aria-disabled', 'true')
   })
 
   it('does not invoke executeTxFlow twice on rapid double-click', async () => {
@@ -166,6 +183,7 @@ describe('BtcVaultClaimSharesButton', () => {
         vaultRequest={MOCK_CLAIMABLE_DEPOSIT}
         onAfterClaimRefetch={mockOnAfterClaimRefetch}
       />,
+      { wrapper: TestWrapper },
     )
     const btn = screen.getByTestId('btc-vault-claim-shares-button')
     fireEvent.click(btn)
@@ -181,6 +199,7 @@ describe('BtcVaultClaimSharesButton', () => {
         vaultRequest={MOCK_CLAIMABLE_DEPOSIT}
         onAfterClaimRefetch={mockOnAfterClaimRefetch}
       />,
+      { wrapper: TestWrapper },
     )
 
     expect(screen.getByTestId('btc-vault-claim-shares-button')).toHaveTextContent('Claim Shares')
@@ -213,6 +232,7 @@ describe('BtcVaultClaimSharesButton', () => {
         vaultRequest={MOCK_CLAIMABLE_DEPOSIT}
         onAfterClaimRefetch={mockOnAfterClaimRefetch}
       />,
+      { wrapper: TestWrapper },
     )
 
     await act(async () => {

--- a/src/app/btc-vault/components/BtcVaultClaimSharesButton.tsx
+++ b/src/app/btc-vault/components/BtcVaultClaimSharesButton.tsx
@@ -1,90 +1,33 @@
 'use client'
 
-import { useRef } from 'react'
-import { useAccount } from 'wagmi'
-
-import { ConditionalTooltip } from '@/app/components/Tooltip/ConditionalTooltip'
 import { Button } from '@/components/Button'
-import { executeTxFlow } from '@/shared/notification'
 
-import { BTC_VAULT_BACKEND_INDEX_DELAY_MS, BTC_VAULT_CLAIM_IN_PROGRESS_MESSAGE } from '../constants'
-import { useBtcVaultInvalidation } from '../hooks/useBtcVaultInvalidation'
-import { useClaimRequest } from '../hooks/useClaimRequest'
+import { useBtcVaultFinalizeSharesFlow } from '../hooks/useBtcVaultFinalizeSharesFlow'
 import type { VaultRequest } from '../services/types'
+import { BtcVaultFinalizeSharesBusyButton } from './BtcVaultFinalizeSharesBusyButton'
 
 const buttonClassName = 'h-auto min-h-11 w-full shrink-0 py-0.5 px-4 md:min-h-0'
 
 export interface BtcVaultClaimSharesButtonProps {
   vaultRequest: VaultRequest | null
-  onAfterClaimRefetch?: () => void
+  onAfterClaimRefetch?: () => void | Promise<void>
 }
 
 export function BtcVaultClaimSharesButton({
   vaultRequest,
   onAfterClaimRefetch,
 }: BtcVaultClaimSharesButtonProps) {
-  const { address } = useAccount()
-  const claimFlowLock = useRef(false)
-  const { invalidateAfterAction } = useBtcVaultInvalidation()
-  const { claim, canClaim, isRequesting, isTxPending, isReadingAmount, isReadingError } =
-    useClaimRequest(vaultRequest)
+  const { shouldRender, isBusy, handleFinalize } = useBtcVaultFinalizeSharesFlow({
+    vaultRequest,
+    expectedType: 'deposit',
+    onAfterRefetch: onAfterClaimRefetch,
+  })
 
-  if (!address) return null
-  if (!vaultRequest || vaultRequest.type !== 'deposit' || vaultRequest.status !== 'claimable') {
-    return null
-  }
+  if (!shouldRender) return null
 
-  if (isReadingAmount || isReadingError) {
-    return null
-  }
-
-  const isClaimPending = isRequesting || isTxPending
-
-  if (!canClaim && !isClaimPending) {
-    return null
-  }
-
-  const handleClaim = async () => {
-    if (claimFlowLock.current) return
-    claimFlowLock.current = true
-    try {
-      await executeTxFlow({
-        action: 'btcVaultClaim',
-        onRequestTx: () => claim(),
-        onSuccess: async () => {
-          await new Promise(resolve => setTimeout(resolve, BTC_VAULT_BACKEND_INDEX_DELAY_MS))
-          invalidateAfterAction(vaultRequest.id)
-          onAfterClaimRefetch?.()
-        },
-      })
-    } finally {
-      claimFlowLock.current = false
-    }
-  }
-
-  if (isClaimPending) {
+  if (isBusy) {
     return (
-      <ConditionalTooltip
-        supportMobileTap
-        className="w-full p-0"
-        conditionPairs={[
-          {
-            condition: () => true,
-            lazyContent: () => BTC_VAULT_CLAIM_IN_PROGRESS_MESSAGE,
-          },
-        ]}
-      >
-        <Button
-          variant="primary"
-          className={buttonClassName}
-          textClassName="text-sm"
-          data-testid="btc-vault-claim-shares-button"
-          disabled={false}
-          onClick={() => {}}
-        >
-          Claiming...
-        </Button>
-      </ConditionalTooltip>
+      <BtcVaultFinalizeSharesBusyButton data-testid="btc-vault-claim-shares-button" busyLabel="Claiming..." />
     )
   }
 
@@ -95,7 +38,7 @@ export function BtcVaultClaimSharesButton({
       textClassName="text-sm"
       data-testid="btc-vault-claim-shares-button"
       disabled={false}
-      onClick={handleClaim}
+      onClick={handleFinalize}
     >
       Claim Shares
     </Button>

--- a/src/app/btc-vault/components/BtcVaultDashboard.test.tsx
+++ b/src/app/btc-vault/components/BtcVaultDashboard.test.tsx
@@ -323,7 +323,7 @@ describe('BtcVaultDashboard', () => {
     expect(probe).toHaveAttribute('data-has-refetch', 'yes')
   })
 
-  it('forwards claimableWithdrawRequest and onAfterRedeemRefetch to Redeem Shares', () => {
+  it('forwards claimableWithdrawRequest and onAfterRedeemRefetch to Claim rBTC', () => {
     const onRefetch = vi.fn()
     const claimableWithdraw: VaultRequest = {
       id: 'red-dash-probe',
@@ -344,7 +344,7 @@ describe('BtcVaultDashboard', () => {
     expect(probe).toHaveAttribute('data-has-refetch', 'yes')
   })
 
-  it('passes null claimableWithdrawRequest to Redeem Shares when omitted', () => {
+  it('passes null claimableWithdrawRequest to Claim rBTC when omitted', () => {
     render(<BtcVaultDashboard />, { wrapper: Wrapper })
     const probe = screen.getByTestId('btc-vault-redeem-shares-probe')
     expect(probe).toHaveAttribute('data-request-id', '')

--- a/src/app/btc-vault/components/BtcVaultDashboard.test.tsx
+++ b/src/app/btc-vault/components/BtcVaultDashboard.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { TooltipProvider } from '@radix-ui/react-tooltip'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
@@ -54,6 +55,7 @@ vi.mock('./BtcVaultClaimSharesButton', () => ({
       data-testid="btc-vault-claim-shares-probe"
       data-request-id={vaultRequest?.id ?? ''}
       data-has-refetch={onAfterClaimRefetch ? 'yes' : 'no'}
+      onClick={() => onAfterClaimRefetch?.()}
     />
   ),
 }))
@@ -71,6 +73,7 @@ vi.mock('./BtcVaultRedeemSharesButton', () => ({
       data-testid="btc-vault-redeem-shares-probe"
       data-request-id={vaultRequest?.id ?? ''}
       data-has-refetch={onAfterRedeemRefetch ? 'yes' : 'no'}
+      onClick={() => onAfterRedeemRefetch?.()}
     />
   ),
 }))
@@ -108,6 +111,7 @@ describe('BtcVaultDashboard', () => {
         withdrawBlockReason: '',
       },
       isLoading: false,
+      refetch: vi.fn(),
     })
     mockUseBtcVaultWithdrawFlow.mockReturnValue({
       isWithdrawModalOpen: false,
@@ -316,7 +320,7 @@ describe('BtcVaultDashboard', () => {
     render(<BtcVaultDashboard />, { wrapper: Wrapper })
     const probe = screen.getByTestId('btc-vault-claim-shares-probe')
     expect(probe).toHaveAttribute('data-request-id', '')
-    expect(probe).toHaveAttribute('data-has-refetch', 'no')
+    expect(probe).toHaveAttribute('data-has-refetch', 'yes')
   })
 
   it('forwards claimableWithdrawRequest and onAfterRedeemRefetch to Redeem Shares', () => {
@@ -344,6 +348,69 @@ describe('BtcVaultDashboard', () => {
     render(<BtcVaultDashboard />, { wrapper: Wrapper })
     const probe = screen.getByTestId('btc-vault-redeem-shares-probe')
     expect(probe).toHaveAttribute('data-request-id', '')
-    expect(probe).toHaveAttribute('data-has-refetch', 'no')
+    expect(probe).toHaveAttribute('data-has-refetch', 'yes')
+  })
+
+  it('refetches action eligibility after parent onAfterClaimRefetch when claim probe fires', async () => {
+    const user = userEvent.setup()
+    const refetchEligibility = vi.fn()
+    mockUseActionEligibility.mockReturnValue({
+      data: {
+        canDeposit: true,
+        canWithdraw: true,
+        hasVaultShares: false,
+        depositBlockReason: '',
+        withdrawBlockReason: '',
+      },
+      isLoading: false,
+      refetch: refetchEligibility,
+    })
+    const onRefetch = vi.fn()
+    render(<BtcVaultDashboard onAfterClaimRefetch={onRefetch} />, { wrapper: Wrapper })
+    await user.click(screen.getByTestId('btc-vault-claim-shares-probe'))
+    expect(onRefetch).toHaveBeenCalledTimes(1)
+    expect(refetchEligibility).toHaveBeenCalledTimes(1)
+    expect(onRefetch.mock.invocationCallOrder[0]).toBeLessThan(refetchEligibility.mock.invocationCallOrder[0])
+  })
+
+  it('refetches action eligibility when claim probe fires without parent callback', async () => {
+    const user = userEvent.setup()
+    const refetchEligibility = vi.fn()
+    mockUseActionEligibility.mockReturnValue({
+      data: {
+        canDeposit: true,
+        canWithdraw: true,
+        hasVaultShares: false,
+        depositBlockReason: '',
+        withdrawBlockReason: '',
+      },
+      isLoading: false,
+      refetch: refetchEligibility,
+    })
+    render(<BtcVaultDashboard />, { wrapper: Wrapper })
+    await user.click(screen.getByTestId('btc-vault-claim-shares-probe'))
+    expect(refetchEligibility).toHaveBeenCalledTimes(1)
+  })
+
+  it('refetches action eligibility after parent onAfterRedeemRefetch when redeem probe fires', async () => {
+    const user = userEvent.setup()
+    const refetchEligibility = vi.fn()
+    mockUseActionEligibility.mockReturnValue({
+      data: {
+        canDeposit: true,
+        canWithdraw: true,
+        hasVaultShares: false,
+        depositBlockReason: '',
+        withdrawBlockReason: '',
+      },
+      isLoading: false,
+      refetch: refetchEligibility,
+    })
+    const onRefetch = vi.fn()
+    render(<BtcVaultDashboard onAfterRedeemRefetch={onRefetch} />, { wrapper: Wrapper })
+    await user.click(screen.getByTestId('btc-vault-redeem-shares-probe'))
+    expect(onRefetch).toHaveBeenCalledTimes(1)
+    expect(refetchEligibility).toHaveBeenCalledTimes(1)
+    expect(onRefetch.mock.invocationCallOrder[0]).toBeLessThan(refetchEligibility.mock.invocationCallOrder[0])
   })
 })

--- a/src/app/btc-vault/components/BtcVaultDashboard.tsx
+++ b/src/app/btc-vault/components/BtcVaultDashboard.tsx
@@ -35,11 +35,11 @@ function metricAmount(isLoading: boolean, isError: boolean, value: string | unde
  * Returns null when wallet is disconnected so the page section renders empty.
  */
 interface BtcVaultDashboardProps {
-  onRequestSubmitted?: () => void
+  onRequestSubmitted?: () => void | Promise<void>
   claimableDepositRequest?: VaultRequest | null
   claimableWithdrawRequest?: VaultRequest | null
-  onAfterClaimRefetch?: () => void
-  onAfterRedeemRefetch?: () => void
+  onAfterClaimRefetch?: () => void | Promise<void>
+  onAfterRedeemRefetch?: () => void | Promise<void>
 }
 
 export const BtcVaultDashboard = ({
@@ -54,14 +54,14 @@ export const BtcVaultDashboard = ({
   const { data: actionEligibility, refetch: refetchActionEligibility } = useActionEligibility(address)
   const withdrawFlow = useBtcVaultWithdrawFlow({ onRequestSubmitted })
 
-  const handleAfterClaimRefetch = useCallback(() => {
-    onAfterClaimRefetch?.()
-    void refetchActionEligibility()
+  const handleAfterClaimRefetch = useCallback(async () => {
+    await onAfterClaimRefetch?.()
+    await refetchActionEligibility()
   }, [onAfterClaimRefetch, refetchActionEligibility])
 
-  const handleAfterRedeemRefetch = useCallback(() => {
-    onAfterRedeemRefetch?.()
-    void refetchActionEligibility()
+  const handleAfterRedeemRefetch = useCallback(async () => {
+    await onAfterRedeemRefetch?.()
+    await refetchActionEligibility()
   }, [onAfterRedeemRefetch, refetchActionEligibility])
 
   if (!address || !isConnected) return null

--- a/src/app/btc-vault/components/BtcVaultDashboard.tsx
+++ b/src/app/btc-vault/components/BtcVaultDashboard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { type ReactNode } from 'react'
+import { type ReactNode, useCallback } from 'react'
 import { useAccount } from 'wagmi'
 
 import { SectionContainer } from '@/app/communities/components/SectionContainer'
@@ -51,8 +51,18 @@ export const BtcVaultDashboard = ({
 }: BtcVaultDashboardProps) => {
   const { address, isConnected } = useAccount()
   const { data, isLoading, isError } = useUserPosition(address)
-  const { data: actionEligibility } = useActionEligibility(address)
+  const { data: actionEligibility, refetch: refetchActionEligibility } = useActionEligibility(address)
   const withdrawFlow = useBtcVaultWithdrawFlow({ onRequestSubmitted })
+
+  const handleAfterClaimRefetch = useCallback(() => {
+    onAfterClaimRefetch?.()
+    void refetchActionEligibility()
+  }, [onAfterClaimRefetch, refetchActionEligibility])
+
+  const handleAfterRedeemRefetch = useCallback(() => {
+    onAfterRedeemRefetch?.()
+    void refetchActionEligibility()
+  }, [onAfterRedeemRefetch, refetchActionEligibility])
 
   if (!address || !isConnected) return null
 
@@ -73,7 +83,7 @@ export const BtcVaultDashboard = ({
             />
             <BtcVaultRedeemSharesButton
               vaultRequest={claimableWithdrawRequest}
-              onAfterRedeemRefetch={onAfterRedeemRefetch}
+              onAfterRedeemRefetch={handleAfterRedeemRefetch}
             />
           </div>
           <div className={`flex flex-col gap-4 ${METRIC_COLUMN}`}>
@@ -87,7 +97,7 @@ export const BtcVaultDashboard = ({
             />
             <BtcVaultClaimSharesButton
               vaultRequest={claimableDepositRequest}
-              onAfterClaimRefetch={onAfterClaimRefetch}
+              onAfterClaimRefetch={handleAfterClaimRefetch}
             />
           </div>
           <BalanceInfo

--- a/src/app/btc-vault/components/BtcVaultFinalizeSharesBusyButton.tsx
+++ b/src/app/btc-vault/components/BtcVaultFinalizeSharesBusyButton.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { ConditionalTooltip } from '@/app/components/Tooltip/ConditionalTooltip'
+import { Button } from '@/components/Button'
+import { cn } from '@/lib/utils'
+
+import { BTC_VAULT_CLAIM_IN_PROGRESS_MESSAGE } from '../constants'
+
+const buttonClassName = 'h-auto min-h-11 w-full shrink-0 py-0.5 px-4 md:min-h-0'
+
+export interface BtcVaultFinalizeSharesBusyButtonProps {
+  'data-testid': string
+  busyLabel: string
+}
+
+/**
+ * In-progress vault finalize control: primary styling, no native `disabled` (avoids grey styles),
+ * pointer-events on the button so the wrapping tooltip stays the hit target.
+ */
+export function BtcVaultFinalizeSharesBusyButton({
+  'data-testid': dataTestId,
+  busyLabel,
+}: BtcVaultFinalizeSharesBusyButtonProps) {
+  return (
+    <ConditionalTooltip
+      supportMobileTap
+      className="w-full px-5 py-4"
+      conditionPairs={[
+        {
+          condition: () => true,
+          lazyContent: () => BTC_VAULT_CLAIM_IN_PROGRESS_MESSAGE,
+        },
+      ]}
+    >
+      <span className="block w-full cursor-default">
+        <Button
+          variant="primary"
+          className={cn(buttonClassName, 'pointer-events-none')}
+          textClassName="text-sm"
+          data-testid={dataTestId}
+          aria-disabled
+          aria-busy
+          tabIndex={-1}
+        >
+          {busyLabel}
+        </Button>
+      </span>
+    </ConditionalTooltip>
+  )
+}

--- a/src/app/btc-vault/components/BtcVaultRedeemSharesButton.test.tsx
+++ b/src/app/btc-vault/components/BtcVaultRedeemSharesButton.test.tsx
@@ -133,6 +133,21 @@ describe('BtcVaultRedeemSharesButton', () => {
     expect(container.firstChild).toBeNull()
   })
 
+  it('shows Redeeming… while executeTxFlow is pending even if wagmi flags are false', async () => {
+    mockExecuteTxFlow.mockImplementation(() => new Promise(() => {}))
+    render(<BtcVaultRedeemSharesButton vaultRequest={MOCK_CLAIMABLE_WITHDRAWAL} />, {
+      wrapper: TestWrapper,
+    })
+    const btn = screen.getByTestId('btc-vault-redeem-shares-button')
+    fireEvent.click(btn)
+    await waitFor(() => {
+      expect(screen.getByTestId('btc-vault-redeem-shares-button')).toHaveTextContent('Redeeming...')
+    })
+    const redeemingBtn = screen.getByTestId('btc-vault-redeem-shares-button') as HTMLButtonElement
+    expect(redeemingBtn.disabled).toBe(false)
+    expect(redeemingBtn).toHaveAttribute('aria-disabled', 'true')
+  })
+
   it('shows Redeeming… with tooltip path when finalize tx in progress', () => {
     mockUseClaimRequest.mockReturnValue({
       claim: mockClaim,
@@ -145,9 +160,10 @@ describe('BtcVaultRedeemSharesButton', () => {
     render(<BtcVaultRedeemSharesButton vaultRequest={MOCK_CLAIMABLE_WITHDRAWAL} />, {
       wrapper: TestWrapper,
     })
-    const btn = screen.getByTestId('btc-vault-redeem-shares-button')
+    const btn = screen.getByTestId('btc-vault-redeem-shares-button') as HTMLButtonElement
     expect(btn).toHaveTextContent('Redeeming...')
-    expect(btn).not.toBeDisabled()
+    expect(btn.disabled).toBe(false)
+    expect(btn).toHaveAttribute('aria-disabled', 'true')
     fireEvent.click(btn)
     expect(mockExecuteTxFlow).not.toHaveBeenCalled()
   })
@@ -163,6 +179,7 @@ describe('BtcVaultRedeemSharesButton', () => {
         vaultRequest={MOCK_CLAIMABLE_WITHDRAWAL}
         onAfterRedeemRefetch={mockOnAfterRedeemRefetch}
       />,
+      { wrapper: TestWrapper },
     )
     const btn = screen.getByTestId('btc-vault-redeem-shares-button')
     fireEvent.click(btn)
@@ -178,6 +195,7 @@ describe('BtcVaultRedeemSharesButton', () => {
         vaultRequest={MOCK_CLAIMABLE_WITHDRAWAL}
         onAfterRedeemRefetch={mockOnAfterRedeemRefetch}
       />,
+      { wrapper: TestWrapper },
     )
 
     expect(screen.getByTestId('btc-vault-redeem-shares-button')).toHaveTextContent('Redeem Shares')
@@ -210,6 +228,7 @@ describe('BtcVaultRedeemSharesButton', () => {
         vaultRequest={MOCK_CLAIMABLE_WITHDRAWAL}
         onAfterRedeemRefetch={mockOnAfterRedeemRefetch}
       />,
+      { wrapper: TestWrapper },
     )
 
     await act(async () => {

--- a/src/app/btc-vault/components/BtcVaultRedeemSharesButton.test.tsx
+++ b/src/app/btc-vault/components/BtcVaultRedeemSharesButton.test.tsx
@@ -189,7 +189,7 @@ describe('BtcVaultRedeemSharesButton', () => {
     await waitFor(() => expect(mockExecuteTxFlow).toHaveBeenCalledTimes(1))
   })
 
-  it('shows Redeem Shares and calls executeTxFlow with btcVaultClaim on click', async () => {
+  it('shows Claim rBTC and calls executeTxFlow with btcVaultClaim on click', async () => {
     render(
       <BtcVaultRedeemSharesButton
         vaultRequest={MOCK_CLAIMABLE_WITHDRAWAL}
@@ -198,7 +198,7 @@ describe('BtcVaultRedeemSharesButton', () => {
       { wrapper: TestWrapper },
     )
 
-    expect(screen.getByTestId('btc-vault-redeem-shares-button')).toHaveTextContent('Redeem Shares')
+    expect(screen.getByTestId('btc-vault-redeem-shares-button')).toHaveTextContent('Claim rBTC')
     fireEvent.click(screen.getByTestId('btc-vault-redeem-shares-button'))
 
     await waitFor(() => {

--- a/src/app/btc-vault/components/BtcVaultRedeemSharesButton.tsx
+++ b/src/app/btc-vault/components/BtcVaultRedeemSharesButton.tsx
@@ -1,22 +1,16 @@
 'use client'
 
-import { useRef } from 'react'
-import { useAccount } from 'wagmi'
-
-import { ConditionalTooltip } from '@/app/components/Tooltip/ConditionalTooltip'
 import { Button } from '@/components/Button'
-import { executeTxFlow } from '@/shared/notification'
 
-import { BTC_VAULT_BACKEND_INDEX_DELAY_MS, BTC_VAULT_CLAIM_IN_PROGRESS_MESSAGE } from '../constants'
-import { useBtcVaultInvalidation } from '../hooks/useBtcVaultInvalidation'
-import { useClaimRequest } from '../hooks/useClaimRequest'
+import { useBtcVaultFinalizeSharesFlow } from '../hooks/useBtcVaultFinalizeSharesFlow'
 import type { VaultRequest } from '../services/types'
+import { BtcVaultFinalizeSharesBusyButton } from './BtcVaultFinalizeSharesBusyButton'
 
 const buttonClassName = 'h-auto min-h-11 w-full shrink-0 py-0.5 px-4 md:min-h-0'
 
 export interface BtcVaultRedeemSharesButtonProps {
   vaultRequest: VaultRequest | null
-  onAfterRedeemRefetch?: () => void
+  onAfterRedeemRefetch?: () => void | Promise<void>
 }
 
 /**
@@ -27,68 +21,20 @@ export function BtcVaultRedeemSharesButton({
   vaultRequest,
   onAfterRedeemRefetch,
 }: BtcVaultRedeemSharesButtonProps) {
-  const { address } = useAccount()
-  const claimFlowLock = useRef(false)
-  const { invalidateAfterAction } = useBtcVaultInvalidation()
-  const { claim, canClaim, isRequesting, isTxPending, isReadingAmount, isReadingError } =
-    useClaimRequest(vaultRequest)
+  const { shouldRender, isBusy, handleFinalize } = useBtcVaultFinalizeSharesFlow({
+    vaultRequest,
+    expectedType: 'withdrawal',
+    onAfterRefetch: onAfterRedeemRefetch,
+  })
 
-  if (!address) return null
-  if (!vaultRequest || vaultRequest.type !== 'withdrawal' || vaultRequest.status !== 'claimable') {
-    return null
-  }
+  if (!shouldRender) return null
 
-  if (isReadingAmount || isReadingError) {
-    return null
-  }
-
-  const isClaimPending = isRequesting || isTxPending
-
-  if (!canClaim && !isClaimPending) {
-    return null
-  }
-
-  const handleFinalize = async () => {
-    if (claimFlowLock.current) return
-    claimFlowLock.current = true
-    try {
-      await executeTxFlow({
-        action: 'btcVaultClaim',
-        onRequestTx: () => claim(),
-        onSuccess: async () => {
-          await new Promise(resolve => setTimeout(resolve, BTC_VAULT_BACKEND_INDEX_DELAY_MS))
-          invalidateAfterAction(vaultRequest.id)
-          onAfterRedeemRefetch?.()
-        },
-      })
-    } finally {
-      claimFlowLock.current = false
-    }
-  }
-
-  if (isClaimPending) {
+  if (isBusy) {
     return (
-      <ConditionalTooltip
-        supportMobileTap
-        className="w-full p-0"
-        conditionPairs={[
-          {
-            condition: () => true,
-            lazyContent: () => BTC_VAULT_CLAIM_IN_PROGRESS_MESSAGE,
-          },
-        ]}
-      >
-        <Button
-          variant="primary"
-          className={buttonClassName}
-          textClassName="text-sm"
-          data-testid="btc-vault-redeem-shares-button"
-          disabled={false}
-          onClick={() => {}}
-        >
-          Redeeming...
-        </Button>
-      </ConditionalTooltip>
+      <BtcVaultFinalizeSharesBusyButton
+        data-testid="btc-vault-redeem-shares-button"
+        busyLabel="Redeeming..."
+      />
     )
   }
 

--- a/src/app/btc-vault/components/BtcVaultRedeemSharesButton.tsx
+++ b/src/app/btc-vault/components/BtcVaultRedeemSharesButton.tsx
@@ -47,7 +47,7 @@ export function BtcVaultRedeemSharesButton({
       disabled={false}
       onClick={handleFinalize}
     >
-      Redeem Shares
+      Claim rBTC
     </Button>
   )
 }

--- a/src/app/btc-vault/hooks/get-btc-vault-action-eligibility-contracts.ts
+++ b/src/app/btc-vault/hooks/get-btc-vault-action-eligibility-contracts.ts
@@ -1,0 +1,19 @@
+import type { Address } from 'viem'
+
+import { rbtcVault } from '@/lib/contracts'
+
+/**
+ * Readonly contract descriptors for the BTC vault multicall that backs {@link useActionEligibility}.
+ * Kept in one module so wagmi `readContracts` invalidation keys stay aligned with the hook.
+ *
+ * @param address - Vault user address passed into `asyncDepositRequests`, `asyncRedeemRequests`, and `balanceOf`
+ */
+export function getBtcVaultActionEligibilityContracts(address: Address) {
+  return [
+    { ...rbtcVault, functionName: 'depositRequestsPaused' as const },
+    { ...rbtcVault, functionName: 'redeemRequestsPaused' as const },
+    { ...rbtcVault, functionName: 'asyncDepositRequests' as const, args: [address] },
+    { ...rbtcVault, functionName: 'asyncRedeemRequests' as const, args: [address] },
+    { ...rbtcVault, functionName: 'balanceOf' as const, args: [address] },
+  ] as const
+}

--- a/src/app/btc-vault/hooks/useActionEligibility/useActionEligibility.test.ts
+++ b/src/app/btc-vault/hooks/useActionEligibility/useActionEligibility.test.ts
@@ -134,9 +134,9 @@ describe('useActionEligibility', () => {
       expect(contracts).toHaveLength(5)
     })
 
-    it('refetch calls both multicall and whitelist refetches', () => {
+    it('refetch calls both multicall and whitelist refetches', async () => {
       const { result } = renderHook(() => useActionEligibility(USER_ADDRESS))
-      result.current.refetch()
+      await result.current.refetch()
 
       expect(vaultRefetch).toHaveBeenCalledOnce()
       expect(whitelistRefetch).toHaveBeenCalledOnce()

--- a/src/app/btc-vault/hooks/useActionEligibility/useActionEligibility.ts
+++ b/src/app/btc-vault/hooks/useActionEligibility/useActionEligibility.ts
@@ -4,14 +4,14 @@ import { useCallback, useMemo } from 'react'
 import type { Address } from 'viem'
 import { useReadContracts } from 'wagmi'
 
+import { getBtcVaultActionEligibilityContracts } from '@/app/btc-vault/hooks/get-btc-vault-action-eligibility-contracts'
 import { useWhitelistCheck } from '@/app/btc-vault/hooks/useWhitelistCheck'
-import { rbtcVault } from '@/lib/contracts'
 
 import type { EligibilityStatus, PauseState, VaultRequest } from '../../services/types'
 import { toActionEligibility } from '../../services/ui/mappers'
 
 /**
- * Vault multicall result order (must match `vaultContracts`):
+ * Vault multicall result order (must match {@link getBtcVaultActionEligibilityContracts}):
  * 0–1 pause flags, 2–3 deposit/redeem requests, 4 balanceOf(user).
  */
 type VaultMulticallData = [
@@ -38,13 +38,7 @@ export function useActionEligibility(address: string | undefined) {
 
   const vaultContracts = useMemo(() => {
     if (!address) return
-    return [
-      { ...rbtcVault, functionName: 'depositRequestsPaused' as const },
-      { ...rbtcVault, functionName: 'redeemRequestsPaused' as const },
-      { ...rbtcVault, functionName: 'asyncDepositRequests' as const, args: [address as Address] },
-      { ...rbtcVault, functionName: 'asyncRedeemRequests' as const, args: [address as Address] },
-      { ...rbtcVault, functionName: 'balanceOf' as const, args: [address as Address] },
-    ] as const
+    return getBtcVaultActionEligibilityContracts(address as Address)
   }, [address])
 
   const {

--- a/src/app/btc-vault/hooks/useActionEligibility/useActionEligibility.ts
+++ b/src/app/btc-vault/hooks/useActionEligibility/useActionEligibility.ts
@@ -54,9 +54,9 @@ export function useActionEligibility(address: string | undefined) {
   // Wagmi returns ContractFunctionResult[]; we assert the known 5-slot vault shape for fail-closed handling.
   const vaultData = rawVaultData as VaultMulticallData | undefined
 
-  const refetch = useCallback(() => {
-    void refetchVault()
-    void refetchWhitelist()
+  const refetch = useCallback(async () => {
+    await refetchVault()
+    await refetchWhitelist()
   }, [refetchVault, refetchWhitelist])
 
   const whitelistForMapper = whitelistLoading ? null : isWhitelisted

--- a/src/app/btc-vault/hooks/useActiveRequests/useActiveRequests.ts
+++ b/src/app/btc-vault/hooks/useActiveRequests/useActiveRequests.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import type { Address } from 'viem'
 import { zeroAddress } from 'viem'
 import { useReadContracts } from 'wagmi'
@@ -31,13 +31,13 @@ const HISTORY_API_PATH = '/api/btc-vault/v1/history'
  *   always null for claimable withdrawals only and while data is loading or unavailable.
  *   `claimableWithdrawRequest` — the withdrawal `VaultRequest` when the user can finalize (`claimRedeemNative`);
  *   mirrors history “Claim rBTC” / detail claim; null while loading or when no claimable redeem.
- *   `refetch()` — call after on-chain success: wagmi multicall results are not keyed like TanStack invalidation alone.
+ *   `refetch()` — call after on-chain success: awaits **parallel** phase1/phase2/history refetches (TanStack/wagmi reconcile order); do not serialize phase1→phase2 without an intervening render.
  */
 export function useActiveRequests(address: string | undefined): {
   data: ActiveRequestDisplay[] | undefined
   claimableDepositRequest: VaultRequest | null
   claimableWithdrawRequest: VaultRequest | null
-  refetch: () => void
+  refetch: () => Promise<void>
 } {
   const { prices } = usePricesContext()
   const rbtcPrice = prices[RBTC]?.price ?? 0
@@ -309,16 +309,23 @@ export function useActiveRequests(address: string | undefined): {
     historyData,
   ])
 
-  // Narrow refetch types to avoid wagmi's "excessively deep" type instantiation in useCallback deps
-  const doRefetchPhase1: () => void = refetchPhase1
-  const doRefetchPhase2: () => void = refetchPhase2
-  const doRefetchHistory: () => void = refetchHistory
+  const refetchPhase1Ref = useRef(refetchPhase1)
+  const refetchPhase2Ref = useRef(refetchPhase2)
+  const refetchHistoryRef = useRef(refetchHistory)
+  refetchPhase1Ref.current = refetchPhase1
+  refetchPhase2Ref.current = refetchPhase2
+  refetchHistoryRef.current = refetchHistory
 
-  const refetch = useCallback(() => {
-    doRefetchPhase1()
-    doRefetchPhase2()
-    doRefetchHistory()
-  }, [doRefetchPhase1, doRefetchPhase2, doRefetchHistory])
+  // Refs avoid wagmi "excessively deep" instantiation on useCallback deps while always calling latest refetch fns.
+  // Fire phase1/phase2/history refetches in parallel (same as pre-await behavior). Sequential await was wrong:
+  // after phase1 resolves, React has not necessarily recomputed phase2Contracts from new phase1Data yet, so
+  // awaiting phase2 next could no-op or refetch the wrong query shape — claimableWithdrawRequest could stay empty.
+  const refetch = useCallback(async (): Promise<void> => {
+    const r1 = (refetchPhase1Ref.current as () => unknown)()
+    const r2 = (refetchPhase2Ref.current as () => unknown)()
+    const r3 = (refetchHistoryRef.current as () => unknown)()
+    await Promise.all([Promise.resolve(r1), Promise.resolve(r2), Promise.resolve(r3)])
+  }, [])
 
   return { data, claimableDepositRequest, claimableWithdrawRequest, refetch }
 }

--- a/src/app/btc-vault/hooks/useBtcVaultFinalizeSharesFlow.ts
+++ b/src/app/btc-vault/hooks/useBtcVaultFinalizeSharesFlow.ts
@@ -1,0 +1,94 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useAccount } from 'wagmi'
+
+import { executeTxFlow } from '@/shared/notification'
+
+import { BTC_VAULT_BACKEND_INDEX_DELAY_MS } from '../constants'
+import type { RequestType, VaultRequest } from '../services/types'
+import { useBtcVaultInvalidation } from './useBtcVaultInvalidation'
+import { useClaimRequest } from './useClaimRequest'
+import { useClaimSharesFlowCommitted } from './useClaimSharesFlowCommitted'
+
+export interface UseBtcVaultFinalizeSharesFlowParams {
+  /** Claimable deposit or claimable withdrawal request from the parent; null when none. */
+  vaultRequest: VaultRequest | null
+  /** Which request shape this control handles (deposit = claim shares, withdrawal = redeem shares). */
+  expectedType: RequestType
+  /** After on-chain success: refresh active requests / eligibility (may be async). */
+  onAfterRefetch?: () => void | Promise<void>
+}
+
+export interface UseBtcVaultFinalizeSharesFlowResult {
+  /** True when the primary or busy button should render (wallet + matching claimable request + reads + eligibility). */
+  shouldRender: boolean
+  /** True while tx or refetch UI should show the busy branch. */
+  isBusy: boolean
+  /** Starts finalize tx flow (claim deposit or claim redeem per `useClaimRequest`). */
+  handleFinalize: () => Promise<void>
+}
+
+/**
+ * Shared orchestration for “finalize claimable vault action” on the dashboard:
+ * wagmi read + write state, `executeTxFlow`, cache invalidation, post-success refetch, and UI flags
+ * that avoid flicker (wagmi pending gap + props lagging after refetch).
+ */
+export function useBtcVaultFinalizeSharesFlow({
+  vaultRequest,
+  expectedType,
+  onAfterRefetch,
+}: UseBtcVaultFinalizeSharesFlowParams): UseBtcVaultFinalizeSharesFlowResult {
+  const { address } = useAccount()
+  const claimFlowLock = useRef(false)
+  const { isFlowCommitted, withFlowCommitUi } = useClaimSharesFlowCommitted()
+  const { invalidateAfterAction } = useBtcVaultInvalidation()
+  const { claim, canClaim, isRequesting, isTxPending, isReadingAmount, isReadingError } =
+    useClaimRequest(vaultRequest)
+  const [holdBusyAfterSuccess, setHoldBusyAfterSuccess] = useState(false)
+
+  const requestMatchesType =
+    !!vaultRequest && vaultRequest.type === expectedType && vaultRequest.status === 'claimable'
+
+  useEffect(() => {
+    if (!holdBusyAfterSuccess) return
+    if (!vaultRequest || vaultRequest.status !== 'claimable') {
+      setHoldBusyAfterSuccess(false)
+    }
+  }, [vaultRequest, holdBusyAfterSuccess])
+
+  const isBusy =
+    isFlowCommitted || isRequesting || isTxPending || (holdBusyAfterSuccess && requestMatchesType)
+
+  const readReady = !isReadingAmount && !isReadingError
+  const eligible = canClaim || isBusy
+
+  const shouldRender = !!address && requestMatchesType && readReady && eligible
+
+  const handleFinalize = useCallback(async () => {
+    if (!vaultRequest || vaultRequest.type !== expectedType || vaultRequest.status !== 'claimable') {
+      return
+    }
+    if (claimFlowLock.current) return
+    claimFlowLock.current = true
+    setHoldBusyAfterSuccess(false)
+    try {
+      await withFlowCommitUi(() =>
+        executeTxFlow({
+          action: 'btcVaultClaim',
+          onRequestTx: () => claim(),
+          onSuccess: async () => {
+            await new Promise(resolve => setTimeout(resolve, BTC_VAULT_BACKEND_INDEX_DELAY_MS))
+            invalidateAfterAction(vaultRequest.id)
+            await onAfterRefetch?.()
+            setHoldBusyAfterSuccess(true)
+          },
+        }),
+      )
+    } finally {
+      claimFlowLock.current = false
+    }
+  }, [vaultRequest, expectedType, claim, withFlowCommitUi, invalidateAfterAction, onAfterRefetch])
+
+  return { shouldRender, isBusy, handleFinalize }
+}

--- a/src/app/btc-vault/hooks/useBtcVaultInvalidation.test.ts
+++ b/src/app/btc-vault/hooks/useBtcVaultInvalidation.test.ts
@@ -1,12 +1,18 @@
+import { readContractsQueryKey } from '@wagmi/core/query'
 import { useQueryClient } from '@tanstack/react-query'
 import { renderHook } from '@testing-library/react'
-import { useAccount } from 'wagmi'
+import type { Address } from 'viem'
+import { useAccount, useChainId } from 'wagmi'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { getBtcVaultActionEligibilityContracts } from './get-btc-vault-action-eligibility-contracts'
 import { useBtcVaultInvalidation } from './useBtcVaultInvalidation'
+
+const mockChainId = 30
 
 vi.mock('wagmi', () => ({
   useAccount: vi.fn(),
+  useChainId: vi.fn(),
 }))
 
 vi.mock('@tanstack/react-query', () => ({
@@ -14,11 +20,12 @@ vi.mock('@tanstack/react-query', () => ({
 }))
 
 const mockInvalidateQueries = vi.fn()
-const mockAddress = '0xUserAddress'
+const mockAddress = '0x0000000000000000000000000000000000000001' as Address
 
 beforeEach(() => {
   vi.clearAllMocks()
   vi.mocked(useAccount).mockReturnValue({ address: mockAddress } as unknown as ReturnType<typeof useAccount>)
+  vi.mocked(useChainId).mockReturnValue(mockChainId)
   vi.mocked(useQueryClient).mockReturnValue({
     invalidateQueries: mockInvalidateQueries,
   } as unknown as ReturnType<typeof useQueryClient>)
@@ -26,16 +33,30 @@ beforeEach(() => {
 
 describe('useBtcVaultInvalidation', () => {
   describe('invalidateAfterSubmit', () => {
-    it('invalidates active-requests and action-eligibility', () => {
+    it('invalidates active-requests history and eligibility readContracts', () => {
       const { result } = renderHook(() => useBtcVaultInvalidation())
       result.current.invalidateAfterSubmit()
 
       expect(mockInvalidateQueries).toHaveBeenCalledTimes(2)
       expect(mockInvalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['btc-vault', 'active-requests', mockAddress],
+        queryKey: ['btc-vault', 'active-requests-history', mockAddress],
       })
       expect(mockInvalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['btc-vault', 'action-eligibility', mockAddress],
+        queryKey: readContractsQueryKey({
+          contracts: [...getBtcVaultActionEligibilityContracts(mockAddress)],
+          chainId: mockChainId,
+        }),
+      })
+    })
+
+    it('skips readContracts invalidation when wallet address is missing', () => {
+      vi.mocked(useAccount).mockReturnValue({ address: undefined } as unknown as ReturnType<typeof useAccount>)
+      const { result } = renderHook(() => useBtcVaultInvalidation())
+      result.current.invalidateAfterSubmit()
+
+      expect(mockInvalidateQueries).toHaveBeenCalledTimes(1)
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['btc-vault', 'active-requests-history', undefined],
       })
     })
   })
@@ -47,10 +68,13 @@ describe('useBtcVaultInvalidation', () => {
 
       expect(mockInvalidateQueries).toHaveBeenCalledTimes(5)
       expect(mockInvalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['btc-vault', 'active-requests', mockAddress],
+        queryKey: ['btc-vault', 'active-requests-history', mockAddress],
       })
       expect(mockInvalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['btc-vault', 'action-eligibility', mockAddress],
+        queryKey: readContractsQueryKey({
+          contracts: [...getBtcVaultActionEligibilityContracts(mockAddress)],
+          chainId: mockChainId,
+        }),
       })
       expect(mockInvalidateQueries).toHaveBeenCalledWith({
         queryKey: ['btc-vault', 'history', mockAddress],

--- a/src/app/btc-vault/hooks/useBtcVaultInvalidation.ts
+++ b/src/app/btc-vault/hooks/useBtcVaultInvalidation.ts
@@ -1,21 +1,34 @@
 import { useQueryClient } from '@tanstack/react-query'
+import { readContractsQueryKey } from '@wagmi/core/query'
 import { useCallback } from 'react'
-import { useAccount } from 'wagmi'
+import type { Address } from 'viem'
+import { useAccount, useChainId } from 'wagmi'
+
+import { getBtcVaultActionEligibilityContracts } from './get-btc-vault-action-eligibility-contracts'
 
 /**
  * Shared cache invalidation for BTC Vault mutations.
  *
- * - `invalidateAfterSubmit` — deposit/withdraw: invalidates active-requests + action-eligibility
+ * - `invalidateAfterSubmit` — deposit/withdraw: invalidates active-requests history and wagmi
+ *   `readContracts` for the eligibility multicall (same contract list as `useActionEligibility`)
  * - `invalidateAfterAction` — cancel/claim: invalidates the above plus request detail and history list
  */
 export function useBtcVaultInvalidation() {
   const queryClient = useQueryClient()
   const { address } = useAccount()
+  const chainId = useChainId()
 
   const invalidateAfterSubmit = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: ['btc-vault', 'active-requests', address] })
-    queryClient.invalidateQueries({ queryKey: ['btc-vault', 'action-eligibility', address] })
-  }, [queryClient, address])
+    queryClient.invalidateQueries({ queryKey: ['btc-vault', 'active-requests-history', address] })
+    if (address) {
+      queryClient.invalidateQueries({
+        queryKey: readContractsQueryKey({
+          contracts: [...getBtcVaultActionEligibilityContracts(address as Address)],
+          chainId,
+        }),
+      })
+    }
+  }, [queryClient, address, chainId])
 
   const invalidateAfterAction = useCallback(
     (requestId?: string) => {

--- a/src/app/btc-vault/hooks/useClaimSharesFlowCommitted.ts
+++ b/src/app/btc-vault/hooks/useClaimSharesFlowCommitted.ts
@@ -1,0 +1,23 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+
+/**
+ * Holds claim/redeem CTA in the in-progress branch for the full `executeTxFlow` call.
+ * Wagmi can briefly clear `isPending` on the write hook before receipt `isPending` is true;
+ * this covers that gap so the button does not flash back to clickable mid-flow.
+ */
+export function useClaimSharesFlowCommitted() {
+  const [isFlowCommitted, setIsFlowCommitted] = useState(false)
+
+  const withFlowCommitUi = useCallback(async (run: () => Promise<unknown>) => {
+    setIsFlowCommitted(true)
+    try {
+      await run()
+    } finally {
+      setIsFlowCommitted(false)
+    }
+  }, [])
+
+  return { isFlowCommitted, withFlowCommitUi }
+}

--- a/src/app/btc-vault/request-history/[id]/TransactionDetailPage.test.tsx
+++ b/src/app/btc-vault/request-history/[id]/TransactionDetailPage.test.tsx
@@ -287,7 +287,7 @@ describe('TransactionDetailPage', () => {
     })
   })
 
-  it('shows non-disabled Claiming… on claim button while only isTxPending', () => {
+  it('shows inert Claiming… (primary look) on claim button while only isTxPending', () => {
     mockUseRequestById.mockReturnValue({ data: { request: MOCK_WITHDRAWAL_CLAIMABLE, claimableInfo: null }, isLoading: false })
     mockUseClaimRequest.mockReturnValue({
       claim: mockClaim,
@@ -299,9 +299,10 @@ describe('TransactionDetailPage', () => {
       isTxPending: true,
     })
     renderWithTooltip(<TransactionDetailPage id="req-withdrawal-claimable" />)
-    const btn = screen.getByTestId('claim-button')
+    const btn = screen.getByTestId('claim-button') as HTMLButtonElement
     expect(btn).toHaveTextContent('Claiming...')
-    expect(btn).not.toBeDisabled()
+    expect(btn.disabled).toBe(false)
+    expect(btn).toHaveAttribute('aria-disabled', 'true')
     fireEvent.click(btn)
     expect(mockExecuteTxFlow).not.toHaveBeenCalled()
   })

--- a/src/app/btc-vault/request-history/[id]/components/TransactionDetailView.tsx
+++ b/src/app/btc-vault/request-history/[id]/components/TransactionDetailView.tsx
@@ -3,6 +3,7 @@
 import { ConditionalTooltip } from '@/app/components/Tooltip/ConditionalTooltip'
 import { Button } from '@/components/Button'
 import { Header } from '@/components/Typography'
+import { cn } from '@/lib/utils'
 
 import { BTC_VAULT_CLAIM_IN_PROGRESS_MESSAGE } from '../../../constants'
 import type { RequestStatus, RequestType } from '../../../services/types'
@@ -49,9 +50,18 @@ export function TransactionDetailView({
                 },
               ]}
             >
-              <Button variant="primary" data-testid="claim-button" disabled={false} onClick={() => {}}>
-                Claiming...
-              </Button>
+              <span className="inline-block w-full cursor-default md:w-fit">
+                <Button
+                  variant="primary"
+                  className={cn('pointer-events-none')}
+                  data-testid="claim-button"
+                  aria-disabled
+                  aria-busy
+                  tabIndex={-1}
+                >
+                  Claiming...
+                </Button>
+              </span>
             </ConditionalTooltip>
           ) : (
             <Button variant="primary" data-testid="claim-button" onClick={onClaim} disabled={!onClaim}>


### PR DESCRIPTION
## Why this exists

After someone claims shares from a settled deposit or redeems from a claimable withdrawal, the vault UI has to catch up with reality: what the contracts still consider claimable, what the indexer shows, and whether **Deposit** / **Withdraw** should unlock again. If refetches race each other or finish in an order that leaves derived state half-updated, users can see **actions stuck disabled** or **Redeem** vanishing until a hard refresh. That is confusing and looks like a broken vault.

Separately, wagmi’s pending flags do not always cover the whole hand-off from “user signed” to “receipt pending.” There is a short window where a button can look clickable again even though the flow is still running, which invites double submits and erodes trust.

## What we optimized for

**Consistent refetch semantics**  
The page-level “active requests” data is assembled from more than one read pass plus history. Waiting for one pass before starting the next can actually be wrong here: React may not have rebuilt the second batch of contract calls from the newest first-pass snapshot yet, so the follow-up refetch can run against stale inputs. Firing the related refetches together again matches the behavior that already worked in production and avoids subtle “redeem disappeared” regressions.

**Eligibility that really means “ready”**  
Deposit and withdraw availability comes from vault multicall reads plus whitelist state. When a finalize succeeds, downstream code needs `refetch()` to mean “all of that settled,” not “we kicked off work.” Vault reads are awaited before whitelist so the mapper does not briefly mix a new vault snapshot with an old whitelist result.

**One finalize story for claim and redeem**  
Dashboard claim and redeem are the same orchestration at the transaction layer. Centralizing that in one hook keeps invalidation, post-success refetch, and busy rules identical so fixes apply to both paths.

**Busy UI that matches the risk**  
We keep the primary look during the flow but avoid native `disabled` (which greys out and fights the “primary in progress” design), wrap for tooltip hit target, and track an explicit “user committed to this flow” bit across wagmi’s pending gap. We also hold busy until claimable props actually clear so the label does not snap back to “Claim shares” / “Redeem shares” for a frame while the parent is still catching up.

**Dashboard then detail**  
The dashboard wires post-finalize work so parent refetch finishes before action eligibility refetch, keeping the metrics row and the actions row in sync. The request detail page gets the same in-progress expectations so behavior matches what users see on the main vault screen.

---

_Tracks DAO-2251._