### PR TITLE
fix(table-pager): add proper spacing to pager count text

### DIFF
--- a/src/components/TableNew/TablePager.tsx
+++ b/src/components/TableNew/TablePager.tsx
@@ -48,7 +48,7 @@ const PagerCount = ({
     className="text-v3-bg-accent-0 select-none first-letter:uppercase"
     data-testid="table-pager-count"
   >
-    {itemName} {start}– {end}out of {total}
+    {itemName} {start} – {end} out of {total}
   </Paragraph>
 )
 type NextPageHandler = (props: {


### PR DESCRIPTION
Fixes pager text from "{itemName} {start}– {end}out of {total}" to "{itemName} {start} – {end} out of {total}"