### PR TITLE
fix timestamp for rpc logs from blockscout

### DIFF
--- a/src/lib/blockscout/fetch-logs-by-topic.test.ts
+++ b/src/lib/blockscout/fetch-logs-by-topic.test.ts
@@ -68,6 +68,7 @@ describe('fetchLogsByTopic', () => {
       transactionIndex: '0x0',
       removed: false,
       topics: ['0xtopic0', '0xtopic1'],
+      timeStamp: '0x1',
     })
 
     const calledUrl = new URL((global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0])

--- a/src/lib/blockscout/fetch-logs-by-topic.ts
+++ b/src/lib/blockscout/fetch-logs-by-topic.ts
@@ -7,6 +7,9 @@ import {
   fetchBlockscoutGetLogsPaginated,
 } from './fetch-blockscout-get-logs-paginated'
 
+/** viem {@link RpcLog} extended with Blockscout's `timeStamp` (hex string, e.g. `"0x627a3b2c"`). */
+export type RpcLogWithTimestamp = RpcLog & { timeStamp: string }
+
 /**
  * Arguments forwarded into {@link fetchBlockscoutGetLogsPaginated}'s `query` (topic2 / extra operators not exposed here).
  */
@@ -25,8 +28,8 @@ interface FetchLogsByTopicParams {
   fetchInit?: BlockscoutGetLogsFetchInit
 }
 
-/** Maps a Blockscout log row into viem {@link RpcLog}; strips `null` entries from `topics`. */
-function toRpcLog(log: BackendEventByTopic0ResponseValue): RpcLog {
+/** Maps a Blockscout log row into {@link RpcLogWithTimestamp}; strips `null` entries from `topics`. */
+function toRpcLog(log: BackendEventByTopic0ResponseValue): RpcLogWithTimestamp {
   return {
     address: log.address as Address,
     blockHash: null,
@@ -37,6 +40,7 @@ function toRpcLog(log: BackendEventByTopic0ResponseValue): RpcLog {
     transactionIndex: log.transactionIndex as Hex,
     removed: false,
     topics: log.topics.filter((t): t is string => t !== null) as [] | [Hex, ...Hex[]],
+    timeStamp: log.timeStamp,
   }
 }
 
@@ -50,7 +54,7 @@ function toRpcLog(log: BackendEventByTopic0ResponseValue): RpcLog {
  * @param fromBlock — Pagination start (decimal string); default `'0'`.
  * @param topic1 — Optional indexed argument topic.
  * @param topic0_1_opr — How `topic0` and `topic1` combine (`and` / `or`).
- * @returns `{ data }` where `data` is deduped {@link RpcLog} entries in fetch order across pages.
+ * @returns `{ data }` where `data` is deduped {@link RpcLogWithTimestamp} entries in fetch order across pages.
  *
  * @see {@link fetchBlockscoutGetLogsPaginated} — Use directly when you need `topic2`, extra operators, or raw rows.
  *
@@ -93,7 +97,7 @@ export async function fetchLogsByTopic({
   topic1,
   topic0_1_opr,
   fetchInit,
-}: FetchLogsByTopicParams): Promise<{ data: RpcLog[] }> {
+}: FetchLogsByTopicParams): Promise<{ data: RpcLogWithTimestamp[] }> {
   const rows = await fetchBlockscoutGetLogsPaginated({
     query: {
       address,


### PR DESCRIPTION
Add timeStamp field from blockscout response to mapping function.