### PR TITLE
feat/replacing ENVIO_GRAPHQL_URL

### DIFF
--- a/.env.cr.qa
+++ b/.env.cr.qa
@@ -111,5 +111,6 @@ DAO_DATA_DB_CONNECTION_STRING=
 # Envio sync-check (optional; RPC URL = Rootstock node for chain tip)
 ENVIO_SYNC_CHECK_RPC_URL=
 # Envio sync-check
+ENVIO_GRAPHQL_URL=https://indexer.dev.hyperindex.xyz/5329421/v1/graphql
 ENVIO_SYNC_CHECK_SYNC_PROGRESS_ID=chain-31
 ENVIO_SYNC_CHECK_INSTANCE_NAME=cr-qa

--- a/.env.dao.qa
+++ b/.env.dao.qa
@@ -112,5 +112,6 @@ DAO_DATA_DB_CONNECTION_STRING=
 # Envio sync-check (optional; RPC URL = Rootstock node for chain tip)
 ENVIO_SYNC_CHECK_RPC_URL=
 # Envio sync-check
+ENVIO_GRAPHQL_URL=https://indexer.dev.hyperindex.xyz/5329421/v1/graphql
 ENVIO_SYNC_CHECK_SYNC_PROGRESS_ID=chain-31
 ENVIO_SYNC_CHECK_INSTANCE_NAME=dao-qa

--- a/.env.dev
+++ b/.env.dev
@@ -109,7 +109,7 @@ SENTRY_ORG=rootstocklabs-limited
 SENTRY_PROJECT=dao-frontend
 
 # Envio Indexer
-ENVIO_GRAPHQL_URL=https://indexer.dev.hyperindex.xyz/abece9d/v1/graphql
+ENVIO_GRAPHQL_URL=https://indexer.dev.hyperindex.xyz/b7a0124/v1/graphql
 ENVIO_SYNC_CHECK_SYNC_PROGRESS_ID=chain-31
 ENVIO_SYNC_CHECK_INSTANCE_NAME=dev
 # Set locally or via deployment secrets — do not commit webhook URLs

--- a/.env.mainnet
+++ b/.env.mainnet
@@ -102,7 +102,7 @@ SENTRY_PROJECT=dao-frontend
 # DAO Data DB (user-generated data, e.g. likes). Set via CI/CD or docker-compose environment.
 DAO_DATA_DB_CONNECTION_STRING=
 # Envio Indexer (server-side; proposals + optional /api/envio-sync-check)
-ENVIO_GRAPHQL_URL=https://indexer.dev.hyperindex.xyz/96544ad/v1/graphql
+ENVIO_GRAPHQL_URL=https://indexer.dev.hyperindex.xyz/b6d3632/v1/graphql
 ENVIO_SYNC_CHECK_RPC_URL=
 ENVIO_SYNC_CHECK_SYNC_PROGRESS_ID=chain-30
 ENVIO_SYNC_CHECK_INSTANCE_NAME=mainnet

--- a/.env.release-candidate-mainnet
+++ b/.env.release-candidate-mainnet
@@ -108,7 +108,7 @@ SENTRY_PROJECT=dao-frontend
 # DAO Data DB (user-generated data, e.g. likes). Set via CI/CD or docker-compose environment.
 DAO_DATA_DB_CONNECTION_STRING=
 # Envio Indexer (server-side; proposals + optional /api/envio-sync-check)
-ENVIO_GRAPHQL_URL=https://indexer.dev.hyperindex.xyz/96544ad/v1/graphql
+ENVIO_GRAPHQL_URL=https://indexer.dev.hyperindex.xyz/b6d3632/v1/graphql
 ENVIO_SYNC_CHECK_RPC_URL=
 ENVIO_SYNC_CHECK_SYNC_PROGRESS_ID=chain-30
 ENVIO_SYNC_CHECK_INSTANCE_NAME=rc-mainnet

--- a/.env.release-candidate-testnet
+++ b/.env.release-candidate-testnet
@@ -110,7 +110,7 @@ SENTRY_ORG=rootstocklabs-limited
 SENTRY_PROJECT=dao-frontend
 
 # Envio Indexer
-ENVIO_GRAPHQL_URL=https://indexer.dev.hyperindex.xyz/d903918/v1/graphql
+ENVIO_GRAPHQL_URL=https://indexer.dev.hyperindex.xyz/5329421/v1/graphql
 ENVIO_SYNC_CHECK_SYNC_PROGRESS_ID=chain-31
 ENVIO_SYNC_CHECK_INSTANCE_NAME=rc-testnet
 # Set via GitHub Secrets for deployments — do not commit webhook URLs

--- a/.env.testnet.local
+++ b/.env.testnet.local
@@ -121,6 +121,7 @@ SENTRY_ORG=rootstocklabs-limited
 SENTRY_PROJECT=dao-frontend
 
 # Envio sync-check
+ENVIO_GRAPHQL_URL=https://indexer.dev.hyperindex.xyz/5329421/v1/graphql
 ENVIO_SYNC_CHECK_SYNC_PROGRESS_ID=chain-31
 ENVIO_SYNC_CHECK_INSTANCE_NAME=testnet-local
 


### PR DESCRIPTION
replacing ENVIO_GRAPHQL_URL var with new one, created on new personal account. The previous one (free tier) has been deleted from Envio.