### PR TITLE
fix(btc-vault): stack shares and metrics vertically on mobile in deposit modal

### DIFF
--- a/src/app/btc-vault/components/DepositAmountStep.tsx
+++ b/src/app/btc-vault/components/DepositAmountStep.tsx
@@ -172,7 +172,7 @@ export const DepositAmountStep = ({
       </div>
 
       {/* --- Shares Estimate + Fee --- */}
-      <div className="flex gap-10 mt-4 px-3">
+      <div className="flex flex-col gap-4 mt-4 px-3 md:flex-row md:gap-10">
         <div className="flex flex-col gap-1" data-testid="review-shares">
           <Label variant="body-s" className="text-text-60">
             No. of shares to receive (est.)

--- a/src/app/btc-vault/components/DepositReviewStep.tsx
+++ b/src/app/btc-vault/components/DepositReviewStep.tsx
@@ -58,7 +58,7 @@ export const DepositReviewStep = ({
         Make sure that everything is correct before continuing:
       </Paragraph>
 
-      <div className="grid grid-cols-2 gap-y-6 gap-x-10">
+      <div className="grid grid-cols-1 gap-y-4 md:grid-cols-2 md:gap-y-6 md:gap-x-10">
         <div className="flex flex-col gap-1" data-testid="review-amount">
           <Label variant="body-s" className="text-text-60">
             Amount to deposit

--- a/src/app/communities/components/SectionContainer.tsx
+++ b/src/app/communities/components/SectionContainer.tsx
@@ -38,7 +38,7 @@ export const SectionContainer = ({
       <Header variant={headerVariant} className="flex-1">
         {title}
       </Header>
-      {rightContent && <p className="flex-1">{rightContent}</p>}
+      {rightContent && <div className="flex-1">{rightContent}</div>}
     </div>
     <div className={cn('mt-8', contentClassName)} data-testid="SectionContainerContent">
       {children}


### PR DESCRIPTION
## Ticket
[DAO-2185](https://rsklabs.atlassian.net/browse/DAO-2185) — BTC Vault mobile — improve shares to receive display in deposit modal

## Summary
- Stack shares estimate and fee info vertically on mobile instead of forcing a horizontal layout
- Switch review step metrics grid to single-column on mobile, two-column on desktop

## Screenshots
### Before
<img width="405" height="854" alt="Screenshot 2026-04-16 at 03 05 08" src="https://github.com/user-attachments/assets/2e81f325-8185-4fd4-a086-4511b4b1a80b" />
### After
<img width="389" height="845" alt="Screenshot 2026-04-16 at 03 07 07" src="https://github.com/user-attachments/assets/65c43f9a-9e1c-434a-8aa4-257313553cc8" />


## Test Plan
- Open `/btc-vault` → Deposit modal on a narrow viewport (< 768px)
- Amount step: verify "No. of shares to receive" and "Deposit fee" stack vertically
- Review step: verify all four metrics (amount, shares, fee, completion) stack in a single column
- Desktop (>= 768px): verify both steps retain horizontal/grid layout as before