### PR TITLE
fix: preserve cached data when state sync health check becomes unhealthy

### DIFF
--- a/src/app/collective-rewards/shared/hooks/useGetABIWithStateSync.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetABIWithStateSync.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import Big from 'big.js'
 
 import { AVERAGE_BLOCKTIME } from '@/lib/constants'
@@ -30,6 +30,7 @@ export const useGetMetricsAbiWithStateSync = () => {
     },
     queryKey: ['abiData'],
     refetchInterval: AVERAGE_BLOCKTIME,
+    placeholderData: keepPreviousData,
     enabled: !healthCheckIsLoading && isStateSyncHealthy,
   })
 
@@ -38,9 +39,10 @@ export const useGetMetricsAbiWithStateSync = () => {
   const unhealthyStateSyncError =
     (!healthCheckIsLoading && !isStateSyncHealthy && new Error('Unhealthy state sync')) || null
 
+  const hasData = !!abiData
   return {
-    data: isStateSyncHealthy ? data : Big(0),
+    data: hasData ? data : Big(0),
     isLoading: healthCheckIsLoading || abiDataIsLoading,
-    error: healthCheckError || abiDataError || unhealthyStateSyncError,
+    error: hasData ? null : healthCheckError || abiDataError || unhealthyStateSyncError,
   }
 }

--- a/src/app/collective-rewards/shared/hooks/useGetLastCycleRewardsWithStateSync.ts
+++ b/src/app/collective-rewards/shared/hooks/useGetLastCycleRewardsWithStateSync.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 
 import { AVERAGE_BLOCKTIME } from '@/lib/constants'
 
@@ -29,13 +29,15 @@ export const useGetLastCycleRewardsWithStateSync = () => {
     },
     queryKey: ['lastCycleRewardsWithStateSync'],
     refetchInterval: AVERAGE_BLOCKTIME,
+    placeholderData: keepPreviousData,
     enabled: !healthCheckIsLoading && isStateSyncHealthy,
   })
 
   const unhealthyStateSyncError =
     (!healthCheckIsLoading && !isStateSyncHealthy && new Error('Unhealthy state sync')) || null
 
-  const error = healthCheckError || unhealthyStateSyncError || lastCycleRewardsError
+  const hasData = !!lastCycleRewards
+  const error = hasData ? null : healthCheckError || unhealthyStateSyncError || lastCycleRewardsError
   const isLoading = healthCheckIsLoading || lastCycleRewardsLoading
 
   return { data: lastCycleRewards, isLoading, error }


### PR DESCRIPTION
When the state sync health check returns unhealthy, the queries were being disabled and the unhealthy error was propagated immediately, triggering the ErrorBoundary fallback even when valid cached data was still available. This caused reward amounts and ABI metrics to momentarily flash to 0 every time the health check refetched.

Use keepPreviousData to retain query results across disable/enable cycles, and only propagate the error when no cached data exists so the fallback is used as a last resort rather than the default path.