### PR TITLE
DAO-2252: Align "Claim rBTC" to be present on all 3 places instead of different naming

### DIFF
--- a/src/app/btc-vault/components/BtcVaultDashboard.test.tsx
+++ b/src/app/btc-vault/components/BtcVaultDashboard.test.tsx
@@ -323,7 +323,7 @@ describe('BtcVaultDashboard', () => {
     expect(probe).toHaveAttribute('data-has-refetch', 'yes')
   })
 
-  it('forwards claimableWithdrawRequest and onAfterRedeemRefetch to Redeem Shares', () => {
+  it('forwards claimableWithdrawRequest and onAfterRedeemRefetch to Claim rBTC', () => {
     const onRefetch = vi.fn()
     const claimableWithdraw: VaultRequest = {
       id: 'red-dash-probe',
@@ -344,7 +344,7 @@ describe('BtcVaultDashboard', () => {
     expect(probe).toHaveAttribute('data-has-refetch', 'yes')
   })
 
-  it('passes null claimableWithdrawRequest to Redeem Shares when omitted', () => {
+  it('passes null claimableWithdrawRequest to Claim rBTC when omitted', () => {
     render(<BtcVaultDashboard />, { wrapper: Wrapper })
     const probe = screen.getByTestId('btc-vault-redeem-shares-probe')
     expect(probe).toHaveAttribute('data-request-id', '')

--- a/src/app/btc-vault/components/BtcVaultRedeemSharesButton.test.tsx
+++ b/src/app/btc-vault/components/BtcVaultRedeemSharesButton.test.tsx
@@ -189,7 +189,7 @@ describe('BtcVaultRedeemSharesButton', () => {
     await waitFor(() => expect(mockExecuteTxFlow).toHaveBeenCalledTimes(1))
   })
 
-  it('shows Redeem Shares and calls executeTxFlow with btcVaultClaim on click', async () => {
+  it('shows Claim rBTC and calls executeTxFlow with btcVaultClaim on click', async () => {
     render(
       <BtcVaultRedeemSharesButton
         vaultRequest={MOCK_CLAIMABLE_WITHDRAWAL}
@@ -198,7 +198,7 @@ describe('BtcVaultRedeemSharesButton', () => {
       { wrapper: TestWrapper },
     )
 
-    expect(screen.getByTestId('btc-vault-redeem-shares-button')).toHaveTextContent('Redeem Shares')
+    expect(screen.getByTestId('btc-vault-redeem-shares-button')).toHaveTextContent('Claim rBTC')
     fireEvent.click(screen.getByTestId('btc-vault-redeem-shares-button'))
 
     await waitFor(() => {

--- a/src/app/btc-vault/components/BtcVaultRedeemSharesButton.tsx
+++ b/src/app/btc-vault/components/BtcVaultRedeemSharesButton.tsx
@@ -47,7 +47,7 @@ export function BtcVaultRedeemSharesButton({
       disabled={false}
       onClick={handleFinalize}
     >
-      Redeem Shares
+      Claim rBTC
     </Button>
   )
 }


### PR DESCRIPTION

<img width="1413" height="691" alt="Screenshot 2026-04-15 at 13 11 52" src="https://github.com/user-attachments/assets/89bb6999-35b5-4682-afb7-4b05a9f72d84" />
<img width="1373" height="128" alt="Screenshot 2026-04-15 at 13 11 57" src="https://github.com/user-attachments/assets/7ef48e80-352f-4a37-825f-f7b6e4943254" />
<img width="1324" height="499" alt="Screenshot 2026-04-15 at 13 12 04" src="https://github.com/user-attachments/assets/6e3c278b-50bf-42ae-b94c-93fe39c8126a" />


## Summary

After a withdrawal request has gone through the vault’s batching and settlement flow, the user still has one on-chain step: receive native rBTC by finalizing the redeem (the same path already labeled **Claim rBTC** in request history and on the transaction detail screen).

On the main BTC Vault dashboard that final step was labeled **Redeem Shares**, which reads like a different action (redeeming share tokens) even though it is the same user intent and the same finalize flow as elsewhere: **claim the rBTC payout** for a claimable withdrawal.

## Why this change

- **One action, one name:** Using **Claim rBTC** on the dashboard removes ambiguity and matches the language users already see when they open history or the detail page for the same request.
- **Scope is intentionally narrow:** This is a **call-to-action label** on the withdrawal finalize control only. Status copy (for example progress step labels and table status badges) stays as-is so “what state is this request in?” remains separate from “what button do I press to finish?”.

## For reviewers

No contract or routing changes—display copy and tests only. If you are new to the vault UI, think of this as renaming the last interactive step of a withdrawal so it matches the rest of the product instead of introducing a second phrase for the same operation.