### PR TITLE
fix: bind SIWE challenges to a trusted domain (EIP-4361)

### DIFF
--- a/src/lib/auth/README.md
+++ b/src/lib/auth/README.md
@@ -54,6 +54,7 @@ Key components: `LikeButton.tsx`, `useLike.ts`, `SiweTooltipContent.tsx`
 | `siweStore.ts`                | Zustand store for JWT token, auth state, and `signOut`        |
 | `actions.ts`                  | Server-side auth logic: `requestChallenge`, `verifySignature` |
 | `challengeStore.ts`           | Server-side challenge storage and validation                  |
+| `domain.ts`                   | Trusted domain allowlist for EIP-4361 domain binding          |
 | `jwt.ts`                      | Client-side JWT utilities (decode, check expiry)              |
 | `jwt.server.ts`               | Server-side JWT signing and verification                      |
 | `session.ts`                  | Session management utilities                                  |
@@ -62,12 +63,16 @@ Key components: `LikeButton.tsx`, `useLike.ts`, `SiweTooltipContent.tsx`
 | `api/auth/challenge/route.ts` | POST endpoint for SIWE challenge creation                     |
 | `api/auth/login/route.ts`     | POST endpoint for signature verification and JWT issuance     |
 | `api/auth/verify/route.ts`    | POST endpoint for JWT validation                              |
-| `middleware.ts` (src root)    | Rate limiting middleware for all auth API routes              |
+| `proxy.ts` (src root)         | Rate limiting middleware for all auth API routes              |
 | `rateLimit.ts` (src/lib)      | In-memory sliding window rate limiter                         |
 
 ## Security Considerations
 
 - **Challenge is server-generated**: The SIWE message is created entirely on the server, preventing client-side manipulation of the nonce, domain, or expiration.
+- **Domain binding** ([EIP-4361 Relying Party steps](https://eips.ethereum.org/EIPS/eip-4361#relying-party-implementer-steps)): a challenge is only issued for an origin this deployment actually serves, and the same expected domain is passed to `siweMessage.verify()` at redemption. The `Host` header is caller-supplied, so it is not trusted as the expected origin on its own.
+  - By default, `rootstockcollective.xyz` and its subdomains are accepted, plus `localhost` / loopback outside production.
+  - Set `SIWE_ALLOWED_DOMAINS` (server-only, comma-separated hostnames) to serve SIWE from any other origin. When set, it replaces the defaults entirely — subdomains of a listed domain are **not** implied.
+  - Requests from an unlisted origin fail at `/api/auth/challenge` with `Invalid request`.
 - **JWT on disconnect**: When the user disconnects their wallet, the JWT is destroyed and all authenticated UI state (e.g. like icons) is reset. On reconnect, the user must re-authenticate via SIWE to restore their session.
 - **Token expiry**: Expired JWTs are cleared automatically on store rehydration.
 - **Rate limiting**: All auth endpoints are rate-limited via middleware (5 req/min for challenge and login, 20 req/min for verify) to prevent brute-force and DoS attacks.

--- a/src/lib/auth/actions.test.ts
+++ b/src/lib/auth/actions.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+// Server-only module: jose rejects jsdom's cross-realm Uint8Array when signing JWTs
+import { SiweMessage } from 'siwe'
+import { privateKeyToAccount } from 'viem/accounts'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { requestChallenge, verifySignature } from './actions'
+
+const TRUSTED_HOST = 'app.rootstockcollective.xyz'
+const account = privateKeyToAccount('0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d')
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('requestChallenge', () => {
+  it('binds the message to the trusted host', async () => {
+    const { message } = await requestChallenge(account.address, TRUSTED_HOST)
+    const parsed = new SiweMessage(message)
+
+    expect(parsed.domain).toBe(TRUSTED_HOST)
+    expect(parsed.uri).toBe(`http://${TRUSTED_HOST}`)
+  })
+
+  it('refuses to issue a challenge for an untrusted Host header', async () => {
+    await expect(requestChallenge(account.address, 'untrusted.example')).rejects.toThrow(/Untrusted domain/)
+  })
+
+  it('still rejects invalid input', async () => {
+    await expect(requestChallenge('not-an-address', TRUSTED_HOST)).rejects.toThrow(/Invalid address/)
+    await expect(requestChallenge(account.address, '')).rejects.toThrow(/Missing host/)
+  })
+})
+
+describe('verifySignature', () => {
+  it('issues a token for a signature over the server-issued message', async () => {
+    const { challengeId, message } = await requestChallenge(account.address, TRUSTED_HOST)
+    const signature = await account.signMessage({ message })
+
+    const { token } = await verifySignature(challengeId, signature)
+
+    expect(token).toEqual(expect.any(String))
+  })
+
+  it('rejects a signature over a message from another domain', async () => {
+    const { challengeId, message } = await requestChallenge(account.address, TRUSTED_HOST)
+
+    // A signature produced over a message for a different domain must not be
+    // redeemable against our challenge
+    const otherDomainMessage = message.replace(TRUSTED_HOST, 'other.example')
+    const signature = await account.signMessage({ message: otherDomainMessage })
+
+    await expect(verifySignature(challengeId, signature)).rejects.toThrow(/verification failed/)
+  })
+
+  it('consumes the challenge so a signature cannot be replayed', async () => {
+    const { challengeId, message } = await requestChallenge(account.address, TRUSTED_HOST)
+    const signature = await account.signMessage({ message })
+
+    await verifySignature(challengeId, signature)
+
+    await expect(verifySignature(challengeId, signature)).rejects.toThrow(/Invalid or expired challenge/)
+  })
+
+  it('rejects a challenge whose domain is no longer served', async () => {
+    const { challengeId, message } = await requestChallenge(account.address, TRUSTED_HOST)
+    const signature = await account.signMessage({ message })
+
+    // Deployment is reconfigured between issuance and redemption
+    vi.stubEnv('SIWE_ALLOWED_DOMAINS', 'dao.example.org')
+
+    await expect(verifySignature(challengeId, signature)).rejects.toThrow(/Untrusted domain/)
+  })
+
+  it('validates the signature format before touching the store', async () => {
+    await expect(verifySignature('some-id', 'not-a-signature')).rejects.toThrow(/Invalid signature format/)
+    await expect(verifySignature('', '0xdeadbeef')).rejects.toThrow(/Invalid challenge ID/)
+  })
+})
+
+describe('environment', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('accepts the local dev host outside production', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    const { requestChallenge: request } = await import('./actions')
+
+    const { message } = await request(account.address, 'localhost:3000')
+
+    expect(new SiweMessage(message).domain).toBe('localhost')
+  })
+})

--- a/src/lib/auth/actions.ts
+++ b/src/lib/auth/actions.ts
@@ -5,8 +5,8 @@ import { isAddress, isHex } from 'viem'
 import { currentEnvChain } from '@/config/config'
 
 import { CHALLENGE_TTL_MS, getAndConsumeChallenge, storeChallenge } from './challengeStore'
+import { assertTrustedHost, isAllowedDomain } from './domain'
 import { signJWT } from './jwt.server'
-import { isProduction } from './utils'
 
 export interface RequestChallengeResult {
   challengeId: string
@@ -35,9 +35,9 @@ export async function requestChallenge(address: string, host: string): Promise<R
     throw new Error('Missing host header')
   }
 
-  const domain = host.split(':')[0]
-  const protocol = isProduction ? 'https' : 'http'
-  const origin = `${protocol}://${host}`
+  // The Host header is caller-supplied, so it is only usable after being checked
+  // against the origins this deployment actually serves (EIP-4361 domain binding)
+  const { domain, origin } = assertTrustedHost(host)
   const chainId = currentEnvChain.id
 
   // Cryptographically secure nonce to prevent replay attacks
@@ -62,6 +62,7 @@ export async function requestChallenge(address: string, host: string): Promise<R
   const challengeId = storeChallenge({
     message,
     address: address.toLowerCase(),
+    domain,
   })
 
   return { challengeId, message }
@@ -95,11 +96,20 @@ export async function verifySignature(
     throw new Error('Invalid or expired challenge')
   }
 
+  // Re-check the expected domain rather than trusting the value recorded at
+  // issuance, so a challenge cannot be redeemed against an origin this
+  // deployment has since stopped serving
+  if (!isAllowedDomain(challenge.domain)) {
+    throw new Error(`Untrusted domain: ${challenge.domain}`)
+  }
+
   const siweMessage = new SiweMessage(challenge.message)
 
   let verifyResult: Awaited<ReturnType<typeof siweMessage.verify>>
   try {
-    verifyResult = await siweMessage.verify({ signature })
+    // EIP-4361 (Relying Party Implementer Steps): the signed `domain` MUST be
+    // checked against the expected origin, not merely parsed from the message
+    verifyResult = await siweMessage.verify({ signature, domain: challenge.domain })
   } catch {
     throw new Error('Signature verification failed')
   }

--- a/src/lib/auth/challengeStore.ts
+++ b/src/lib/auth/challengeStore.ts
@@ -11,6 +11,8 @@
 interface StoredChallenge {
   message: string
   address: string
+  /** Expected `domain` of the signed message, validated when the challenge was issued */
+  domain: string
   expiresAt: number
 }
 

--- a/src/lib/auth/domain.test.ts
+++ b/src/lib/auth/domain.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function getDomainModule(env: { NODE_ENV?: string; SIWE_ALLOWED_DOMAINS?: string } = {}) {
+  vi.resetModules()
+  vi.stubEnv('NODE_ENV', env.NODE_ENV ?? 'production')
+  vi.stubEnv('SIWE_ALLOWED_DOMAINS', env.SIWE_ALLOWED_DOMAINS ?? '')
+  return import('./domain')
+}
+
+describe('assertTrustedHost', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('accepts the deployment apex and its subdomains', async () => {
+    const { assertTrustedHost } = await getDomainModule()
+
+    expect(assertTrustedHost('rootstockcollective.xyz')).toEqual({
+      domain: 'rootstockcollective.xyz',
+      origin: 'https://rootstockcollective.xyz',
+    })
+    expect(assertTrustedHost('app.rootstockcollective.xyz').domain).toBe('app.rootstockcollective.xyz')
+    expect(assertTrustedHost('qa.dao.rootstockcollective.xyz').domain).toBe('qa.dao.rootstockcollective.xyz')
+  })
+
+  it('rejects an untrusted Host header', async () => {
+    const { assertTrustedHost } = await getDomainModule()
+
+    expect(() => assertTrustedHost('untrusted.example')).toThrow(/Untrusted domain/)
+  })
+
+  it('rejects lookalike domains that merely contain the apex', async () => {
+    const { assertTrustedHost } = await getDomainModule()
+
+    // Suffix match must be on a label boundary, not a substring
+    expect(() => assertTrustedHost('notrootstockcollective.xyz')).toThrow(/Untrusted domain/)
+    expect(() => assertTrustedHost('rootstockcollective.xyz.untrusted.example')).toThrow(/Untrusted domain/)
+  })
+
+  it('rejects loopback hosts in production', async () => {
+    const { assertTrustedHost } = await getDomainModule({ NODE_ENV: 'production' })
+
+    expect(() => assertTrustedHost('localhost:3000')).toThrow(/Untrusted domain/)
+  })
+
+  it('accepts loopback hosts outside production and keeps the port in the uri', async () => {
+    const { assertTrustedHost } = await getDomainModule({ NODE_ENV: 'development' })
+
+    expect(assertTrustedHost('localhost:3000')).toEqual({
+      domain: 'localhost',
+      origin: 'http://localhost:3000',
+    })
+    expect(assertTrustedHost('[::1]:3000').domain).toBe('::1')
+  })
+
+  it('uses SIWE_ALLOWED_DOMAINS as the only allowlist when set', async () => {
+    const { assertTrustedHost } = await getDomainModule({
+      SIWE_ALLOWED_DOMAINS: 'dao.example.org, other.example.org',
+    })
+
+    expect(assertTrustedHost('dao.example.org').domain).toBe('dao.example.org')
+    expect(assertTrustedHost('other.example.org').domain).toBe('other.example.org')
+    // The built-in default no longer applies once the deployment configures its own
+    expect(() => assertTrustedHost('app.rootstockcollective.xyz')).toThrow(/Untrusted domain/)
+    // Nor do subdomains of a configured domain
+    expect(() => assertTrustedHost('sub.dao.example.org')).toThrow(/Untrusted domain/)
+  })
+
+  it('normalises case and rejects malformed authorities', async () => {
+    const { assertTrustedHost } = await getDomainModule()
+
+    expect(assertTrustedHost('APP.RootstockCollective.XYZ').domain).toBe('app.rootstockcollective.xyz')
+    expect(() => assertTrustedHost('app.rootstockcollective.xyz:notaport')).toThrow(/Untrusted domain/)
+    expect(() => assertTrustedHost('')).toThrow(/Untrusted domain/)
+  })
+})

--- a/src/lib/auth/domain.ts
+++ b/src/lib/auth/domain.ts
@@ -1,0 +1,111 @@
+/**
+ * Trusted domain resolution for SIWE authentication.
+ *
+ * EIP-4361 requires the Relying Party to bind a sign-in message to its own
+ * *expected* origin, and to check that binding when the signature is redeemed.
+ * The `Host` header is supplied by the caller, so it cannot serve as that
+ * expectation on its own.
+ *
+ * The expected domain therefore comes from server-side configuration only:
+ * `SIWE_ALLOWED_DOMAINS` when set, otherwise the deployment apex below.
+ */
+
+import { isProduction } from './utils'
+
+/** All deployed environments live under this apex domain (see README env table) */
+const DEFAULT_ALLOWED_APEX = 'rootstockcollective.xyz'
+
+/** Loopback hosts, accepted outside production so local development keeps working */
+const LOCAL_HOSTNAMES = ['localhost', '127.0.0.1', '::1']
+
+export interface TrustedHost {
+  /** RFC 4501 dns authority for the SIWE `domain` field */
+  domain: string
+  /** Absolute origin for the SIWE `uri` field */
+  origin: string
+}
+
+/**
+ * Split a Host header value into hostname and port.
+ * Handles bracketed IPv6 authorities such as `[::1]:3000`.
+ * A non-numeric port yields an empty hostname so the caller rejects it.
+ */
+function splitHost(host: string): { hostname: string; port: string } {
+  const value = host.trim().toLowerCase()
+
+  let hostname: string
+  let port: string
+
+  if (value.startsWith('[')) {
+    const end = value.indexOf(']')
+    if (end === -1) {
+      return { hostname: '', port: '' }
+    }
+    hostname = value.slice(1, end)
+    port = value.slice(end + 1).replace(/^:/, '')
+  } else {
+    const parts = value.split(':')
+    if (parts.length > 2) {
+      return { hostname: '', port: '' }
+    }
+    hostname = parts[0]
+    port = parts[1] ?? ''
+  }
+
+  if (port && !/^\d+$/.test(port)) {
+    return { hostname: '', port: '' }
+  }
+
+  return { hostname, port }
+}
+
+/**
+ * Domains configured for this deployment, if any.
+ * When set, this list is the only source of truth — the defaults below do not apply.
+ */
+function configuredDomains(): string[] {
+  return (process.env.SIWE_ALLOWED_DOMAINS ?? '')
+    .split(',')
+    .map(entry => splitHost(entry).hostname)
+    .filter(Boolean)
+}
+
+/**
+ * Whether a hostname is an origin this deployment actually serves.
+ * @param hostname - Bare hostname, without port
+ */
+export function isAllowedDomain(hostname: string): boolean {
+  if (!hostname) {
+    return false
+  }
+
+  const configured = configuredDomains()
+  if (configured.length > 0) {
+    return configured.includes(hostname)
+  }
+
+  if (!isProduction && LOCAL_HOSTNAMES.includes(hostname)) {
+    return true
+  }
+
+  return hostname === DEFAULT_ALLOWED_APEX || hostname.endsWith(`.${DEFAULT_ALLOWED_APEX}`)
+}
+
+/**
+ * Validate a Host header and derive the SIWE `domain` and `uri` values from it.
+ *
+ * @param host - The Host header value from the incoming request
+ * @throws If the host is not an origin this deployment serves
+ */
+export function assertTrustedHost(host: string): TrustedHost {
+  const { hostname, port } = splitHost(host)
+
+  if (!isAllowedDomain(hostname)) {
+    throw new Error(`Untrusted domain: ${hostname || host}`)
+  }
+
+  const protocol = isProduction ? 'https' : 'http'
+  const authority = port ? `${hostname}:${port}` : hostname
+
+  return { domain: hostname, origin: `${protocol}://${authority}` }
+}

--- a/src/lib/auth/utils.ts
+++ b/src/lib/auth/utils.ts
@@ -9,6 +9,7 @@ export function sanitizeError(message: string): string {
     // Request validation errors
     if (message.includes('Invalid address')) return 'Invalid request'
     if (message.includes('Missing host')) return 'Invalid request'
+    if (message.includes('Untrusted domain')) return 'Invalid request'
 
     // Token/authentication errors
     if (message.includes('Missing token')) return 'Authentication required'


### PR DESCRIPTION
## Summary

Brings the SIWE implementation in line with the [EIP-4361 Relying Party steps](https://eips.ethereum.org/EIPS/eip-4361#relying-party-implementer-steps) by binding sign-in challenges to a domain the server controls, instead of one derived from the request.

The SIWE `domain` and `uri` were taken from the `Host` header:

```ts
const domain = host.split(':')[0]
const origin = `${protocol}://${host}`
```

The `Host` header is supplied by the caller, so it cannot serve as the expected origin on its own. `siweMessage.verify({ signature })` also omitted the `domain` parameter, which the standard requires the Relying Party to check.

Security details have been shared with the team privately.

## Changes

- **`src/lib/auth/domain.ts`** (new) — allowlist of the origins this deployment serves. `assertTrustedHost()` validates the `Host` header and derives the SIWE `domain` / `uri` from it. Suffix matching is on a label boundary, so `notrootstockcollective.xyz` does not match.
- **`requestChallenge`** — only issues a challenge for a host in the allowlist, and records the expected domain alongside it.
- **`verifySignature`** — re-checks the expected domain against the allowlist (so a challenge cannot be redeemed against an origin we have since stopped serving) and passes `domain` to `siweMessage.verify()`.
- **`sanitizeError`** — maps `Untrusted domain` to `Invalid request` in production so the host is not echoed back to the caller.

## Configuration

Defaults to `rootstockcollective.xyz` and its subdomains, plus `localhost` / loopback outside production. This covers every environment in the README table, so **no deployment change is required**.

Set `SIWE_ALLOWED_DOMAINS` (server-only, comma-separated hostnames) to serve SIWE from any other origin. When set it replaces the defaults entirely; subdomains of a listed domain are **not** implied. Requests from an origin outside the allowlist fail at `/api/auth/challenge` with `Invalid request`.

Rejecting unknown `Host` values at the proxy/edge remains worthwhile defence in depth, but the app no longer depends on it.

## Tests

`src/lib/auth/domain.test.ts` and `src/lib/auth/actions.test.ts` — 16 cases covering rejection of untrusted and lookalike hosts, loopback in production vs. development, `SIWE_ALLOWED_DOMAINS` replacing the defaults, the full sign/verify round trip, single-use challenge consumption, and redemption of a challenge whose domain is no longer served.

`tsc --noEmit`, `eslint` and `prettier` are clean; all 227 tests in `src/lib/` pass. Also verified end to end against a running dev server.

## Notes

- `src/lib/auth/README.md`: documented the domain-binding requirement and the new env var, and corrected a stale reference to `middleware.ts` (renamed to `src/proxy.ts` in Next 16 — rate limiting is active on `/api/auth/*`).
- SIWE currently gates proposal likes, so that is the affected surface. `/siwe-test` exercises the flow directly.