### PR TITLE
feat(db): tag database connections with application_name for profiling

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -4,11 +4,20 @@ import { sslConfig } from './dbUtils'
 
 const globalForDb = globalThis as typeof globalThis & { _db?: Knex }
 
+const withAppName = (url: string | undefined, name: string): string | undefined => {
+  if (!url) return url
+  const sep = url.includes('?') ? '&' : '?'
+  return `${url}${sep}application_name=${encodeURIComponent(name)}`
+}
+
 if (!globalForDb._db) {
+  const profile = process.env.NEXT_PUBLIC_PROFILE ?? 'local'
   globalForDb._db = knex({
     client: 'pg',
     connection: {
-      connectionString: process.env.DB_CONNECTION_STRING,
+      // Tag connections with application_name via the URL — the top-level option
+      // is ignored by pg when `connectionString` is set.
+      connectionString: withAppName(process.env.DB_CONNECTION_STRING, `dao-frontend-knex-${profile}`),
       ssl: sslConfig,
     },
     pool: { min: 0, max: 5 },

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -7,9 +7,11 @@ const globalForPrisma = globalThis as typeof globalThis & {
 }
 
 if (url && !globalForPrisma._prisma) {
+  const profile = process.env.NEXT_PUBLIC_PROFILE ?? 'local'
+  const appName = encodeURIComponent(`dao-frontend-prisma-${profile}`)
   const separator = url.includes('?') ? '&' : '?'
   globalForPrisma._prisma = new PrismaClient({
-    datasources: { db: { url: `${url}${separator}connection_limit=5` } },
+    datasources: { db: { url: `${url}${separator}connection_limit=5&application_name=${appName}` } },
   })
 }
 


### PR DESCRIPTION
Add `application_name` to Prisma and Knex connection strings using `NEXT_PUBLIC_PROFILE` to enable environment-specific connection tagging for easier database profiling and debugging.