### PR TITLE
fix(support): harden ticket endpoint and Slack payload against abuse

### DIFF
--- a/src/app/api/support/ticket/route.ts
+++ b/src/app/api/support/ticket/route.ts
@@ -10,6 +10,10 @@ const ROUTE = '/api/support/ticket'
 const MAX_DESCRIPTION_LENGTH = 1000
 const MIN_DESCRIPTION_LENGTH = 10
 const MAX_EMAIL_LENGTH = 254
+// Legit payloads top out around ~3.5 KB (Turnstile token + capped fields).
+// Rejecting anything larger before JSON.parse blocks DoS amplification with
+// oversized bodies that would otherwise consume memory just to be discarded.
+const MAX_BODY_BYTES = 8_192
 
 interface SiteVerifyResponse {
   success: boolean
@@ -40,12 +44,23 @@ const FIELD_ERROR_CODES: Record<keyof TicketData, string> = {
 const FIELD_PRIORITY: (keyof TicketData)[] = ['token', 'topic', 'description', 'email']
 
 /**
+ * Strips Unicode control characters a reader can't see but that change how
+ * text is rendered — RTL overrides (U+202A–202E), directional isolates
+ * (U+2066–2069), zero-width spaces/joiners (U+200B–200D), and BOM (U+FEFF).
+ * These are used to disguise URLs (e.g. `evil.com/‮exe.doc`) or hide payloads
+ * inside otherwise-innocent text.
+ */
+const stripInvisibleControls = (text: string): string =>
+  text.replaceAll(/[\u202A-\u202E\u2066-\u2069\u200B-\u200D\uFEFF]/g, '')
+
+/**
  * Escapes characters that Slack interprets in `mrkdwn` text so that
  * user-supplied content can't inject mentions (e.g. `<!channel>`, `<@U…>`)
- * or break the block layout. See https://api.slack.com/reference/surfaces/formatting#escaping
+ * or break the block layout, and strips invisible control chars.
+ * See https://api.slack.com/reference/surfaces/formatting#escaping
  */
-const escapeSlack = (text: string): string =>
-  text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+const escapeSlackMrkdwn = (text: string): string =>
+  stripInvisibleControls(text).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
 
 const generateTicketRef = (): string =>
   `SUP-${crypto.randomUUID().replaceAll('-', '').slice(0, 8).toUpperCase()}`
@@ -62,18 +77,33 @@ const buildSlackBlocks = (
     text: { type: 'plain_text', text: 'New support ticket', emoji: false },
   },
   {
+    type: 'context',
+    elements: [
+      {
+        type: 'mrkdwn',
+        text: ':warning: Content submitted by an unverified user. Verify any link before clicking.',
+      },
+    ],
+  },
+  {
     type: 'section',
     fields: [
       { type: 'mrkdwn', text: `*Ticket:*\n${ticketRef}` },
       { type: 'mrkdwn', text: `*Topic:*\n${topic}` },
-      { type: 'mrkdwn', text: `*From:*\n${email ? escapeSlack(email) : '_anonymous_'}` },
+      { type: 'mrkdwn', text: `*From:*\n${email ? escapeSlackMrkdwn(email) : '_anonymous_'}` },
       { type: 'mrkdwn', text: `*Received:*\n${receivedAt}` },
     ],
   },
   { type: 'divider' },
   {
     type: 'section',
-    text: { type: 'mrkdwn', text: `*Description:*\n${escapeSlack(description)}` },
+    text: { type: 'mrkdwn', text: '*Description:*' },
+  },
+  {
+    type: 'section',
+    // plain_text disables Slack's URL auto-linkification, so a phishing link
+    // in the description is not clickable — the agent must copy it out.
+    text: { type: 'plain_text', text: stripInvisibleControls(description), emoji: false },
   },
 ]
 
@@ -87,6 +117,11 @@ export async function POST(request: NextRequest) {
       'Support endpoint is missing required env vars',
     )
     return NextResponse.json({ success: false, error: 'server_misconfigured' }, { status: 500 })
+  }
+
+  const contentLength = Number(request.headers.get('content-length') ?? 0)
+  if (contentLength > MAX_BODY_BYTES) {
+    return NextResponse.json({ success: false, error: 'body_too_large' }, { status: 413 })
   }
 
   let rawBody: unknown
@@ -107,26 +142,20 @@ export async function POST(request: NextRequest) {
 
   const { token, topic, description, email } = parsed.data
 
-  const remoteip = request.headers.get('x-forwarded-for')?.split(',')[0].trim()
-
   try {
+    // `remoteip` is intentionally omitted — the only header we could source it
+    // from (`x-forwarded-for`) is attacker-controllable and would let a spoofed
+    // value reach Cloudflare. siteverify accepts requests without it.
     const cfResponse = await fetch(SITEVERIFY_URL, {
       method: 'POST',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        secret,
-        response: token,
-        ...(remoteip ? { remoteip } : {}),
-      }),
+      body: new URLSearchParams({ secret, response: token }),
     })
     const verification = (await cfResponse.json()) as SiteVerifyResponse
 
     if (!verification.success) {
       logger.warn({ route: ROUTE, errorCodes: verification['error-codes'] }, 'Turnstile verification failed')
-      return NextResponse.json(
-        { success: false, errorCodes: verification['error-codes'] ?? [] },
-        { status: 403 },
-      )
+      return NextResponse.json({ success: false, error: 'captcha_failed' }, { status: 403 })
     }
   } catch (err) {
     logger.error({ err, route: ROUTE }, 'Error contacting Cloudflare siteverify')
@@ -140,7 +169,7 @@ export async function POST(request: NextRequest) {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
-        text: `New support ticket ${ticketRef} (${topic}) from ${email ? escapeSlack(email) : 'anonymous'}`,
+        text: `New support ticket ${ticketRef} (${topic}) from ${email ? escapeSlackMrkdwn(email) : 'anonymous'}`,
         blocks: buildSlackBlocks(ticketRef, topic, description, email, new Date().toISOString()),
       }),
     })

--- a/src/components/MainContainer/sidebars/SupportModal.tsx
+++ b/src/components/MainContainer/sidebars/SupportModal.tsx
@@ -14,11 +14,20 @@ import { Header, Paragraph, Span } from '@/components/Typography'
 import { SUPPORT_TOPICS } from '@/shared/constants'
 import { showToast } from '@/shared/notification'
 
-// Cloudflare-published test key that always passes. Safe as a public default;
-// production builds must set NEXT_PUBLIC_TURNSTILE_SITE_KEY to a real siteKey.
+// Cloudflare-published test key that always passes verification. Never ship it —
+// paired with a matching test secret it would let any client through without a
+// real captcha.
 const TURNSTILE_TEST_SITE_KEY = '1x00000000000000000000AA'
 
-const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || TURNSTILE_TEST_SITE_KEY
+const envSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY
+
+if (process.env.NODE_ENV === 'production' && !envSiteKey) {
+  throw new Error(
+    'NEXT_PUBLIC_TURNSTILE_SITE_KEY must be set in production. The test siteKey always passes and must never ship.',
+  )
+}
+
+const TURNSTILE_SITE_KEY = envSiteKey || TURNSTILE_TEST_SITE_KEY
 
 const emptyString = z.literal('').transform(() => {})
 
@@ -39,6 +48,9 @@ const resolveSubmitError = (status: number, errorCode?: string): string => {
   if (status === 429) {
     return 'Too many requests. Please wait a moment and try again.'
   }
+  if (status === 413) {
+    return 'Your message is too large. Please shorten it and try again.'
+  }
   switch (errorCode) {
     case 'delivery_failed':
       return 'Could not deliver your request. Please try again in a moment.'
@@ -51,6 +63,7 @@ const resolveSubmitError = (status: number, errorCode?: string): string => {
     case 'server_misconfigured':
     case 'verification_failed':
       return 'Something went wrong on our side. Please try again later.'
+    case 'captcha_failed':
     default:
       return 'Captcha verification failed. Please try again.'
   }


### PR DESCRIPTION
## Summary

Hardening pass over the support-ticket feature introduced in #2173. Scoped to fixes for issues that were introduced by that PR — a pre-existing `getClientIp` bug in `src/proxy.ts` (also affects auth endpoints) is intentionally out of scope and should be tracked separately.

Targets the release branch `v1.22.0` because that is where the feature landed.

### Fixes included

- **Fail-loud on missing Turnstile siteKey in production.** `SupportModal.tsx` no longer silently falls back to Cloudflare's public test siteKey (`1x0…AA`), which always passes. In production builds the module now throws at load if `NEXT_PUBLIC_TURNSTILE_SITE_KEY` is unset. The test-key path is preserved for local dev.
- **No auto-linkified URLs in the Slack channel.** The user-supplied description is now rendered in a `plain_text` block, so a phishing link pasted into a ticket is not clickable — the support agent has to copy it out. Kills the social-engineering vector via the internal support channel.
- **Strip invisible Unicode controls before Slack.** RTL overrides (U+202A–202E), directional isolates (U+2066–2069), zero-width chars (U+200B–200D) and BOM (U+FEFF) are removed from user input in both the description and the email. Blocks visual URL disguises like `evil.com/‮exe.doc`.
- **Unverified-content warning banner** above every ticket in Slack to remind the reader that the content is user-supplied.
- **Content-Length guard (413) before `request.json()`.** Rejects oversized bodies (>8 KB) before they touch the JSON parser to cut DoS amplification.
- **No Cloudflare error-code leak.** The endpoint used to echo `error-codes` from `siteverify` back to the client (e.g. `invalid-input-secret`, useful for probing misconfig). Replaced with a generic `captcha_failed`; details are still logged server-side.
- **Drop `remoteip` sent to Cloudflare.** It was sourced from `x-forwarded-for`, which is spoofable. `siteverify` accepts requests without it.

### Out of scope (follow-up)

- `getClientIp` in `src/proxy.ts` reads `x-forwarded-for[0]`, which is attacker-controllable and lets rate limiting be bypassed via header spoof. This is pre-existing (also affects `/api/auth/*`) and belongs in its own PR.
- Rate limiter is in-memory in `src/lib/rateLimit.ts`. Fine while we run a single instance; if we ever scale out this needs Redis/Upstash or a WAF-level limiter.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `eslint` passes on changed files
- [x] Manual: submit a valid ticket in dev — Slack posts arrive with the new banner + plain-text description
- [x] Manual: submit a description containing `https://example.com` — verify it is not clickable in Slack
- [ ] Manual: submit an oversized body with `curl -H 'Content-Length: 100000'` — expect 413
- [ ] Manual: force a captcha failure — expect UI shows "Captcha verification failed" and the response body no longer includes `errorCodes`
- [ ] Confirm production deploy sets `NEXT_PUBLIC_TURNSTILE_SITE_KEY` (all `.env.*` for prod-adjacent envs already include it in the parent PR)