### PR TITLE
fix: keep support icon visible when the desktop sidebar is collapsed

### DIFF
--- a/src/components/MainContainer/sidebars/SidebarDesktop.tsx
+++ b/src/components/MainContainer/sidebars/SidebarDesktop.tsx
@@ -76,17 +76,20 @@ export const SidebarDesktop = () => {
             ))}
           </ul>
         </div>
-        {/* Useful links */}
-        <motion.div
-          variants={variants}
-          initial="text"
-          animate="text"
-          transition={{ duration: transition.duration, ease: 'easeOut' }}
-          className={cn('shrink-0 px-6 py-4', { 'pointer-events-none': !isSidebarOpen })}
-        >
-          <UsefulLinks />
-          <SupportButton />
-        </motion.div>
+        <div className="shrink-0 px-6 py-4">
+          {/* Useful links */}
+          <motion.div
+            variants={variants}
+            initial="text"
+            animate="text"
+            transition={{ duration: transition.duration, ease: 'easeOut' }}
+            className={cn({ 'pointer-events-none': !isSidebarOpen })}
+          >
+            <UsefulLinks />
+          </motion.div>
+          {/* Support stays reachable when the sidebar is collapsed */}
+          <SupportButton isCollapsed={!isSidebarOpen} variants={variants} transition={transition} />
+        </div>
       </div>
     </motion.aside>
   )

--- a/src/components/MainContainer/sidebars/SupportButton.tsx
+++ b/src/components/MainContainer/sidebars/SupportButton.tsx
@@ -1,18 +1,33 @@
 'use client'
 
 import { Headset } from 'lucide-react'
+import { motion, type Transition, type Variants } from 'motion/react'
 import { HTMLAttributes } from 'react'
 
+import { Tooltip } from '@/components/Tooltip'
 import { Span } from '@/components/Typography'
+import { cn } from '@/lib/utils'
 import { useModal } from '@/shared/hooks/useModal'
 
 import { SupportModal } from './SupportModal'
 
 interface SupportButtonProps extends HTMLAttributes<HTMLDivElement> {
   labelClassName?: string
+  /** True when the desktop sidebar is collapsed: the icon stays visible, the label fades out */
+  isCollapsed?: boolean
+  /** Collapse animation from the desktop sidebar; expects `icon` and `text` variants */
+  variants?: Variants
+  transition?: Transition
 }
 
-export const SupportButton = ({ className, labelClassName, ...props }: SupportButtonProps) => {
+export const SupportButton = ({
+  className,
+  labelClassName,
+  isCollapsed = false,
+  variants,
+  transition,
+  ...props
+}: SupportButtonProps) => {
   const { isModalOpened, openModal, closeModal } = useModal()
 
   return (
@@ -23,10 +38,29 @@ export const SupportButton = ({ className, labelClassName, ...props }: SupportBu
         className="flex w-full items-center gap-2 py-3 cursor-pointer text-warm-gray hover:text-text-100"
         data-testid="SidebarSupportButton"
       >
-        <Headset size={16} />
-        <Span variant="tag" className={labelClassName}>
-          Support
-        </Span>
+        <motion.div
+          variants={variants}
+          initial="icon"
+          animate="icon"
+          transition={transition}
+          // same footprint as the nav icons, so both stay centered when collapsed
+          className="shrink-0 flex w-5 justify-center"
+        >
+          <Tooltip text="Support" disabled={!isCollapsed}>
+            <Headset size={16} />
+          </Tooltip>
+        </motion.div>
+        <motion.div
+          variants={variants}
+          initial="text"
+          animate="text"
+          transition={transition}
+          className={cn({ 'pointer-events-none': isCollapsed })}
+        >
+          <Span variant="tag" className={labelClassName}>
+            Support
+          </Span>
+        </motion.div>
       </button>
       {isModalOpened && <SupportModal onClose={closeModal} />}
     </div>


### PR DESCRIPTION
## Problem

Collapsing the desktop sidebar made the Support icon disappear.

The bottom block (Useful links + Support) shared a single `motion.div` driven by the `text` variant, which animates `opacity: 0` and applies `pointer-events-none` when the sidebar collapses — so the support entry faded out entirely and became unclickable.

## Fix

- Only **Useful links** fades out now.
- **Support** stays mounted and visible when collapsed:
  - the icon uses the same `icon` variant as the nav icons (same scale/offset), inside a `w-5` box so it stays centered in the 79px rail;
  - the label uses the `text` variant, so it fades out as before;
  - a `Support` tooltip shows when collapsed, consistent with the nav items.
- `SidebarMobile` is unaffected — the new props are optional.

## Verification

<img width="87" height="809" alt="Screenshot 2026-07-30 at 11 46 06 PM" src="https://github.com/user-attachments/assets/a318b02f-08c3-4869-a0b8-752dd444b4e2" />

<img width="126" height="899" alt="Screenshot 2026-07-30 at 11 47 02 PM" src="https://github.com/user-attachments/assets/25f74463-5f77-40fa-8649-bebb1c7d8d63" />

