### PR TITLE
fix(btc-vault): correct APY calculation in deposit history (DAO-2254)

### DIFF
--- a/src/app/api/btc-vault/v1/epoch-history/action.test.ts
+++ b/src/app/api/btc-vault/v1/epoch-history/action.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+
+import { attachApy, type EpochSettledEventDto } from './action'
+
+function baseDto(overrides: Partial<EpochSettledEventDto>): EpochSettledEventDto {
+  return {
+    epochId: '0',
+    reportedOffchainAssets: '0',
+    assets: '0',
+    supply: '0',
+    closedAt: '0',
+    apy: null,
+    ...overrides,
+  }
+}
+
+describe('attachApy', () => {
+  it('returns empty array for empty input', () => {
+    expect(attachApy([])).toEqual([])
+  })
+
+  it('leaves apy null on the oldest (only) row', () => {
+    const dtos: EpochSettledEventDto[] = [baseDto({ epochId: '1', assets: '1000', supply: '1000', closedAt: '1500000' })]
+    const result = attachApy(dtos)
+    expect(result).toHaveLength(1)
+    expect(result[0].apy).toBeNull()
+  })
+
+  it('compounds per-period share-price ratios into apy for 3 consecutive epochs', () => {
+    // 3 epochs, descending, synthetic small-integer data (100000s-second epochs).
+    // Expected apy values computed offline from computeIndicativeApy:
+    //   row 0: priceRatio = (3000/2800) / (2000/1900) ≈ 1.01786, elapsed = 100000s,
+    //          apy = 1.01786^(31557600/100000) - 1 ≈ 265.55 (i.e. 26555%; synthetic data).
+    //   row 1: priceRatio = (2000/1900) / (1000/1000) ≈ 1.0526, elapsed = 100000s,
+    //          apy = 1.0526^315.576 - 1 ≈ 1.07e7 (extreme; synthetic data).
+    const dtos: EpochSettledEventDto[] = [
+      baseDto({ epochId: '3', assets: '3000', supply: '2800', closedAt: '1700000' }),
+      baseDto({ epochId: '2', assets: '2000', supply: '1900', closedAt: '1600000' }),
+      baseDto({ epochId: '1', assets: '1000', supply: '1000', closedAt: '1500000' }),
+    ]
+    const result = attachApy(dtos)
+    expect(result).toHaveLength(3)
+    expect(result[0].apy).toBeCloseTo(265.55, 1)
+    expect(result[1].apy).toBeCloseTo(10712614.99, -2)
+    expect(result[2].apy).toBeNull()
+  })
+
+  it('returns null apy when prior epoch is bootstrap (zero supply)', () => {
+    // Real-world bootstrap: epoch 1 has zero supply, epoch 2 is the first real deposit.
+    // computeIndicativeApy guards supplyAtClose === 0n and returns null — so the newer
+    // row gets null apy (no meaningful yield baseline), and the oldest is null by rule.
+    const dtos: EpochSettledEventDto[] = [
+      baseDto({
+        epochId: '2',
+        assets: '191188999214597',
+        supply: '191188999214597000000',
+        closedAt: '1776242196',
+      }),
+      baseDto({
+        epochId: '1',
+        assets: '0',
+        supply: '0',
+        closedAt: '1774988172',
+      }),
+    ]
+    const result = attachApy(dtos)
+    expect(result[0].apy).toBeNull()
+    expect(result[1].apy).toBeNull()
+  })
+
+  it('compounds 14-day share-price growth into ≈21.69% and ≈4.17% apy', () => {
+    // Supply fixed at 1.91189e20, assets grow each 14.5-day (~1254024s) epoch.
+    //   row 0 (epoch 3 vs 2): priceRatio ≈ 193/191.5 ≈ 1.00783, elapsed = 1254024s,
+    //          periodsPerYear ≈ 25.164, apy = 1.00783^25.164 - 1 ≈ 0.2169 (21.69%).
+    //   row 1 (epoch 2 vs 1): priceRatio ≈ 191500/191188.999... ≈ 1.001626,
+    //          apy = 1.001626^25.164 - 1 ≈ 0.0417 (4.17%).
+    const dtos: EpochSettledEventDto[] = [
+      baseDto({
+        epochId: '3',
+        assets: '193000000000000',
+        supply: '191188999214597000000',
+        closedAt: '1777496220',
+      }),
+      baseDto({
+        epochId: '2',
+        assets: '191500000000000',
+        supply: '191188999214597000000',
+        closedAt: '1776242196',
+      }),
+      baseDto({
+        epochId: '1',
+        assets: '191188999214597',
+        supply: '191188999214597000000',
+        closedAt: '1774988172',
+      }),
+    ]
+    const result = attachApy(dtos)
+    expect(result[0].apy).toBeCloseTo(0.2169, 3)
+    expect(result[1].apy).toBeCloseTo(0.0417, 3)
+    expect(result[2].apy).toBeNull()
+  })
+
+  it('confines bootstrap null to the next epoch and compounds ≈11.24% apy for the one after', () => {
+    // Epoch 1: bootstrap (zeros). Epoch 2: first real deposit. Epoch 3: yield accrued.
+    // Expected propagation: only epoch 2 gets null (its prior is bootstrap); epoch 3
+    // compares against epoch 2 (both have real supply) and produces a positive apy.
+    //   row 0 (epoch 3 vs 2): priceRatio ≈ 192/191.188999... ≈ 1.004242,
+    //          elapsed = 1254024s, apy = 1.004242^25.164 - 1 ≈ 0.1124 (11.24%).
+    const dtos: EpochSettledEventDto[] = [
+      baseDto({
+        epochId: '3',
+        assets: '192000000000000',
+        supply: '191188999214597000000',
+        closedAt: '1777496220',
+      }),
+      baseDto({
+        epochId: '2',
+        assets: '191188999214597',
+        supply: '191188999214597000000',
+        closedAt: '1776242196',
+      }),
+      baseDto({
+        epochId: '1',
+        assets: '0',
+        supply: '0',
+        closedAt: '1774988172',
+      }),
+    ]
+    const result = attachApy(dtos)
+    expect(result[0].apy).toBeCloseTo(0.1124, 3)
+    expect(result[1].apy).toBeNull()
+    expect(result[2].apy).toBeNull()
+  })
+
+  it('preserves the other DTO fields unchanged', () => {
+    const dtos: EpochSettledEventDto[] = [
+      baseDto({ epochId: '2', reportedOffchainAssets: '123', assets: '2000', supply: '1900', closedAt: '1600000' }),
+      baseDto({ epochId: '1', reportedOffchainAssets: '456', assets: '1000', supply: '1000', closedAt: '1500000' }),
+    ]
+    const result = attachApy(dtos)
+    expect(result[0].epochId).toBe('2')
+    expect(result[0].reportedOffchainAssets).toBe('123')
+    expect(result[0].assets).toBe('2000')
+    expect(result[0].supply).toBe('1900')
+    expect(result[0].closedAt).toBe('1600000')
+  })
+})

--- a/src/app/api/btc-vault/v1/epoch-history/action.ts
+++ b/src/app/api/btc-vault/v1/epoch-history/action.ts
@@ -4,10 +4,15 @@ import {
   type EpochSettledEvent,
   fetchEpochSettledLogs,
 } from '@/app/btc-vault/hooks/useDepositHistory/fetchEpochSettledLogs'
+import { computeIndicativeApy } from '@/lib/apy'
 
 /**
  * Serialisable version of EpochSettledEvent for JSON responses.
  * bigint is not JSON-serialisable, so we convert to string.
+ *
+ * `apy` is populated by `attachApy` after the source fetch. It is a decimal
+ * (e.g. 0.05 = 5%) computed against the next-older epoch, or null when the
+ * comparison is not meaningful (oldest row, bootstrap prior, etc.).
  */
 export interface EpochSettledEventDto {
   epochId: string
@@ -15,6 +20,7 @@ export interface EpochSettledEventDto {
   assets: string
   supply: string
   closedAt: string
+  apy: number | null
 }
 
 function toDto(event: EpochSettledEvent): EpochSettledEventDto {
@@ -24,7 +30,35 @@ function toDto(event: EpochSettledEvent): EpochSettledEventDto {
     assets: event.assets.toString(),
     supply: event.supply.toString(),
     closedAt: event.closedAt.toString(),
+    apy: null,
   }
+}
+
+/**
+ * Populates `apy` on each DTO by comparing against the next-older epoch.
+ * Expects input sorted **descending** by epochId (newest first), matching
+ * the output contract of every source adapter.
+ *
+ * `apy` is a decimal (0.05 = 5%). The oldest row stays null.
+ */
+export function attachApy(dtos: EpochSettledEventDto[]): EpochSettledEventDto[] {
+  return dtos.map((dto, i) => {
+    const prev = dtos[i + 1]
+    if (!prev) return dto
+    const apy = computeIndicativeApy(
+      {
+        closedAt: BigInt(dto.closedAt),
+        assetsAtClose: BigInt(dto.assets),
+        supplyAtClose: BigInt(dto.supply),
+      },
+      {
+        closedAt: BigInt(prev.closedAt),
+        assetsAtClose: BigInt(prev.assets),
+        supplyAtClose: BigInt(prev.supply),
+      },
+    )
+    return { ...dto, apy }
+  })
 }
 
 /** Named data sources. Add new sources here as they become available. */
@@ -69,7 +103,7 @@ export async function fetchEpochHistory(): Promise<EpochHistoryResult> {
     try {
       const epochs = await fetch()
       if (epochs.length > 0) {
-        return { epochs, source: name, errors }
+        return { epochs: attachApy(epochs), source: name, errors }
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)

--- a/src/app/btc-vault/hooks/useDepositHistory/deriveDepositWindows.test.ts
+++ b/src/app/btc-vault/hooks/useDepositHistory/deriveDepositWindows.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { EpochSettledEventDto } from '@/app/api/btc-vault/v1/epoch-history/action'
 
-import { buildDepositWindowRows, deriveApy, derivePricePerShare } from './deriveDepositWindows'
+import { buildDepositWindowRows, derivePricePerShare } from './deriveDepositWindows'
 
 describe('derivePricePerShare', () => {
   it('computes price per share with known values', () => {
@@ -24,31 +24,6 @@ describe('derivePricePerShare', () => {
   })
 })
 
-describe('deriveApy', () => {
-  it('computes annualised yield for known values', () => {
-    const currentNav = 1100n * 10n ** 18n
-    const previousNav = 1000n * 10n ** 18n
-    // 30 days apart
-    const previousClosedAt = 1_000_000
-    const currentClosedAt = 1_000_000 + 30 * 24 * 60 * 60
-
-    const result = deriveApy(currentNav, previousNav, currentClosedAt, previousClosedAt)
-    expect(result).not.toBeNull()
-    // 10% return over 30 days annualised: (0.1 / 2592000) * 31557600 * 100 ≈ 121.7%
-    expect(result).toBeCloseTo(121.74, 0)
-  })
-
-  it('returns null when previousNav is 0n', () => {
-    const result = deriveApy(1000n, 0n, 2000, 1000)
-    expect(result).toBeNull()
-  })
-
-  it('returns null when duration is 0', () => {
-    const result = deriveApy(1100n, 1000n, 1000, 1000)
-    expect(result).toBeNull()
-  })
-})
-
 describe('buildDepositWindowRows', () => {
   const THREE_DTOS: EpochSettledEventDto[] = [
     {
@@ -57,6 +32,7 @@ describe('buildDepositWindowRows', () => {
       assets: '3000',
       supply: '2800',
       closedAt: '1700000',
+      apy: 0.12,
     },
     {
       epochId: '2',
@@ -64,6 +40,7 @@ describe('buildDepositWindowRows', () => {
       assets: '2000',
       supply: '1900',
       closedAt: '1600000',
+      apy: 0.08,
     },
     {
       epochId: '1',
@@ -71,6 +48,7 @@ describe('buildDepositWindowRows', () => {
       assets: '1000',
       supply: '1000',
       closedAt: '1500000',
+      apy: null,
     },
   ]
 
@@ -78,20 +56,20 @@ describe('buildDepositWindowRows', () => {
     const rows = buildDepositWindowRows(THREE_DTOS)
     expect(rows).toHaveLength(3)
 
-    // First row (epoch 3) — has startDate from epoch 2 and APY
+    // First row (epoch 3) — has startDate from epoch 2 and APY passed through (×100)
     expect(rows[0].epochId).toBe('3')
     expect(rows[0].endDate).toBe(1700000)
     expect(rows[0].startDate).toBe(1600000)
     expect(rows[0].tvl).toBe(3000n)
     expect(rows[0].pricePerShare).toBe(derivePricePerShare(3000n, 2800n))
-    expect(rows[0].apy).not.toBeNull()
+    expect(rows[0].apy).toBeCloseTo(12, 5)
     expect(rows[0].status).toBe('settled')
 
-    // Second row (epoch 2) — has startDate from epoch 1 and APY
+    // Second row (epoch 2) — has startDate from epoch 1 and APY passed through (×100)
     expect(rows[1].epochId).toBe('2')
     expect(rows[1].endDate).toBe(1600000)
     expect(rows[1].startDate).toBe(1500000)
-    expect(rows[1].apy).not.toBeNull()
+    expect(rows[1].apy).toBeCloseTo(8, 5)
 
     // Third row (epoch 1) — oldest, startDate=null, apy=null
     expect(rows[2].epochId).toBe('1')
@@ -114,6 +92,7 @@ describe('buildDepositWindowRows', () => {
         assets: '1000',
         supply: '1000',
         closedAt: '1500000',
+        apy: null,
       },
     ]
     const rows = buildDepositWindowRows(single)
@@ -127,5 +106,29 @@ describe('buildDepositWindowRows', () => {
   it('returns empty array for empty input', () => {
     const rows = buildDepositWindowRows([])
     expect(rows).toEqual([])
+  })
+
+  it('passes through null apy from DTO', () => {
+    const dtos: EpochSettledEventDto[] = [
+      {
+        epochId: '2',
+        reportedOffchainAssets: '0',
+        assets: '2000',
+        supply: '1900',
+        closedAt: '1600000',
+        apy: null,
+      },
+      {
+        epochId: '1',
+        reportedOffchainAssets: '0',
+        assets: '1000',
+        supply: '1000',
+        closedAt: '1500000',
+        apy: null,
+      },
+    ]
+    const rows = buildDepositWindowRows(dtos)
+    expect(rows[0].apy).toBeNull()
+    expect(rows[1].apy).toBeNull()
   })
 })

--- a/src/app/btc-vault/hooks/useDepositHistory/deriveDepositWindows.ts
+++ b/src/app/btc-vault/hooks/useDepositHistory/deriveDepositWindows.ts
@@ -3,7 +3,6 @@ import type { EpochSettledEventDto } from '@/app/api/btc-vault/v1/epoch-history/
 import type { DepositWindowRow } from '../../services/types'
 
 const SCALE = 10n ** 18n
-const SECONDS_PER_YEAR = 365.25 * 24 * 60 * 60
 
 /**
  * Derives the price-per-share (NAV per share) from total assets and total supply.
@@ -16,31 +15,6 @@ export function derivePricePerShare(assets: bigint, supply: bigint): bigint {
 }
 
 /**
- * Derives annualised percentage yield from two consecutive epoch NAVs and their timestamps.
- * Returns a float percentage (e.g. 12.5 means 12.5%).
- *
- * Returns `null` when the calculation would be meaningless:
- * - previousNav is 0n (no prior reference point)
- * - duration between epochs is 0 (division by zero)
- */
-export function deriveApy(
-  currentNav: bigint,
-  previousNav: bigint,
-  currentClosedAt: number,
-  previousClosedAt: number,
-): number | null {
-  if (previousNav === 0n) return null
-
-  const durationSeconds = currentClosedAt - previousClosedAt
-  if (durationSeconds === 0) return null
-
-  const periodReturn = Number(currentNav - previousNav) / Number(previousNav)
-  const annualised = (periodReturn / durationSeconds) * SECONDS_PER_YEAR * 100
-
-  return annualised
-}
-
-/**
  * Transforms an array of EpochSettledEventDto into DepositWindowRow[].
  *
  * Expects input sorted **descending** by epochId (newest first).
@@ -49,7 +23,7 @@ export function deriveApy(
  * For each epoch:
  * - `startDate` is the previous epoch's `closedAt` (null for the oldest epoch)
  * - `endDate` is this epoch's `closedAt`
- * - `apy` is derived from this epoch and the previous epoch's NAV (null for the oldest)
+ * - `apy` is read from the DTO (server-computed decimal) and rescaled to a percentage
  */
 export function buildDepositWindowRows(dtos: EpochSettledEventDto[]): DepositWindowRow[] {
   return dtos.map((dto, i) => {
@@ -60,14 +34,7 @@ export function buildDepositWindowRows(dtos: EpochSettledEventDto[]): DepositWin
 
     const hasPrevious = i + 1 < dtos.length
     const previousDto = hasPrevious ? dtos[i + 1] : null
-
-    let apy: number | null = null
-    if (previousDto) {
-      const previousAssets = BigInt(previousDto.assets)
-      const previousSupply = BigInt(previousDto.supply)
-      const previousNav = derivePricePerShare(previousAssets, previousSupply)
-      apy = deriveApy(pricePerShare, previousNav, closedAt, Number(previousDto.closedAt))
-    }
+    const apy = dto.apy === null ? null : dto.apy * 100
 
     return {
       epochId: dto.epochId,

--- a/src/app/btc-vault/hooks/useDepositHistory/useDepositHistory.test.tsx
+++ b/src/app/btc-vault/hooks/useDepositHistory/useDepositHistory.test.tsx
@@ -14,6 +14,7 @@ const MOCK_DTOS: EpochSettledEventDto[] = [
     assets: '3000',
     supply: '2800',
     closedAt: '1700000',
+    apy: 0.12,
   },
   {
     epochId: '2',
@@ -21,6 +22,7 @@ const MOCK_DTOS: EpochSettledEventDto[] = [
     assets: '2000',
     supply: '1900',
     closedAt: '1600000',
+    apy: 0.08,
   },
   {
     epochId: '1',
@@ -28,6 +30,7 @@ const MOCK_DTOS: EpochSettledEventDto[] = [
     assets: '1000',
     supply: '1000',
     closedAt: '1500000',
+    apy: null,
   },
 ]
 


### PR DESCRIPTION
## Summary
- Fix incorrect APY on BTC Vault Deposit History (DAO-2254) by replacing the broken linear formula with compound annualisation via `computeIndicativeApy`, eliminating extreme negative values like -2516%.
- Move APY computation server-side: `epoch-history` endpoint now pre-computes `apy` per DTO (decimal) once per 20s cache window via a new `attachApy` step.
- Handle bootstrap edge case: when the prior epoch has zero supply, `apy` is null and renders as `—`. Confinement test ensures downstream epochs still get correct APY.