### PR TITLE
perf: reduce request fan-out to avoid WAF 403 on rapid navigation

### DIFF
--- a/src/app/providers/ContextProviders.tsx
+++ b/src/app/providers/ContextProviders.tsx
@@ -3,7 +3,7 @@ import { TooltipProvider } from '@radix-ui/react-tooltip'
 import { createAppKit } from '@reown/appkit/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { NavigationGuardProvider } from 'next-navigation-guard'
-import type { ReactNode } from 'react'
+import { type ReactNode, useState } from 'react'
 import { type State, WagmiProvider } from 'wagmi'
 
 import { BalancesProvider } from '@/app/user/Balances/context/BalancesContext'
@@ -82,7 +82,19 @@ function ChunkErrorHandlerInit({ children }: { children: ReactNode }) {
 }
 
 export const ContextProviders = ({ children, initialState }: Props) => {
-  const queryClient = new QueryClient()
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30_000,
+            gcTime: 5 * 60_000,
+            retry: 1,
+            refetchOnWindowFocus: false,
+          },
+        },
+      }),
+  )
 
   return (
     <GlobalErrorBoundary>

--- a/src/components/MainContainer/sidebars/SidebarDesktop.tsx
+++ b/src/components/MainContainer/sidebars/SidebarDesktop.tsx
@@ -14,6 +14,7 @@ import { NavIcon } from '../icons/NavIcon'
 import { useLayoutContext } from '../LayoutProvider'
 import { MenuData } from './menuData'
 import styles from './styles.module.css'
+import { throttleNav } from './throttleNav'
 import { useFilteredMenuData } from './useFilteredMenuData'
 import { UsefulLinks } from './UsefulLinks'
 
@@ -94,7 +95,7 @@ const MenuItem = ({ href, text, buttonProps, variants, iconUrl }: MenuData & { v
   const isActive = usePathname().split('/').at(1) === href
   return (
     <li className={cn('relative pl-3', { 'bg-v-charcoal': isSidebarOpen && isActive })}>
-      <Link href={`/${href}`} prefetch={false} data-testid={buttonProps.id}>
+      <Link href={`/${href}`} prefetch={false} onClick={throttleNav} data-testid={buttonProps.id}>
         <div
           className={cn(
             'h-10 flex flex-row flex-nowrap gap-2 items-center group',

--- a/src/components/MainContainer/sidebars/SidebarDesktop.tsx
+++ b/src/components/MainContainer/sidebars/SidebarDesktop.tsx
@@ -94,7 +94,7 @@ const MenuItem = ({ href, text, buttonProps, variants, iconUrl }: MenuData & { v
   const isActive = usePathname().split('/').at(1) === href
   return (
     <li className={cn('relative pl-3', { 'bg-v-charcoal': isSidebarOpen && isActive })}>
-      <Link href={`/${href}`} data-testid={buttonProps.id}>
+      <Link href={`/${href}`} prefetch={false} data-testid={buttonProps.id}>
         <div
           className={cn(
             'h-10 flex flex-row flex-nowrap gap-2 items-center group',

--- a/src/components/MainContainer/sidebars/SidebarMobile.tsx
+++ b/src/components/MainContainer/sidebars/SidebarMobile.tsx
@@ -1,7 +1,7 @@
 import { motion, type Variants } from 'motion/react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { usePathname, useRouter } from 'next/navigation'
+import { usePathname } from 'next/navigation'
 import { Fragment, useMemo } from 'react'
 
 import { Span } from '@/components/Typography'
@@ -61,21 +61,10 @@ export function SidebarMobile() {
 
 const MenuItem = ({ text, href, iconUrl, buttonProps }: MenuData) => {
   const isActive = usePathname()?.substring(1) === href
-  const { closeSidebar } = useLayoutContext()
-  const router = useRouter()
-
-  const handleClick = () => {
-    // Close sidebar immediately to prevent interference with navigation
-    closeSidebar()
-    // Use setTimeout to ensure sidebar closes before navigation
-    setTimeout(() => {
-      router.push(`/${href}`)
-    }, 100)
-  }
 
   return (
     <li className={cn('relative pl-3 pr-16', { 'bg-v-charcoal': isActive })}>
-      <Link href={`/${href}`} onClick={handleClick} data-testid={buttonProps.id}>
+      <Link href={`/${href}`} data-testid={buttonProps.id}>
         <div className={cn('h-10 flex flex-nowrap gap-2 items-center', { [styles['nav-active']]: isActive })}>
           {iconUrl ? <Image src={iconUrl} width={20} height={20} alt="Icon" /> : <NavIcon />}
           <p className="text-sm font-light font-rootstock-sans">{text}</p>

--- a/src/components/MainContainer/sidebars/SidebarMobile.tsx
+++ b/src/components/MainContainer/sidebars/SidebarMobile.tsx
@@ -11,6 +11,7 @@ import { NavIcon } from '../icons/NavIcon'
 import { useLayoutContext } from '../LayoutProvider'
 import { MenuData } from './menuData'
 import styles from './styles.module.css'
+import { throttleNav } from './throttleNav'
 import { useFilteredMenuData } from './useFilteredMenuData'
 import { UsefulLinks } from './UsefulLinks'
 
@@ -64,7 +65,7 @@ const MenuItem = ({ text, href, iconUrl, buttonProps }: MenuData) => {
 
   return (
     <li className={cn('relative pl-3 pr-16', { 'bg-v-charcoal': isActive })}>
-      <Link href={`/${href}`} prefetch={false} data-testid={buttonProps.id}>
+      <Link href={`/${href}`} prefetch={false} onClick={throttleNav} data-testid={buttonProps.id}>
         <div className={cn('h-10 flex flex-nowrap gap-2 items-center', { [styles['nav-active']]: isActive })}>
           {iconUrl ? <Image src={iconUrl} width={20} height={20} alt="Icon" /> : <NavIcon />}
           <p className="text-sm font-light font-rootstock-sans">{text}</p>

--- a/src/components/MainContainer/sidebars/SidebarMobile.tsx
+++ b/src/components/MainContainer/sidebars/SidebarMobile.tsx
@@ -64,7 +64,7 @@ const MenuItem = ({ text, href, iconUrl, buttonProps }: MenuData) => {
 
   return (
     <li className={cn('relative pl-3 pr-16', { 'bg-v-charcoal': isActive })}>
-      <Link href={`/${href}`} data-testid={buttonProps.id}>
+      <Link href={`/${href}`} prefetch={false} data-testid={buttonProps.id}>
         <div className={cn('h-10 flex flex-nowrap gap-2 items-center', { [styles['nav-active']]: isActive })}>
           {iconUrl ? <Image src={iconUrl} width={20} height={20} alt="Icon" /> : <NavIcon />}
           <p className="text-sm font-light font-rootstock-sans">{text}</p>

--- a/src/components/MainContainer/sidebars/throttleNav.ts
+++ b/src/components/MainContainer/sidebars/throttleNav.ts
@@ -1,0 +1,15 @@
+import type { MouseEvent } from 'react'
+
+const NAV_THROTTLE_MS = 700
+let lastNavAt = 0
+
+// Module-level timestamp shared by desktop and mobile sidebar MenuItems, prevents bursts of navigations that trigger the AWS WAF rate-limit.
+export function throttleNav(e: MouseEvent) {
+  const now = Date.now()
+  if (now - lastNavAt < NAV_THROTTLE_MS) {
+    e.preventDefault()
+    e.stopPropagation()
+    return
+  }
+  lastNavAt = now
+}


### PR DESCRIPTION
  - ContextProviders: keep QueryClient stable via useState and set conservative defaults (staleTime 30s, retry 1, no refetch on focus) so React Query cache is not discarded on every wallet state change
  - SidebarMobile: remove redundant router.push + setTimeout in MenuItem; <Link> handles navigation and parent motion.div onClick closes the drawer via event bubbling