### PR TITLE
fix: remove muted exhaustive-deps suppressions and clear stale table errors

### DIFF
--- a/src/app/backing/components/AllocationBar/AllocationBar.tsx
+++ b/src/app/backing/components/AllocationBar/AllocationBar.tsx
@@ -133,22 +133,27 @@ const AllocationBar = ({
     }
   }
 
-  const onMouseUp = () => setDragTarget(null)
+  // `handleResize` closes over items/values/onChange, which change on every render while
+  // dragging. Keep the latest version in a ref so the window listeners stay subscribed for
+  // the whole drag instead of being torn down and re-added on each mousemove.
+  const handleResizeRef = useRef(handleResize)
+  useEffect(() => {
+    handleResizeRef.current = handleResize
+  })
 
   useEffect(() => {
-    if (dragTargetIndex !== null) {
-      window.addEventListener('mousemove', handleResize)
-      window.addEventListener('mouseup', onMouseUp)
-    } else {
-      window.removeEventListener('mousemove', handleResize)
-      window.removeEventListener('mouseup', onMouseUp)
-    }
+    if (dragTargetIndex === null) return
+
+    const onMouseMove = (event: MouseEvent) => handleResizeRef.current(event)
+    const onMouseUp = () => setDragTarget(null)
+
+    window.addEventListener('mousemove', onMouseMove)
+    window.addEventListener('mouseup', onMouseUp)
     return () => {
-      window.removeEventListener('mousemove', handleResize)
+      window.removeEventListener('mousemove', onMouseMove)
       window.removeEventListener('mouseup', onMouseUp)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dragTargetIndex, currentValues])
+  }, [dragTargetIndex])
 
   // dnd-kit reorder logic
   const handleDragEnd = ({ active, over }: DragEndEvent) => {

--- a/src/app/builders/components/Table/BuildersTable.tsx
+++ b/src/app/builders/components/Table/BuildersTable.tsx
@@ -233,7 +233,7 @@ export const BuildersTable = ({ filterOption }: { filterOption: BuilderFilterOpt
       type: 'SET_DEFAULT_SORT',
       payload: { columnId: 'backer_rewards', direction: 'desc' },
     })
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [dispatch])
 
   useEffect(() => {
     dispatch({
@@ -250,13 +250,10 @@ export const BuildersTable = ({ filterOption }: { filterOption: BuilderFilterOpt
   }, [isLoading, isContextLoading, dispatch])
 
   useEffect(() => {
-    if (!error) return
-    if (error) {
-      dispatch({
-        type: 'SET_ERROR',
-        payload: error.message,
-      })
-    }
+    dispatch({
+      type: 'SET_ERROR',
+      payload: error ? error.message : null,
+    })
   }, [error, dispatch])
 
   /**

--- a/src/app/my-rewards/backers/components/Table/BackerRewardsTable.tsx
+++ b/src/app/my-rewards/backers/components/Table/BackerRewardsTable.tsx
@@ -158,7 +158,7 @@ export const BackerRewardsTable = () => {
       type: 'SET_DEFAULT_SORT',
       payload: { columnId: 'unclaimed', direction: SORT_DIRECTION_ASC },
     })
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [dispatch])
 
   useEffect(() => {
     dispatch({
@@ -175,13 +175,10 @@ export const BackerRewardsTable = () => {
   }, [isLoading, dispatch])
 
   useEffect(() => {
-    if (!error) return
-    if (error) {
-      dispatch({
-        type: 'SET_ERROR',
-        payload: error.message,
-      })
-    }
+    dispatch({
+      type: 'SET_ERROR',
+      payload: error ? error.message : null,
+    })
   }, [error, dispatch])
 
   useEffect(() => {

--- a/src/app/my-rewards/tx-history/backer/components/TransactionHistoryTable.tsx
+++ b/src/app/my-rewards/tx-history/backer/components/TransactionHistoryTable.tsx
@@ -107,34 +107,28 @@ export const TransactionHistoryTable = () => {
       type: 'SORT_BY_COLUMN',
       payload: { columnId: 'date', direction: 'desc' },
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [dispatch])
 
   useEffect(() => {
     dispatch({
       type: 'SET_ROWS',
       payload: rowData,
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rowData])
+  }, [dispatch, rowData])
 
   useEffect(() => {
     dispatch({
       type: 'SET_LOADING',
       payload: isLoading || false,
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoading])
+  }, [dispatch, isLoading])
 
   useEffect(() => {
-    if (error) {
-      dispatch({
-        type: 'SET_ERROR',
-        payload: error.message,
-      })
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [error])
+    dispatch({
+      type: 'SET_ERROR',
+      payload: error ? error.message : null,
+    })
+  }, [dispatch, error])
 
   return (
     <div className="w-full flex flex-col gap-8 md:gap-10">

--- a/src/app/my-rewards/tx-history/builder/components/BuilderTransactionHistory.tsx
+++ b/src/app/my-rewards/tx-history/builder/components/BuilderTransactionHistory.tsx
@@ -108,34 +108,28 @@ export const BuilderTransactionHistory = () => {
       type: 'SORT_BY_COLUMN',
       payload: { columnId: 'date', direction: 'desc' },
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [dispatch])
 
   useEffect(() => {
     dispatch({
       type: 'SET_ROWS',
       payload: rowData,
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rowData])
+  }, [dispatch, rowData])
 
   useEffect(() => {
     dispatch({
       type: 'SET_LOADING',
       payload: isLoading || false,
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoading])
+  }, [dispatch, isLoading])
 
   useEffect(() => {
-    if (error) {
-      dispatch({
-        type: 'SET_ERROR',
-        payload: error.message,
-      })
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [error])
+    dispatch({
+      type: 'SET_ERROR',
+      payload: error ? error.message : null,
+    })
+  }, [dispatch, error])
 
   return (
     <div className="w-full flex flex-col gap-8 md:gap-10">

--- a/src/app/staking-history/components/StakingHistoryTable.tsx
+++ b/src/app/staking-history/components/StakingHistoryTable.tsx
@@ -96,34 +96,28 @@ function StakingHistoryTable() {
       type: 'SORT_BY_COLUMN',
       payload: { columnId: 'period', direction: 'desc' },
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [dispatch])
 
   useEffect(() => {
     dispatch({
       type: 'SET_ROWS',
       payload: rowData,
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rowData])
+  }, [dispatch, rowData])
 
   useEffect(() => {
     dispatch({
       type: 'SET_LOADING',
       payload: isLoading || false,
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoading])
+  }, [dispatch, isLoading])
 
   useEffect(() => {
-    if (error) {
-      dispatch({
-        type: 'SET_ERROR',
-        payload: error.message,
-      })
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [error])
+    dispatch({
+      type: 'SET_ERROR',
+      payload: error ? error.message : null,
+    })
+  }, [dispatch, error])
 
   return (
     <div className="w-full flex flex-col gap-6 md:gap-10">

--- a/src/app/user/IntroModal/IntroModal.tsx
+++ b/src/app/user/IntroModal/IntroModal.tsx
@@ -47,8 +47,7 @@ export const IntroModal = () => {
     } else if (tokenStatus === null) {
       closeModal()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoaded, tokenStatus])
+  }, [isLoaded, tokenStatus, openModal, closeModal])
 
   // Don't render if no required tokens or loading is not complete
   if (!tokenStatus || !isLoaded || !isModalOpened) {

--- a/src/app/vault/history/components/VaultHistoryTable.tsx
+++ b/src/app/vault/history/components/VaultHistoryTable.tsx
@@ -92,34 +92,28 @@ function VaultHistoryTable() {
       type: 'SORT_BY_COLUMN',
       payload: { columnId: 'period', direction: 'desc' },
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [dispatch])
 
   useEffect(() => {
     dispatch({
       type: 'SET_ROWS',
       payload: rowData,
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rowData])
+  }, [dispatch, rowData])
 
   useEffect(() => {
     dispatch({
       type: 'SET_LOADING',
       payload: isLoading || false,
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoading])
+  }, [dispatch, isLoading])
 
   useEffect(() => {
-    if (error) {
-      dispatch({
-        type: 'SET_ERROR',
-        payload: error.message,
-      })
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [error])
+    dispatch({
+      type: 'SET_ERROR',
+      payload: error ? error.message : null,
+    })
+  }, [dispatch, error])
 
   return (
     <div className="w-full flex flex-col gap-6 md:gap-10">


### PR DESCRIPTION
## Context

An audit flagged `react-hooks/exhaustive-deps` suppressions in `TransactionHistoryTable`, `AllocationBar` and `IntroModal` as potential bugs. Reviewing them turned up one genuine defect, one fragile-but-currently-working effect, and several false positives — plus five more tables carrying the same defect.

## What was actually wrong

**Table error state never cleared** (6 components). The effects dispatched `SET_ERROR` only when `error` was truthy:

```tsx
if (error) {
  dispatch({ type: 'SET_ERROR', payload: error.message })
}
```

So once a fetch failed, a later successful fetch left the stale message in `TableContext` state forever. Now uses the clear-on-success pattern already present in the `btc-vault` and `fund-manager` tables:

```tsx
dispatch({ type: 'SET_ERROR', payload: error ? error.message : null })
```

**Scope note:** this is currently **latent, not user-visible** — none of the render components for these six tables read `error` from the table context (they only destructure `rows`, `columns`, `sort`). The tables that *do* render the error (`btc-vault`, `fund-manager`) already cleared it correctly. So this is state correctness plus groundwork for whenever an error UI gets wired up, not a visible bug being put out.

Also removed a redundant double guard in `BuildersTable` and `BackerRewardsTable`, where `if (!error) return` was followed by an always-true `if (error)`.

**AllocationBar resize listeners.** The effect omitted `handleResize` from its deps, and `handleResize` closes over `currentItems`, `totalBacking`, `minSegmentValue` and `onChange`. It worked only by accident: in controlled mode `currentValues` is a fresh array on every render (`itemsData.map(...)`), which re-ran the effect and refreshed the closure. Two consequences:

- the `window` listeners were torn down and re-added on **every `mousemove`** during a drag;
- wrapping `currentValues` in a `useMemo` — an entirely natural optimization — would have turned this into a live stale-closure bug: resizing against the pre-reorder segment order and stale `isEditable` checks.

Replaced with a latest-ref so the listeners subscribe once per drag and always call the current handler. Also dropped the dead `else` branch calling `removeEventListener`; the cleanup already covered it.

**The rest were false positives.** They hid only stable references the lint rule can't prove stable because they arrive via a hook or context: `dispatch` is the `useReducer` dispatch from `TableProvider`, and `openModal`/`closeModal` are `useCallback` with empty deps in `useModal`. Adding them to the dep arrays changes nothing about run frequency, mount-only effects included.

## Verification

- `eslint` and `tsc --noEmit` clean (both run in the pre-commit hook).
- Full suite: **139 files, 1354 tests passing.**
- `AllocationBar` exercised in Storybook with real drags: controlled resize 20/10 → 25/5 with the total conserved, no drift after `mouseup`, and — the case the stale closure would have broken — **reorder followed by resize** adjusted the correct pair (Boltz 20→26, another builder 10→4) while preserving order. No console errors.

## Notes for reviewers

- Net **-26 lines**; six suppression comments and one dead `if` removed.
- No behavior change intended for the false-positive effects. The two intentional changes are the error clearing and the AllocationBar listener lifecycle.
- Unrelated: a stale `.next/types/validator.ts` referencing a route from another branch was breaking the `lint-tsc` pre-commit hook. Fixed locally with `rm -rf .next`; nothing in this diff.

## Still pending (not addressed in this PR)

This PR closes the suppressions the audit named, but **it is a first batch, not the full sweep** — 13 `react-hooks/exhaustive-deps` suppressions remain in the repo. Triaged below so the audit item doesn't read as closed.

**One thing that *is* fully done:** the stale-error defect is resolved repo-wide. All 12 `SET_ERROR` dispatch sites now use the clear-on-success pattern — the six in this diff, plus `btc-vault` ×2, `fund-manager` ×2 and `fund-admin` ×2 which already had it. No table is left with the `if (error)`-only guard.

### Deliberate — documented, would need a refactor rather than a dep fix (11)

| File | Why it's suppressed |
|---|---|
| `useGetBTCWhitelistingHistory.ts:92`, `useAuditLog.ts:52`, `useGetBtcNavHistory.ts:78` | Same `resultsDataTick` idiom: `useQueries` returns a fresh array each render, so the memo keys off joined `dataUpdatedAt` instead. Already commented. |
| `TablePager.tsx:116` | Explicit — reset on `mode` only; tying it to `totalItems`/`pageSize` would reset the pager on every fetch. |
| `LayoutProvider.tsx:51` | Close drawer on route change; intentionally keyed on `pathname`. |
| `Spotlight.tsx:55` | Keyed on the derived `selectionsKey`. |
| `useResizeObserver.ts:38` | Mount-only observer setup. |
| `AnimatedTilesLoop.tsx:63`, `AnimatedTilesProgress.tsx:102` | Animation memos keyed on layout/progress params. |
| `BTCWhitelistingHistoryTable.tsx:72` | Mount-only columns + default sort, already commented as such. |
| `TablePager.stories.tsx:24` | Storybook only. |

### Worth a real look — possible latent stale closures (2)

- **`BuilderCardControl.tsx:116`** — deps are `[initialAllocations, allocations]`, but the effect also reads `isConnected` and calls `openDrawer`/`closeDrawer`. On disconnect the effect won't re-run, so the allocation drawer would stay open until allocations change. Same class of defect as the `AllocationBar` one fixed here; not verified against the running app.
- **`proposals/new/review/page.tsx:148`** — deps list the three proposal handlers but the callback also closes over `showToast` and `setLoading`. Needs triage.
