### PR TITLE
fix(DAO-2233): copy generated Prisma Client into runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,10 @@ COPY --from=builder /app/.env.local ./.env.local
 # Copy production-only node_modules from prod-deps stage (built in parallel)
 COPY --from=prod-deps /app/node_modules ./node_modules
 
+# Copy the generated Prisma Client (created by postinstall in the builder stage).
+# prod-deps ran with --ignore-scripts, so .prisma/client is missing from its node_modules.
+COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
+
 # Copy Prisma schema and migrations
 COPY --from=builder /app/prisma ./prisma
 


### PR DESCRIPTION
## Summary
- Fixes runtime crash `Cannot find module '.prisma/client/default'` in the deployed container, which surfaces as 500s on Proposals and any route importing Prisma (e.g. `/api/like`).
- Root cause: the `prod-deps` Dockerfile stage runs `npm ci --omit=dev --ignore-scripts`, so `prisma generate` never creates `node_modules/.prisma/client` there. The `runner` stage only copies `node_modules` from `prod-deps`, so the generated Prisma Client is missing from the final image. A comment on `prod-deps` claims the generated client is copied from `builder` — but that copy was never actually added.
- Adds a single `COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma` to the runner stage so the client generated during `builder`'s `npm ci` postinstall makes it into the running container.

Complements #2110 (connection-pool cap). This fix addresses the missing-client crash; #2110 addresses pool exhaustion under load. Both are for DAO-2233.