### PR TITLE
perf(blockscout): add next.revalidate to uncached Blockscout fetches

### DIFF
--- a/src/app/collective-rewards/actions.ts
+++ b/src/app/collective-rewards/actions.ts
@@ -24,11 +24,14 @@ const REWARD_DISTRIBUTION_REWARDS: Hex = '0xd6a836213168f39ab7f02eb32044ca51969f
 
 const defaultFromBlock = EVENTS_FROM_BLOCK.toString()
 
+const REVALIDATE_SECONDS = 25
+
 export const fetchGaugeNotifyRewardLogs = async (gaugeAddress: Address, fromBlock = 0) => {
   return fetchLogsByTopic({
     address: gaugeAddress,
     topic0: GAUGE_NOTIFY_REWARD_EVENT,
     fromBlock: fromBlock > 0 ? fromBlock.toString() : defaultFromBlock,
+    fetchInit: { next: { revalidate: REVALIDATE_SECONDS } },
   })
 }
 
@@ -37,6 +40,7 @@ export const fetchBuilderRewardsClaimed = async (gaugeAddress: Address, fromBloc
     address: gaugeAddress,
     topic0: BUILDER_REWARDS_CLAIMED_EVENT,
     fromBlock: fromBlock > 0 ? fromBlock.toString() : defaultFromBlock,
+    fetchInit: { next: { revalidate: REVALIDATE_SECONDS } },
   })
 }
 
@@ -45,6 +49,7 @@ export const fetchBackerRewardsClaimed = async (gaugeAddress: Address, fromBlock
     address: gaugeAddress,
     topic0: BACKER_REWARDS_CLAIMED_EVENT,
     fromBlock: fromBlock > 0 ? fromBlock.toString() : defaultFromBlock,
+    fetchInit: { next: { revalidate: REVALIDATE_SECONDS } },
   })
 }
 
@@ -53,6 +58,7 @@ export const fetchRewardDistributionFinished = async (fromBlock = 0) => {
     address: BackersManagerAddress,
     topic0: REWARD_DISTRIBUTION_FINISHED,
     fromBlock: fromBlock > 0 ? fromBlock.toString() : defaultFromBlock,
+    fetchInit: { next: { revalidate: REVALIDATE_SECONDS } },
   })
 }
 
@@ -61,5 +67,6 @@ export const fetchRewardDistributionRewards = async (fromBlock = 0) => {
     address: BackersManagerAddress,
     topic0: REWARD_DISTRIBUTION_REWARDS,
     fromBlock: fromBlock > 0 ? fromBlock.toString() : defaultFromBlock,
+    fetchInit: { next: { revalidate: REVALIDATE_SECONDS } },
   })
 }

--- a/src/app/user/Balances/actions.ts
+++ b/src/app/user/Balances/actions.ts
@@ -133,6 +133,7 @@ export const fetchProposalCreated = async (fromBlock = 0) => {
     address: GovernorAddress,
     topic0: PROPOSAL_CREATED_EVENT,
     fromBlock: fromBlock.toString(),
+    fetchInit: { next: { revalidate: 60 } },
   })
 }
 
@@ -145,6 +146,7 @@ export const fetchVoteCastEventByAccountAddress = async (address: Address) => {
     topic0: CAST_VOTE_EVENT,
     topic1: padHex(address, { size: 32 }),
     topic0_1_opr: 'and',
+    fetchInit: { next: { revalidate: 60 } },
   })
 }
 
@@ -174,7 +176,7 @@ export const fetchNftHoldersOfAddress = async (
   }
   const pagination = buildPaginationParams(nextParams)
   const url = `${BLOCKSCOUT_URL}/api/v2/tokens/${address}/instances?${pagination}`
-  const res = await fetch(url)
+  const res = await fetch(url, { next: { revalidate: 30 } })
   if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`)
   const data = (await res.json()) as {
     items: BlockscoutNftInstance[]
@@ -201,7 +203,7 @@ export const fetchTokenHoldersOfAddress = async (
   }
   const pagination = buildPaginationParams(nextParams)
   const url = `${BLOCKSCOUT_URL}/api/v2/tokens/${address}/holders?${pagination}`
-  const res = await fetch(url)
+  const res = await fetch(url, { next: { revalidate: 30 } })
   if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`)
   const data: ServerResponseV2<TokenHoldersResponse> = await res.json()
   return data


### PR DESCRIPTION
## Summary
- Add `next: { revalidate: 25 }` via `fetchInit` to all 5 event-log fetches in `collective-rewards/actions.ts` (aligns TTL with existing `/api/gauges/*` routes)
- Add `next: { revalidate: 60 }` to `fetchProposalCreated` and `fetchVoteCastEventByAccountAddress` in `user/Balances/actions.ts`
- Add `next: { revalidate: 30 }` to the two Blockscout v2 REST `fetch()` calls for NFT/token holders

## Why
Repeated F5 on the Collective Rewards and Balances pages triggered back-to-back Blockscout requests with no cache layer, causing Blockscout to rate-limit the server.

## Test plan
- [ ] Load `/collective-rewards` and verify reward metrics render correctly
- [ ] Load `/user` Balances tab and verify NFT/token holder lists load
- [ ] F5 rapidly on both pages — confirm no 429s from Blockscout in server logs
- [ ] Check Next.js Data Cache HIT logs for the affected fetch URLs