### PR TITLE
fix(analytics): resolve PostHog QA findings for v1.21.0

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -35,21 +35,23 @@ export async function POST(request: NextRequest) {
     // - cryptographic signature verification via SIWE
     const { token } = await verifySignature(challengeId, signature)
 
-    // Track sign-in server-side using the wallet address as distinct ID
+    // Track sign-in server-side using the wallet address as distinct ID.
+    // Analytics is non-essential: a PostHog failure must never fail an otherwise
+    // successful login, so it's isolated from the route's error handling.
     const payload = await verifyJWT(token)
     if (payload?.userAddress) {
-      const posthog = getPostHogClient()
-      const distinctId = payload.userAddress
-      const clientDistinctId = request.headers.get('X-POSTHOG-DISTINCT-ID')
-      posthog.identify({ distinctId, properties: { wallet_address: distinctId } })
-      posthog.capture({
-        distinctId,
-        event: 'user_signed_in',
-        properties: {
-          wallet_address: distinctId,
-          ...(clientDistinctId ? { $anon_distinct_id: clientDistinctId } : {}),
-        },
-      })
+      try {
+        const posthog = getPostHogClient()
+        const distinctId = payload.userAddress
+        posthog.identify({ distinctId, properties: { wallet_address: distinctId } })
+        posthog.capture({
+          distinctId,
+          event: 'user_signed_in',
+          properties: { wallet_address: distinctId },
+        })
+      } catch (analyticsError) {
+        logger.error({ err: analyticsError, route: '/api/auth/login' }, 'PostHog tracking failed')
+      }
     }
 
     // Return token in response body and as HTTP-only cookie

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -49,6 +49,7 @@ export async function POST(request: NextRequest) {
           event: 'user_signed_in',
           properties: { wallet_address: distinctId },
         })
+        await posthog.flush()
       } catch (analyticsError) {
         logger.error({ err: analyticsError, route: '/api/auth/login' }, 'PostHog tracking failed')
       }

--- a/src/app/collective-rewards/allocations/hooks/useAllocateVotes.ts
+++ b/src/app/collective-rewards/allocations/hooks/useAllocateVotes.ts
@@ -1,9 +1,9 @@
 import posthog from 'posthog-js'
-import { useContext, useEffect } from 'react'
+import { useContext, useEffect, useRef } from 'react'
 import { useWaitForTransactionReceipt, useWriteContract } from 'wagmi'
 
 import { useAwaitedTxReporting } from '@/app/collective-rewards/shared/hooks'
-import { txFailureProps } from '@/components/ErrorPage/commonErrors'
+import { isUserRejectedTxError, txFailureProps } from '@/components/ErrorPage/commonErrors'
 import { BackersManagerAbi } from '@/lib/abis/tok/BackersManagerAbi'
 import { BackersManagerAddress } from '@/lib/contracts'
 
@@ -37,9 +37,15 @@ export const useAllocateVotes = () => {
     }
   }, [isSuccess, refetchRawAllocations])
 
-  // Emit failed event on rejection or on-chain failure
+  const lastCapturedErrorRef = useRef<unknown>(null)
   useEffect(() => {
-    if (!error) return
+    if (!error) {
+      lastCapturedErrorRef.current = null
+      return
+    }
+    if (lastCapturedErrorRef.current === error) return
+    lastCapturedErrorRef.current = error
+    if (isUserRejectedTxError(error)) return
     posthog.capture('backing_allocations_failed', {
       token: 'stRIF',
       ...txFailureProps(error),

--- a/src/app/collective-rewards/components/ClaimRewardModal/ClaimRewardsModal.tsx
+++ b/src/app/collective-rewards/components/ClaimRewardModal/ClaimRewardsModal.tsx
@@ -34,7 +34,7 @@ const ClaimBackerRewardsModal = ({ onClose }: Omit<ClaimRewardsModalProps, 'isBa
     isLoadingReceipt,
     isPendingTx,
     isSuccess,
-    error: claimError,
+    txError: claimTxError,
     hash: claimHash,
   } = useClaimBackerRewards(getRewardTokenAddress(selectedRewardType))
 
@@ -75,7 +75,7 @@ const ClaimBackerRewardsModal = ({ onClose }: Omit<ClaimRewardsModalProps, 'isBa
   }, [backerRewards, prices])
 
   useRewardsClaimFailedCapture('backer', {
-    error: claimError,
+    error: claimTxError,
     rewardType: selectedRewardType,
     hash: claimHash,
   })
@@ -176,6 +176,7 @@ const ClaimBuilderRewardsModal = ({ onClose }: Omit<ClaimRewardsModalProps, 'isB
     isPendingTx,
     isSuccess,
     error: errorClaim,
+    txError: claimTxError,
     hash: claimHash,
   } = useClaimBuilderRewards(builderAddress as Address, buildersGauge as Address)
 
@@ -193,7 +194,7 @@ const ClaimBuilderRewardsModal = ({ onClose }: Omit<ClaimRewardsModalProps, 'isB
   }, [isSuccess, onClose])
 
   useRewardsClaimFailedCapture('builder', {
-    error: errorClaim,
+    error: claimTxError,
     rewardType: selectedRewardType,
     hash: claimHash,
   })

--- a/src/app/collective-rewards/components/ClaimRewardModal/useRewardsClaimFailedCapture.ts
+++ b/src/app/collective-rewards/components/ClaimRewardModal/useRewardsClaimFailedCapture.ts
@@ -1,7 +1,7 @@
 import posthog from 'posthog-js'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
-import { txFailureProps } from '@/components/ErrorPage/commonErrors'
+import { isUserRejectedTxError, txFailureProps } from '@/components/ErrorPage/commonErrors'
 
 import { ClaimRewardType } from './types'
 
@@ -12,15 +12,25 @@ interface Params {
 }
 
 /**
- * Emits the `rewards_claim_failed` PostHog event when a claim error appears.
+ * Emits the `rewards_claim_failed` PostHog event when a claim transaction error appears.
  * Shared by the backer and builder claim modals so both stay in sync.
+ *
+ * User rejections are skipped (matching `executeTxFlow`'s convention elsewhere) since a
+ * rejection isn't a failure. Each distinct error is captured only once, even if unrelated
+ * deps (e.g. `rewardType`) change while the same error is still set.
  */
 export const useRewardsClaimFailedCapture = (
   recipientType: 'backer' | 'builder',
   { error, rewardType, hash }: Params,
 ) => {
+  const capturedErrorRef = useRef<unknown>(null)
+
   useEffect(() => {
-    if (!error) return
+    if (!error || error === capturedErrorRef.current) return
+    capturedErrorRef.current = error
+
+    if (isUserRejectedTxError(error)) return
+
     posthog.capture('rewards_claim_failed', {
       recipient_type: recipientType,
       reward_type: rewardType,

--- a/src/app/collective-rewards/rewards/backers/hooks/useClaimBackerRewards.ts
+++ b/src/app/collective-rewards/rewards/backers/hooks/useClaimBackerRewards.ts
@@ -19,7 +19,11 @@ export const useClaimBackerRewards = (rewardToken?: Address) => {
   const isClaimable = !backerRewardsLoading && gaugesWithEarns(rewardToken).length > 0
   const gauges = gaugesWithEarns(rewardToken)
 
-  const error = executionError || receiptError || backerRewardsError
+  // `error` includes the read-side `backerRewardsError` for the UI toast below.
+  // `txError` is transaction-only, for consumers that must not treat a data-loading
+  // failure as a claim failure (e.g. the `rewards_claim_failed` analytics capture).
+  const txError = executionError || receiptError
+  const error = txError || backerRewardsError
 
   const claimBackerReward = () => {
     return writeContractAsync({
@@ -45,6 +49,7 @@ export const useClaimBackerRewards = (rewardToken?: Address) => {
     isClaimable,
     claimRewards: () => isClaimable && claimBackerReward(),
     error,
+    txError,
     hash,
     isPendingTx: isPending,
     isLoadingReceipt: isLoading,

--- a/src/app/collective-rewards/rewards/builders/hooks/useClaimBuilderRewards.ts
+++ b/src/app/collective-rewards/rewards/builders/hooks/useClaimBuilderRewards.ts
@@ -58,35 +58,40 @@ export const useClaimBuilderRewards = (builder: Address, gauge: Address) => {
   } = TOKENS
 
   const { error: claimBuilderRewardError, ...rest } = useClaimBuilderReward(builder, gauge)
-  const { isClaimable: rifClaimable, error: claimRifError } = useClaimBuilderRewardsPerToken(
-    builder,
-    gauge,
-    rifAddress,
-  )
-  const { isClaimable: rbtcClaimable, error: claimRbtcError } = useClaimBuilderRewardsPerToken(
-    builder,
-    gauge,
-    rbtcAddress,
-  )
+  const {
+    isClaimable: rifClaimable,
+    error: claimRifError,
+    txError: rifTxError,
+  } = useClaimBuilderRewardsPerToken(builder, gauge, rifAddress)
+  const {
+    isClaimable: rbtcClaimable,
+    error: claimRbtcError,
+    txError: rbtcTxError,
+  } = useClaimBuilderRewardsPerToken(builder, gauge, rbtcAddress)
 
-  const { isClaimable: usdrifClaimable, error: claimUsdrifError } = useClaimBuilderRewardsPerToken(
-    builder,
-    gauge,
-    usdrifAddress,
-  )
+  const {
+    isClaimable: usdrifClaimable,
+    error: claimUsdrifError,
+    txError: usdrifTxError,
+  } = useClaimBuilderRewardsPerToken(builder, gauge, usdrifAddress)
 
   const isClaimable = rifClaimable || rbtcClaimable || usdrifClaimable
   const error = claimBuilderRewardError ?? claimRifError ?? claimRbtcError ?? claimUsdrifError
+  // Transaction-only errors, excluding the per-token `builderRewards` read errors — for
+  // consumers that must not treat a data-loading failure as a claim failure (e.g. the
+  // `rewards_claim_failed` analytics capture).
+  const txError = claimBuilderRewardError ?? rifTxError ?? rbtcTxError ?? usdrifTxError
 
   return {
     ...rest,
     isClaimable,
     error,
+    txError,
   }
 }
 
 const useClaimBuilderRewardsPerToken = (builder: Address, gauge: Address, rewardToken: Address) => {
-  const { error: claimBuilderRewardError, ...rest } = useClaimBuilderReward(builder, gauge, rewardToken)
+  const { error: txError, ...rest } = useClaimBuilderReward(builder, gauge, rewardToken)
   const {
     data: rewards,
     isLoading,
@@ -94,11 +99,12 @@ const useClaimBuilderRewardsPerToken = (builder: Address, gauge: Address, reward
   } = useReadGauge({ address: gauge, functionName: 'builderRewards', args: [rewardToken] })
 
   const isClaimable = !isLoading && rewards !== 0n
-  const error = claimBuilderRewardError ?? getBuilderRewardsError
+  const error = txError ?? getBuilderRewardsError
 
   return {
     ...rest,
     isClaimable,
     error,
+    txError,
   }
 }

--- a/src/app/delegate/sections/DelegateContentSection/ConnectedSection.tsx
+++ b/src/app/delegate/sections/DelegateContentSection/ConnectedSection.tsx
@@ -9,7 +9,7 @@ import { useDelegateContext } from '@/app/delegate/contexts/DelegateContext'
 import { DelegatesContainer } from '@/app/delegate/sections/DelegateContentSection/DelegatesContainer'
 import { DelegationDetailsSection } from '@/app/delegate/sections/DelegateContentSection/DelegationDetailsSection'
 import { formatTimestampToMonthYear } from '@/app/proposals/shared/utils'
-import { txFailureProps } from '@/components/ErrorPage/commonErrors'
+import { isUserRejectedTxError, txFailureProps } from '@/components/ErrorPage/commonErrors'
 import { cn, formatNumberWithCommas } from '@/lib/utils'
 import { useDelegateToAddress } from '@/shared/hooks/useDelegateToAddress'
 import { executeTxFlow } from '@/shared/notification/executeTxFlow'
@@ -54,6 +54,7 @@ export const ConnectedSection = () => {
           onHideDelegates()
         },
         onError: (txHash, err) => {
+          if (isUserRejectedTxError(err)) return
           posthog.capture('voting_power_delegate_failed', {
             delegatee_address: address.toLowerCase(),
             ...txFailureProps(err),
@@ -81,6 +82,7 @@ export const ConnectedSection = () => {
       },
       onSuccess: refetch,
       onError: (txHash, err) => {
+        if (isUserRejectedTxError(err)) return
         posthog.capture('voting_power_reclaim_failed', {
           previous_delegatee_address: displayedDelegatee?.address?.toLowerCase(),
           ...txFailureProps(err),

--- a/src/app/proposals/[id]/components/VotingDetails.tsx
+++ b/src/app/proposals/[id]/components/VotingDetails.tsx
@@ -9,7 +9,7 @@ import { useGetProposalVotes } from '@/app/proposals/hooks/useGetProposalVotes'
 import { useProposalQuorumAtSnapshot } from '@/app/proposals/hooks/useProposalQuorumAtSnapshot'
 import { useGetVoteForSpecificProposal } from '@/app/proposals/hooks/useVoteCast'
 import { useVotingPowerAtSnapshot } from '@/app/proposals/hooks/useVotingPowerAtSnapshot'
-import { txFailureProps } from '@/components/ErrorPage/commonErrors'
+import { isUserRejectedTxError, txFailureProps } from '@/components/ErrorPage/commonErrors'
 import { Modal } from '@/components/Modal'
 import { NewPopover } from '@/components/NewPopover'
 import { Span } from '@/components/Typography'
@@ -97,6 +97,7 @@ export const VotingDetails = ({
         },
         onError: (failedHash, err) => {
           setVote(undefined)
+          if (isUserRejectedTxError(err)) return
           posthog.capture('proposal_vote_cast_failed', {
             proposal_id: proposalId,
             vote: _vote,

--- a/src/app/user/Stake/Steps/StepThree.tsx
+++ b/src/app/user/Stake/Steps/StepThree.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react'
 import { useGetAddressBalances } from '@/app/user/Balances/hooks/useGetAddressBalances'
 import { useStakingContext } from '@/app/user/Stake/StakingContext'
 import { StepProps } from '@/app/user/Stake/types'
-import { txFailureProps } from '@/components/ErrorPage/commonErrors'
+import { isUserRejectedTxError, txFailureProps } from '@/components/ErrorPage/commonErrors'
 import { executeTxFlow } from '@/shared/notification'
 
 import { StakeTokenAmountDisplay } from '../components/StakeTokenAmountDisplay'
@@ -39,6 +39,7 @@ export const StepThree = ({ onGoToStep, onCloseModal }: StepProps) => {
               onCloseModal()
             },
             onError: (txHash, err) => {
+              if (isUserRejectedTxError(err)) return
               posthog.capture('stake_rif_failed', {
                 amount_decimal: Number(amount) || 0,
                 token: tokenToSend.symbol,

--- a/src/app/user/Stake/Steps/StepTwo.tsx
+++ b/src/app/user/Stake/Steps/StepTwo.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef } from 'react'
 
 import { useStakingContext } from '@/app/user/Stake/StakingContext'
 import { StepProps } from '@/app/user/Stake/types'
-import { txFailureProps } from '@/components/ErrorPage/commonErrors'
+import { isUserRejectedTxError, txFailureProps } from '@/components/ErrorPage/commonErrors'
 import { Header, Label } from '@/components/Typography'
 import { executeTxFlow } from '@/shared/notification'
 
@@ -44,6 +44,7 @@ export const StepTwo = ({ onGoNext, onGoBack }: StepProps) => {
       onRequestTx: onRequestAllowance,
       onSuccess: onGoNext,
       onError: (txHash, err) => {
+        if (isUserRejectedTxError(err)) return
         posthog.capture('stake_allowance_failed', {
           amount_decimal: Number(amount) || 0,
           token: tokenToSend.symbol,

--- a/src/app/user/Unstake/UnstakeModal.tsx
+++ b/src/app/user/Unstake/UnstakeModal.tsx
@@ -8,7 +8,7 @@ import { useGetAddressBalances } from '@/app/user/Balances/hooks/useGetAddressBa
 import { StakingToken } from '@/app/user/Stake/types'
 import { Button } from '@/components/Button'
 import { Divider } from '@/components/Divider'
-import { txFailureProps } from '@/components/ErrorPage/commonErrors'
+import { isUserRejectedTxError, txFailureProps } from '@/components/ErrorPage/commonErrors'
 import { Modal } from '@/components/Modal'
 import { Header } from '@/components/Typography'
 import Big from '@/lib/big'
@@ -106,6 +106,7 @@ export const UnstakeModal = ({ onCloseModal }: Props) => {
         onCloseModal()
       },
       onError: (txHash, err) => {
+        if (isUserRejectedTxError(err)) return
         posthog.capture('unstake_rif_failed', {
           amount_decimal: Number(amount) || 0,
           token: stRifToken.symbol,

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs'
 import posthog from 'posthog-js'
 
+import { POSTHOG_ENVIRONMENT } from '@/lib/posthog-environment'
 import { initSentryIfEnabled } from '@/lib/sentry/sentry-client'
 import { getEnvFlag } from '@/shared/context/FeatureFlag/flags.utils'
 
@@ -25,6 +26,6 @@ posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN!, {
   capture_exceptions: true,
   debug: process.env.NEXT_PUBLIC_PROFILE === 'dev',
   loaded: ph => {
-    ph.register({ environment: process.env.NEXT_PUBLIC_PROFILE || 'unknown' })
+    ph.register({ environment: POSTHOG_ENVIRONMENT })
   },
 })

--- a/src/lib/auth/siweStore.ts
+++ b/src/lib/auth/siweStore.ts
@@ -3,6 +3,8 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { immer } from 'zustand/middleware/immer'
 
+import { POSTHOG_ENVIRONMENT } from '@/lib/posthog-environment'
+
 import { extractUserAddressFromToken, isTokenExpired } from './jwt'
 
 interface SiweState {
@@ -97,6 +99,7 @@ export const useSiweStore = create<SiweState>()(
        */
       signOut: () => {
         posthog.reset()
+        posthog.register({ environment: POSTHOG_ENVIRONMENT })
         set(state => {
           state.jwtToken = null
           state.error = null

--- a/src/lib/posthog-environment.ts
+++ b/src/lib/posthog-environment.ts
@@ -1,0 +1,1 @@
+export const POSTHOG_ENVIRONMENT = process.env.NEXT_PUBLIC_PROFILE || 'unknown'

--- a/src/shared/hooks/useSignIn.ts
+++ b/src/shared/hooks/useSignIn.ts
@@ -73,7 +73,6 @@ export function useSignIn(): UseSignInReturn {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'X-POSTHOG-DISTINCT-ID': posthog.get_distinct_id(),
         },
         body: JSON.stringify({ challengeId, signature }),
       })

--- a/src/shared/walletConnection/connection/DisconnectWorkflowContainer.tsx
+++ b/src/shared/walletConnection/connection/DisconnectWorkflowContainer.tsx
@@ -26,8 +26,9 @@ export const DisconnectWorkflowContainer = () => {
   const signOut = useSiweStore(state => state.signOut)
 
   const handleDisconnect = () => {
+    // signOut() resets PostHog (and re-registers the environment super property), so the
+    // capture must happen first, before the distinct ID is cleared.
     posthog.capture('wallet_disconnected', { wallet_address: address?.toLowerCase() })
-    posthog.reset()
     disconnect()
     signOut()
     resetAllocations()


### PR DESCRIPTION
## Summary
- Re-register the `environment` super property after every `posthog.reset()` (disconnect and sign-out), not just at init
- Isolate PostHog calls in the login route so an analytics failure can't fail an otherwise successful login
- Stop mixing reward-read errors into `rewards_claim_failed`, and skip/dedupe the event for user-rejected transactions
- Drop the unused `X-POSTHOG-DISTINCT-ID` header and `$anon_distinct_id` property, which had no effect on the custom event
- Remove the redundant `posthog.reset()` call on disconnect

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes
- [ ] Manual check: disconnect wallet and confirm subsequent events still carry `environment`
- [ ] Manual check: reject a reward claim tx and confirm `rewards_claim_failed` is not emitted