### PR TITLE
fix(auth): clear http-only auth cookie on wallet disconnect

### DIFF
--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server'
+
+const isProduction = process.env.NODE_ENV === 'production'
+
+/**
+ * POST /api/auth/logout
+ *
+ * Clear the authentication session by removing the HTTP-only `auth-token`
+ * cookie. Because the cookie is HTTP-only, it cannot be cleared from client
+ * JavaScript — this endpoint must be called (e.g. on wallet disconnect) so a
+ * stale credential does not linger in the browser after sign-out.
+ *
+ * Response:
+ * {
+ *   success: true
+ * }
+ */
+export async function POST() {
+  const response = NextResponse.json({ success: true })
+
+  // Overwrite the cookie with an immediately-expired value. The attributes must
+  // match those used when setting it in /api/auth/login so the browser replaces
+  // the correct cookie.
+  response.cookies.set('auth-token', '', {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'lax',
+    maxAge: 0,
+    path: '/',
+  })
+
+  return response
+}

--- a/src/lib/auth/siweStore.ts
+++ b/src/lib/auth/siweStore.ts
@@ -96,6 +96,12 @@ export const useSiweStore = create<SiweState>()(
       /**
        * Signs out the user by clearing all authentication state
        * Note: Zustand persist middleware handles localStorage cleanup automatically
+       *
+       * The JWT is also mirrored in an HTTP-only `auth-token` cookie set by
+       * /api/auth/login. That cookie cannot be cleared from client JS, so we
+       * call /api/auth/logout to have the server expire it — otherwise a stale
+       * credential lingers after disconnect and keeps authenticating requests
+       * (e.g. likes) via the cookie fallback.
        */
       signOut: () => {
         posthog.reset()
@@ -105,6 +111,9 @@ export const useSiweStore = create<SiweState>()(
           state.error = null
           state.isLoading = false
         })
+        // Fire-and-forget: clearing the store is the source of truth for the UI,
+        // so a logout network failure must not block sign-out.
+        void fetch('/api/auth/logout', { method: 'POST' }).catch(() => {})
       },
     })),
     {


### PR DESCRIPTION
## Problema

Cuando un usuario se autentica para dar "like" (flujo SIWE), el JWT se guarda en **dos lugares**:
1. `localStorage` (store de Zustand `siweStore`)
2. Una **cookie httpOnly `auth-token`** que pone `POST /api/auth/login` con 24h de vida.

Al desconectar la wallet, `DisconnectWorkflowContainer` llama a `signOut()`, que **solo** limpiaba el token de localStorage. La cookie httpOnly **no puede borrarse desde el JS del cliente** (solo el servidor), y no existía ninguna ruta de logout, así que la cookie quedaba viva.

### Impacto de seguridad
El middleware de auth acepta el token vía cookie como fallback (`extractTokenFromRequest`). Es decir, la cookie obsoleta seguía siendo una credencial válida hasta 24h, permitiendo que peticiones (como el like) se autenticaran como el usuario anterior tras desconectar/reconectar.

## Solución

- **Nueva ruta `POST /api/auth/logout`** que expira la cookie `auth-token` (mismos atributos que en login + `maxAge: 0`).
- **`signOut()`** ahora hace `fetch('/api/auth/logout')` en modo fire-and-forget (un fallo de red no bloquea el sign-out; el store sigue siendo la fuente de verdad de la UI). Se colocó en `signOut` en vez de en el handler de desconexión para que **cualquier** ruta de cierre de sesión limpie la cookie.

## Testing
- [x] `tsc --noEmit` sin errores
- [x] `eslint` sin errores
- [ ] Manual: conectar wallet → dar like (firma SIWE) → desconectar → verificar que la cookie `auth-token` ya no está en el navegador.

## Archivos
- `src/app/api/auth/logout/route.ts` (nuevo)
- `src/lib/auth/siweStore.ts`