### PR TITLE
fix(btc-vault): stack deposit modal footer vertically on mobile

### DIFF
--- a/src/app/btc-vault/components/DepositAmountStep.tsx
+++ b/src/app/btc-vault/components/DepositAmountStep.tsx
@@ -194,8 +194,12 @@ export const DepositAmountStep = ({
       {/* --- Footer: Disclaimer + Continue --- */}
       <div className="mt-auto pt-4">
         <Divider />
-        <div className="flex justify-between items-center gap-4 pt-4">
-          <Paragraph variant="body-s" className="text-text-60 text-xs max-w-[440px]" data-testid="Disclaimer">
+        <div className="flex flex-col gap-4 pt-4 md:flex-row md:justify-between md:items-center">
+          <Paragraph
+            variant="body-s"
+            className="text-text-60 text-xs md:max-w-[440px]"
+            data-testid="Disclaimer"
+          >
             {BTC_VAULT_DEPOSIT_DISCLAIMER}
           </Paragraph>
           <Button variant="primary" onClick={onNext} disabled={!isValid} data-testid="ContinueButton">

--- a/src/app/btc-vault/components/DepositReviewStep.tsx
+++ b/src/app/btc-vault/components/DepositReviewStep.tsx
@@ -105,10 +105,14 @@ export const DepositReviewStep = ({
       </div>
 
       {/* Footer: 56px gap then divider, disclaimer + Back + Send request */}
-      <div className="mt-auto pt-14">
+      <div className="mt-auto pt-6 md:pt-14">
         <Divider />
-        <div className="flex justify-between items-center gap-4">
-          <Paragraph variant="body-s" className="text-text-60 text-xs max-w-[440px]" data-testid="Disclaimer">
+        <div className="flex flex-col gap-4 md:flex-row md:justify-between md:items-center">
+          <Paragraph
+            variant="body-s"
+            className="text-text-60 text-xs md:max-w-[440px]"
+            data-testid="Disclaimer"
+          >
             {BTC_VAULT_DEPOSIT_DISCLAIMER}
           </Paragraph>
           <div className="flex items-center gap-3">


### PR DESCRIPTION
## Ticket
[DAO-2184](https://rsklabs.atlassian.net/browse/DAO-2184) — BTC Vault mobile — fix deposit modal footer layout

## Summary
- Stack disclaimer text and action buttons vertically on mobile instead of cramming them on one line
- Reduce excessive top padding on the review step footer for mobile viewports

## Screenshots
### Before
<img width="424" height="160" alt="Screenshot 2026-04-16 at 03 29 37" src="https://github.com/user-attachments/assets/a7e1e740-f53e-4e42-85b4-8db371d3c459" />

### After

<img width="417" height="180" alt="Screenshot 2026-04-16 at 03 31 29" src="https://github.com/user-attachments/assets/14da971f-d643-4eaa-9549-67dbdbe01326" />

## Test Plan
- Open `/btc-vault` → Deposit modal on a narrow viewport (< 768px)
- Amount step: verify disclaimer text is above the "Continue" button with spacing between them
- Review step: verify disclaimer is above "Back" / "Send request" buttons, spacing is reasonable
- Desktop (>= 768px): verify both steps retain the horizontal layout as before