### PR TITLE
fix(table-pager): add proper spacing to pager count text

### DIFF
--- a/src/components/TableNew/TablePager.tsx
+++ b/src/components/TableNew/TablePager.tsx
@@ -48,7 +48,7 @@ const PagerCount = ({
     className="text-v3-bg-accent-0 select-none first-letter:uppercase"
     data-testid="table-pager-count"
   >
-    {itemName} {start}– {end}out of {total}
+    {itemName} {start} – {end} out of {total}
   </Paragraph>
 )
 type NextPageHandler = (props: {


### PR DESCRIPTION
Fixes pager text. An issue introduced [here](https://github.com/RootstockCollective/dao-frontend/commit/ea6d24e084b6e81bb555555ac66c445dcbe2344d#diff-bddf1cd9939b1c393a90ee095c9fe93a7d72ce61185be197101214e74c387316R51).

<img width="166" height="50" alt="image" src="https://github.com/user-attachments/assets/a3d49de3-790b-4a33-91d3-7ba3a6c063af" />
